### PR TITLE
improve handling of HTML entities

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -1683,7 +1683,7 @@ public class BiblioItem {
             if (language != null) {
                 if (n == -1) {
                     if (pubnum != null) {
-                        teiId = pubnum;
+                        teiId = TextUtilities.HTMLEncode(pubnum);
                         tei.append(" xml:lang=\"" + language + "\" xml:id=\"" + teiId + "\">\n");
                     } else
                         tei.append(" xml:lang=\"" + language + ">\n");
@@ -1695,7 +1695,7 @@ public class BiblioItem {
             } else {
                 if (n == -1) {
                     if (pubnum != null) {
-                        teiId = pubnum;
+                        teiId = TextUtilities.HTMLEncode(pubnum);
                         tei.append(" xml:id=\"" + teiId + "\">\n");
                     } else
                         tei.append(">\n");

--- a/grobid-core/src/main/java/org/grobid/core/utilities/TextUtilities.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/TextUtilities.java
@@ -655,29 +655,26 @@ public class TextUtilities {
                         if (c2 == 'a') {
                             if (c3 == 'm') {
                                 if (c4 == 'p') {
-									if (string.length() > i + 4) {
-										char c5 = string.charAt(i + 4);
-										if (c5 == ';') {
-											skip = true;
-										}
-									}
+                                    if (string.length() > i + 4) {
+                                        char c5 = string.charAt(i + 4);
+                                        if (c5 == ';') {
+                                            skip = true;
+                                        }
+                                    }
                                 }
                             }
                         } else if (c2 == 'q') {
                             if (c3 == 'u') {
                                 if (c4 == 'o') {
-									if (string.length() > i + 6) {
-				                        char c5 = string.charAt(i + 4);
-				                        char c6 = string.charAt(i + 5);
-										char c7 = string.charAt(i + 6);
-										if (c5 == 't') {
-											if (c6 == 'e') {
-												if (c7 == ';') {
-													skip = true;
-												}
-											}
-										}
-									}
+                                    if (string.length() > i + 5) {
+                                        char c5 = string.charAt(i + 4);
+                                        char c6 = string.charAt(i + 5);
+                                        if (c5 == 't') {
+                                            if (c6 == ';') {
+                                                    skip = true;
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         } else if (c2 == 'l' || c2 == 'g') {


### PR DESCRIPTION
Dear Grobid team,

I had some trouble with Grobid not properly escaping XML special characters in the `xml:id` attribute when generating `biblStruct`s.

Also I noticed a typo in the part of the `TextUtilities.HTMLEncode` method that tries to prevent double encoding of HTML entities (it was checking for `&quote;` instead of `&quot;`.

Let me know what you think!

All the best,
Fabian