### PR TITLE
Add an alternative name for China to country codes

### DIFF
--- a/grobid-home/lexicon/countries/CountryCodes.xml
+++ b/grobid-home/lexicon/countries/CountryCodes.xml
@@ -335,6 +335,7 @@
                         <cell role="name" xml:lang="en">China</cell>
                         <cell role="nameAlt" xml:lang="en">People’s Republic of China</cell>
                         <cell role="nameAlt" xml:lang="en">People’s Republic China</cell>
+                        <cell role="nameAlt" xml:lang="en">Peoples R China</cell>
                         <cell role="nameAlt" xml:lang="en">P.R. China</cell>
 						<cell role="nameAlt" xml:lang="en">P.R.China</cell>
 						<cell role="nameAlt" xml:lang="en">P. R. China</cell>


### PR DESCRIPTION
It would be useful to add 'Peoples R China' as an additional English alternative name to the country code lexicon. The extracted affiliation strings from Web of Science seem to contain this name quite often.