### PR TITLE
Fixed ResourceException when running GROBID inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,27 @@
 
 # > mvn clean install -P docker
 
-# > docker build -t lfoppiano/grobid:0.4.1-SNAPSHOT .
+# > docker build -t lfoppiano/grobid:0.4.2-SNAPSHOT .
 # > docker run -t --rm -p 8080:8080 {image_name}
 
 # To connect to the container with a bash shell
 # > docker exec -i -t {container_name} /bin/bash
 
 FROM jetty:9.3-jre8
-ENV JAVA_OPTS=-Xmx4g
 
 MAINTAINER Luca Foppiano <luca.foppiano@inria.fr>, Patrice Lopez <patrice.lopez@science-miner.org>
-LABEL Description="This image is used to generate a GROBID image" Version="0.4.1-SNAPSHOT"
+LABEL Description="This image is used to generate a GROBID image" Version="0.4.2-SNAPSHOT"
 
-ADD ./grobid-home/target/grobid-home-0.4.1-SNAPSHOT.zip /opt
-RUN unzip /opt/grobid-home-0.4.1-SNAPSHOT.zip -d /opt && rm /opt/grobid-home-0.4.1-SNAPSHOT.zip
+ENV JAVA_OPTS=-Xmx4g
+
+VOLUME /opt/grobid-home/tmp
 
 RUN apt-get update && apt-get -y --no-install-recommends install libxml2
 
-COPY ./grobid-service/target/grobid-service-0.4.1-SNAPSHOT.war /var/lib/jetty/webapps/ROOT.war
+ADD ./grobid-home/target/grobid-home-0.4.2-SNAPSHOT.zip /opt
+RUN unzip /opt/grobid-home-0.4.2-SNAPSHOT.zip -d /opt && rm /opt/grobid-home-0.4.2-SNAPSHOT.zip
+
+COPY ./grobid-service/target/grobid-service-0.4.2-SNAPSHOT.war /var/lib/jetty/webapps/ROOT.war
 
 
 ## Docker tricks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,20 @@
 
 # > mvn clean install -P docker
 
-# > docker build -t lfoppiano/grobid:0.4.2-SNAPSHOT .
+# > docker build -t lfoppiano/grobid:GROBID_VERSION --build-arg GROBID_VERSION=1.0.0 .
+# Example: > docker build -t lfoppiano/grobid:1.0.0 --build-arg GROBID_VERSION=1.0.0 .
+
 # > docker run -t --rm -p 8080:8080 {image_name}
 
 # To connect to the container with a bash shell
 # > docker exec -i -t {container_name} /bin/bash
-
 FROM jetty:9.3-jre8
 
 MAINTAINER Luca Foppiano <luca.foppiano@inria.fr>, Patrice Lopez <patrice.lopez@science-miner.org>
-LABEL Description="This image is used to generate a GROBID image" Version="0.4.2-SNAPSHOT"
+
+ARG GROBID_VERSION
+
+LABEL Description="This image is used to generate a GROBID image" Version="${GROBID_VERSION}"
 
 ENV JAVA_OPTS=-Xmx4g
 
@@ -21,10 +25,10 @@ VOLUME /opt/grobid-home/tmp
 
 RUN apt-get update && apt-get -y --no-install-recommends install libxml2
 
-ADD ./grobid-home/target/grobid-home-0.4.2-SNAPSHOT.zip /opt
-RUN unzip /opt/grobid-home-0.4.2-SNAPSHOT.zip -d /opt && rm /opt/grobid-home-0.4.2-SNAPSHOT.zip
+ADD ./grobid-home/target/grobid-home-${GROBID_VERSION}.zip /opt
+RUN unzip /opt/grobid-home-${GROBID_VERSION}.zip -d /opt && rm /opt/grobid-home-${GROBID_VERSION}.zip
 
-COPY ./grobid-service/target/grobid-service-0.4.2-SNAPSHOT.war /var/lib/jetty/webapps/ROOT.war
+COPY ./grobid-service/target/grobid-service-${GROBID_VERSION}.war /var/lib/jetty/webapps/ROOT.war
 
 
 ## Docker tricks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 # > mvn clean install -P docker
 
-# > docker build -t lfoppiano/grobid:GROBID_VERSION --build-arg GROBID_VERSION=1.0.0 .
+# > docker build -t lfoppiano/grobid:GROBID_VERSION --build-arg GROBID_VERSION=GROBID_VERSION .
 # Example: > docker build -t lfoppiano/grobid:1.0.0 --build-arg GROBID_VERSION=1.0.0 .
 
 # > docker run -t --rm -p 8080:8080 {image_name}

--- a/doc/Grobid-docker.md
+++ b/doc/Grobid-docker.md
@@ -107,12 +107,12 @@ using the profile docker, in order to correctly set up the grobid-home in the we
 make sure the Dockerfile points to the right jars (TODO: add placeholders based on the version), launch the build: 
 
 ```bash
-> docker build -t lfoppiano/grobid:0.4.2-SNAPSHOT --build-arg GROBID_VERSION=0.4.2-SNAPSHOT .
+> docker build -t lfoppiano/grobid:0.4.2 --build-arg GROBID_VERSION=0.4.2-SNAPSHOT .
 ```
 
 In order to run the container of the newly created image: 
 ```bash
-> docker run -t --rm -p 8080:8080 lfoppiano/grobid:0.4.1-SNAPSHOT 
+> docker run -t --rm -p 8080:8080 lfoppiano/grobid:0.4.2 
 ```
 
 For testing or debugging purposes, you can connect to the container with a bash shell:

--- a/doc/Grobid-docker.md
+++ b/doc/Grobid-docker.md
@@ -107,7 +107,7 @@ using the profile docker, in order to correctly set up the grobid-home in the we
 make sure the Dockerfile points to the right jars (TODO: add placeholders based on the version), launch the build: 
 
 ```bash
-> docker build -t lfoppiano/grobid:0.4.1 .
+> docker build -t lfoppiano/grobid:0.4.2-SNAPSHOT --build-arg GROBID_VERSION=0.4.2-SNAPSHOT .
 ```
 
 In order to run the container of the newly created image: 


### PR DESCRIPTION
When I tried to run GROBID inside Docker, there was a problem with creating /tmp directory.

Stacktrace:

> 2017-01-06 02:17:32.208:INFO::main: Logging initialized @344ms
2017-01-06 02:17:32.428:INFO:oejs.SetUIDListener:main: Setting umask=02
2017-01-06 02:17:32.438:INFO:oejs.SetUIDListener:main: Opened ServerConnector@35f983a6{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2017-01-06 02:17:32.438:INFO:oejs.SetUIDListener:main: Setting GID=999
2017-01-06 02:17:32.439:INFO:oejs.SetUIDListener:main: Setting UID=999
2017-01-06 02:17:32.442:INFO:oejs.Server:main: jetty-9.3.15.v20161220
2017-01-06 02:17:32.464:INFO:oejdp.ScanningAppProvider:main: Deployment monitor [file:///var/lib/jetty/webapps/] at interval 1
2017-01-06 02:17:35.134:INFO:oeja.AnnotationConfiguration:main: Scanning elapsed time=1833ms
Jan 06, 2017 2:17:35 AM com.sun.jersey.api.core.PackagesResourceConfig init
INFO: Scanning for root resource and provider classes in the packages:
  org.grobid.service
Jan 06, 2017 2:17:35 AM com.sun.jersey.api.core.ScanningResourceConfig logClasses
INFO: Root resource classes found:
  class org.grobid.service.GrobidRestService
Jan 06, 2017 2:17:35 AM com.sun.jersey.api.core.ScanningResourceConfig init
INFO: No provider classes found.
Jan 06, 2017 2:17:35 AM com.sun.jersey.server.impl.application.WebApplicationImpl _initiate
INFO: Initiating Jersey application, version 'Jersey: 1.8 06/24/2011 12:17 PM'
2017-01-06 02:17:36.509:WARN:ROOT:main: unavailable
com.sun.jersey.api.container.ContainerException: Unable to create resource
	at com.sun.jersey.server.impl.resource.SingletonFactory$Singleton.init(SingletonFactory.java:139)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:584)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:581)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.getResourceComponentProvider(WebApplicationImpl.java:581)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:658)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:653)
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:124)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1298)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:169)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:775)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:771)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:771)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:766)
	at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:488)
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318)
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:609)
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:210)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:640)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
Caused by: 
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor._construct(ResourceComponentConstructor.java:191)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor.construct(ResourceComponentConstructor.java:179)
	at com.sun.jersey.server.impl.resource.SingletonFactory$Singleton.init(SingletonFactory.java:137)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:584)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:581)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.getResourceComponentProvider(WebApplicationImpl.java:581)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:658)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:653)
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:124)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1298)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:169)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:775)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:771)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:771)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:766)
	at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:488)
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318)
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:609)
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:210)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:640)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
Caused by: 
org.grobid.core.exceptions.GrobidResourceException: [GENERAL] Cannot create the folder '/opt/grobid-home/tmp'.
	at org.grobid.core.utilities.GrobidProperties.initializePaths(GrobidProperties.java:423)
	at org.grobid.core.utilities.GrobidProperties.init(GrobidProperties.java:367)
	at org.grobid.core.utilities.GrobidProperties.init(GrobidProperties.java:390)
	at org.grobid.core.utilities.GrobidProperties.<init>(GrobidProperties.java:342)
	at org.grobid.core.utilities.GrobidProperties.getNewInstance(GrobidProperties.java:122)
	at org.grobid.core.utilities.GrobidProperties.getInstance(GrobidProperties.java:101)
	at org.grobid.core.factory.AbstractEngineFactory.init(AbstractEngineFactory.java:50)
	at org.grobid.core.factory.AbstractEngineFactory.fullInit(AbstractEngineFactory.java:58)
	at org.grobid.service.GrobidRestService.<init>(GrobidRestService.java:78)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor._construct(ResourceComponentConstructor.java:191)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor.construct(ResourceComponentConstructor.java:179)
	at com.sun.jersey.server.impl.resource.SingletonFactory$Singleton.init(SingletonFactory.java:137)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:584)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:581)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.getResourceComponentProvider(WebApplicationImpl.java:581)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:658)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:653)
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:124)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1298)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:169)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:775)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:771)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:771)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:766)
	at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:488)
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318)
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:609)
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:210)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:640)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
2017-01-06 02:17:36.513:WARN:oejw.WebAppContext:main: Failed startup of context o.e.j.w.WebAppContext@5700d6b1{/,file:///tmp/jetty/jetty-0.0.0.0-8080-ROOT.war-_-any-572271227115255082.dir/webapp/,UNAVAILABLE}{/ROOT.war}
javax.servlet.ServletException: grobid-service@41db9281==com.sun.jersey.spi.container.servlet.ServletContainer,1,false
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:661)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
Caused by: 
com.sun.jersey.api.container.ContainerException: Unable to create resource
	at com.sun.jersey.server.impl.resource.SingletonFactory$Singleton.init(SingletonFactory.java:139)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:584)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:581)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.getResourceComponentProvider(WebApplicationImpl.java:581)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:658)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:653)
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:124)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1298)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:169)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:775)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:771)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:771)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:766)
	at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:488)
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318)
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:609)
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:210)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:640)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
Caused by: 
java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor._construct(ResourceComponentConstructor.java:191)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor.construct(ResourceComponentConstructor.java:179)
	at com.sun.jersey.server.impl.resource.SingletonFactory$Singleton.init(SingletonFactory.java:137)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:584)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:581)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.getResourceComponentProvider(WebApplicationImpl.java:581)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:658)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:653)
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:124)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1298)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:169)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:775)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:771)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:771)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:766)
	at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:488)
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318)
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:609)
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:210)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:640)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
Caused by: 
org.grobid.core.exceptions.GrobidResourceException: [GENERAL] Cannot create the folder '/opt/grobid-home/tmp'.
	at org.grobid.core.utilities.GrobidProperties.initializePaths(GrobidProperties.java:423)
	at org.grobid.core.utilities.GrobidProperties.init(GrobidProperties.java:367)
	at org.grobid.core.utilities.GrobidProperties.init(GrobidProperties.java:390)
	at org.grobid.core.utilities.GrobidProperties.<init>(GrobidProperties.java:342)
	at org.grobid.core.utilities.GrobidProperties.getNewInstance(GrobidProperties.java:122)
	at org.grobid.core.utilities.GrobidProperties.getInstance(GrobidProperties.java:101)
	at org.grobid.core.factory.AbstractEngineFactory.init(AbstractEngineFactory.java:50)
	at org.grobid.core.factory.AbstractEngineFactory.fullInit(AbstractEngineFactory.java:58)
	at org.grobid.service.GrobidRestService.<init>(GrobidRestService.java:78)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor._construct(ResourceComponentConstructor.java:191)
	at com.sun.jersey.server.spi.component.ResourceComponentConstructor.construct(ResourceComponentConstructor.java:179)
	at com.sun.jersey.server.impl.resource.SingletonFactory$Singleton.init(SingletonFactory.java:137)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:584)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$10.f(WebApplicationImpl.java:581)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.getResourceComponentProvider(WebApplicationImpl.java:581)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:658)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiateResource(WebApplicationImpl.java:653)
	at com.sun.jersey.server.impl.application.RootResourceUriRules.<init>(RootResourceUriRules.java:124)
	at com.sun.jersey.server.impl.application.WebApplicationImpl._initiate(WebApplicationImpl.java:1298)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.access$700(WebApplicationImpl.java:169)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:775)
	at com.sun.jersey.server.impl.application.WebApplicationImpl$13.f(WebApplicationImpl.java:771)
	at com.sun.jersey.spi.inject.Errors.processWithErrors(Errors.java:193)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:771)
	at com.sun.jersey.server.impl.application.WebApplicationImpl.initiate(WebApplicationImpl.java:766)
	at com.sun.jersey.spi.container.servlet.ServletContainer.initiate(ServletContainer.java:488)
	at com.sun.jersey.spi.container.servlet.ServletContainer$InternalWebComponent.initiate(ServletContainer.java:318)
	at com.sun.jersey.spi.container.servlet.WebComponent.load(WebComponent.java:609)
	at com.sun.jersey.spi.container.servlet.WebComponent.init(WebComponent.java:210)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:373)
	at com.sun.jersey.spi.container.servlet.ServletContainer.init(ServletContainer.java:556)
	at javax.servlet.GenericServlet.init(GenericServlet.java:244)
	at org.eclipse.jetty.servlet.ServletHolder.initServlet(ServletHolder.java:640)
	at org.eclipse.jetty.servlet.ServletHolder.initialize(ServletHolder.java:419)
	at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:892)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:349)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1404)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1366)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:778)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:262)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:520)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:41)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:499)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:147)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:180)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:452)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:64)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:610)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:529)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:392)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:313)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:150)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:561)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:236)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:131)
	at org.eclipse.jetty.server.Server.start(Server.java:422)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:113)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:61)
	at org.eclipse.jetty.server.Server.doStart(Server.java:389)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:68)
	at org.eclipse.jetty.xml.XmlConfiguration$1.run(XmlConfiguration.java:1516)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1441)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:214)
	at org.eclipse.jetty.start.Main.start(Main.java:457)
	at org.eclipse.jetty.start.Main.main(Main.java:75)
2017-01-06 02:17:36.529:INFO:oejs.AbstractConnector:main: Started ServerConnector@35f983a6{HTTP/1.1,[http/1.1]}{0.0.0.0:8080}
2017-01-06 02:17:36.530:INFO:oejs.Server:main: Started @4666ms
