### PR TITLE
Fixing recursive processing with empty subfolders.

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/ProcessEngine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/ProcessEngine.java
@@ -98,7 +98,7 @@ public class ProcessEngine implements Closeable {
                         result = getEngine().processHeader(currPdf.getAbsolutePath(), false, null);
 						File outputPathFile = new File(outputPath);
 						if (!outputPathFile.exists()) {
-							outputPathFile.mkdir();
+							outputPathFile.mkdirs();
 						}
 						if (currPdf.getName().endsWith(".pdf")) {
                         	IOUtilities.writeInFile(outputPath + File.separator


### PR DESCRIPTION
Currently grobid fails to create intermediate output subfolders during
recursive batch processing if the corresponding input subfolder does
not contain any PDFs.

This leads to FileNotFound Exceptions for PDFs deeper in the directory
tree, as the directory tree on the output side is incomplete.

Changing File.mkdir() to File.mkdirs() creates all potential missing
intermediate folders.

The following shell script allows for easy replication:
```
#! /bin/bash

(($# <= 2)) || { echo "Usage: $0 <grobid_project_directory> <test_here>"; exit 1; }

GROBID_DIR="${1:-$HOME/Projects/misc/grobid}"

if [ ! -d "$GROBID_DIR" ]; then
  echo "Error: Grobid base directory does not exist!"
  exit 1
fi

GROBID_HOME="$GROBID_DIR/grobid-home"
GROBID_CORE="$GROBID_DIR/grobid-core"
GROBID_CFG="$GROBID_HOME/config/grobid.properties"
TESTING_DIR="${2:-$HOME/tests/}"

cd "$TESTING_DIR" || { echo "Error: Directory to test in ($TESTING_DIR) does not exist!"; exit 1; }
mkdir output
mkdir -p input/subfolder1/subfolder2
cp "$GROBID_DIR/doc/GROBID.pdf" "input/subfolder1/subfolder2/GROBID.pdf"

# With the two copies below it works fine.
#cp "$GROBID_DIR/doc/GROBID.pdf" "input/GROBID.pdf"
#cp "$GROBID_DIR/doc/GROBID.pdf" "input/subfolder1/GROBID.pdf"

java -Xmx1024m -jar "$GROBID_CORE/target/grobid-core-0.4.2-SNAPSHOT.one-jar.jar" -gH "$GROBID_HOME" -gP "$GROBID_CFG" -dIn input -dOut output -r -exe processHeader
```