### PR TITLE
Provide git info in the MANIFEST.MF

### DIFF
--- a/grobid-core/pom.xml
+++ b/grobid-core/pom.xml
@@ -312,6 +312,10 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
         </plugins>
         <!--/pluginManagement -->
     </build>

--- a/grobid-service/pom.xml
+++ b/grobid-service/pom.xml
@@ -234,6 +234,10 @@
                     </systemProperties>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/grobid-trainer/pom.xml
+++ b/grobid-trainer/pom.xml
@@ -64,6 +64,10 @@
                     <target>1.7</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,23 @@
     </reporting>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <SCM-Revision>${git.commit.id}</SCM-Revision>
+                                <SCM-Description>${git.commit.id.describe}</SCM-Description>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
@@ -101,6 +118,20 @@
                     <check>true</check>
                     <aggregate>true</aggregate>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.2</version>
+                <executions>
+                    <execution>
+                        <id>provide scm info</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
The manifest would look something like:

    Manifest-Version: 1.0
    SCM-Description: grobid-parent-0.4.1-138-g2ab2b23-dirty
    SCM-Revision: 2ab2b23456c9a8cc21c6f3bfbae8989bfc99eba5
    Built-By: userID
    Created-By: Apache Maven 3.3.9
    Build-Jdk: 1.8.0_131

It would help to identify the snapshot version which was from sources by a git revision id.