### PR TITLE
Fix 'zh-tw' language detection.

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/lang/Language.java
+++ b/grobid-core/src/main/java/org/grobid/core/lang/Language.java
@@ -26,7 +26,7 @@ public final class Language {
         }
 
         if ((langId.length() != 3 && langId.length() != 2 && (!langId.equals("sorb")) && 
-            (!langId.equals("zh-cn"))) || !(Character.isLetter(langId.charAt(0)) 
+            (!langId.equals("zh-cn")) && (!langId.equals("zh-tw"))) || !(Character.isLetter(langId.charAt(0))
             && Character.isLetter(langId.charAt(1)))) {
             throw new GrobidException("Language id should consist of two or three letters, but was: " + langId);
         }

--- a/grobid-core/src/test/java/org/grobid/core/lang/LanguageTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lang/LanguageTest.java
@@ -1,0 +1,69 @@
+package org.grobid.core.lang;
+
+import org.junit.Test;
+
+public class LanguageTest {
+
+    @Test
+    public void testLanguagesAvailableInLangdetect() {
+        String[] langList = new String[] {
+            "af",
+            "ar",
+            "bg",
+            "bn",
+            "cs",
+            "da",
+            "de",
+            "el",
+            "en",
+            "es",
+            "et",
+            "fa",
+            "fi",
+            "fr",
+            "gu",
+            "he",
+            "hi",
+            "hr",
+            "hu",
+            "id",
+            "it",
+            "ja",
+            "kn",
+            "ko",
+            "lt",
+            "lv",
+            "mk",
+            "ml",
+            "mr",
+            "ne",
+            "nl",
+            "no",
+            "pa",
+            "pl",
+            "pt",
+            "ro",
+            "ru",
+            "sk",
+            "sl",
+            "so",
+            "sq",
+            "sv",
+            "sw",
+            "ta",
+            "te",
+            "th",
+            "tl",
+            "tr",
+            "uk",
+            "ur",
+            "vi",
+            "zh-cn",
+            "zh-tw"
+        };
+        // Should not throw an exception
+        for (String lang : langList) {
+            new Language(lang, 1d);
+        }
+    }
+}


### PR DESCRIPTION
Exception occurs for some documents:

    org.grobid.core.utilities.LanguageUtilities: Cannot detect language because of: 
    org.grobid.core.exceptions.GrobidException: [GENERAL] Language id should consist of two or three letters, but was: zh-tw
