### PR TITLE
Problematic PDFs could leak resources.

### DIFF
--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessFiles.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessFiles.java
@@ -810,22 +810,23 @@ public class GrobidRestProcessFiles {
 
         Document teiDoc = engine.fullTextToTEIDoc(originFile, config);
 
-        final PDDocument document = PDDocument.load(originFile);
-        //If no pages, skip the document
-        if (document.getNumberOfPages() > 0) {
-            DocumentSource documentSource = DocumentSource.fromPdf(originFile);
-            if (isparallelExec) {
-                outputDocument = dispatchProcessing(type, document, documentSource, teiDoc);
-                GrobidPoolingFactory.returnEngine(engine);
-            } else {
-                synchronized (engine) {
-                    //TODO: VZ: sync on local var does not make sense
+        try (PDDocument document = PDDocument.load(originFile)) {
+            //If no pages, skip the document
+            if (document.getNumberOfPages() > 0) {
+                DocumentSource documentSource = DocumentSource.fromPdf(originFile);
+                if (isparallelExec) {
                     outputDocument = dispatchProcessing(type, document, documentSource, teiDoc);
+                    GrobidPoolingFactory.returnEngine(engine);
+                } else {
+                    synchronized (engine) {
+                        //TODO: VZ: sync on local var does not make sense
+                        outputDocument = dispatchProcessing(type, document, documentSource, teiDoc);
+                    }
                 }
-            }
-        } else {
-            throw new RuntimeException("Cannot identify any pages in the input document. " +
+            } else {
+                throw new RuntimeException("Cannot identify any pages in the input document. " +
                     "The document cannot be annotated. Please check whether the document is valid or the logs.");
+            }
         }
 
         return outputDocument;


### PR DESCRIPTION
If getPages fails with an exception, document is not closed:

> at org.apache.pdfbox.pdmodel.PDPageTree.<init>(PDPageTree.java:75)
at org.apache.pdfbox.pdmodel.PDDocumentCatalog.getPages(PDDocumentCatalog.java:128)
at org.apache.pdfbox.pdmodel.PDDocument.getNumberOfPages(PDDocument.java:1262)