### PR TITLE
Fix BibDataSetContextExtractor to quote replacement text

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/BibDataSetContextExtractor.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/BibDataSetContextExtractor.java
@@ -83,7 +83,7 @@ public class BibDataSetContextExtractor {
         Matcher m = REF_PATTERN.matcher(cont);
         if (m.find()) {
             String g = m.group(1);
-            return m.replaceAll(g);
+            return m.replaceAll(Matcher.quoteReplacement(g));
         } else {
             throw new IllegalStateException("Implementation error: no <ref> found in" + cont);
         }

--- a/grobid-core/src/test/java/org/grobid/core/utilities/BibDataSetContextExtractorTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/BibDataSetContextExtractorTest.java
@@ -1,0 +1,20 @@
+package org.grobid.core.utilities;
+
+import org.apache.commons.io.IOUtils;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+public class BibDataSetContextExtractorTest {
+
+    @Test
+    public void testRefEscapes() throws Exception {
+        InputStream is = this.getClass().getResourceAsStream("/test/tei-escape.xml");
+        String tei = IOUtils.toString(is, StandardCharsets.UTF_8);
+        is.close();
+        BibDataSetContextExtractor.getCitationReferences(tei);
+    }
+
+}

--- a/grobid-core/src/test/resources/test/tei-escape.xml
+++ b/grobid-core/src/test/resources/test/tei-escape.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://www.tei-c.org/ns/1.0 /home/lopez/grobid/grobid-home/schemas/xsd/Grobid.xsd"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+	<text xml:lang="en">
+		<body>
+                    <div xmlns="http://www.tei-c.org/ns/1.0"><p>Lorem ipsum <ref type="bibr" target="#b0">$9,</ref><ref type="bibr" target="#b1">2]</ref>.
+                    </p></div>
+                </body>
+        </text>
+</TEI>


### PR DESCRIPTION
I've been seeing the following error fairly frequently: ```
! java.lang.IllegalArgumentException: Illegal group reference                                                    
! at java.util.regex.Matcher.appendReplacement(Matcher.java:857)                                                 
! at java.util.regex.Matcher.replaceAll(Matcher.java:955)                                                        
! at org.grobid.core.utilities.BibDataSetContextExtractor.extractContextSentence(BibDataSetContextExtractor.java:86)                                                                                                              
! at org.grobid.core.utilities.BibDataSetContextExtractor.getCitationReferences(BibDataSetContextExtractor.java:73)                                                                                                               
! at org.grobid.core.visualization.CitationsVisualizer.getJsonAnnotations(CitationsVisualizer.java:318)          
! at org.grobid.service.process.GrobidRestProcessFiles.processPDFReferenceAnnotation(GrobidRestProcessFiles.java:598)                                                                                                             
! at org.grobid.service.GrobidRestService.processPDFReferenceAnnotation(GrobidRestService.java:557)              
```

It turns out that the BibDataSetContextExtractor isn't quoting the replacement string, so backslashes and dollar signs cause this error or unintended behavior.

This fixes the issue and adds a test case for it.