### PR TITLE
Fix JSON generation for reference annotations

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/layout/BoundingBox.java
+++ b/grobid-core/src/main/java/org/grobid/core/layout/BoundingBox.java
@@ -1,7 +1,11 @@
 package org.grobid.core.layout;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Created by zholudev on 18/08/15.
@@ -228,6 +232,14 @@ public class BoundingBox {
         builder.append("\"w\":").append(width).append(", ");
         builder.append("\"h\":").append(height);
         return builder.toString();
+    }
+
+    public void writeJsonProps(JsonGenerator gen) throws IOException {
+        gen.writeNumberField("p", page);
+        gen.writeNumberField("x", x);
+        gen.writeNumberField("y", y);
+        gen.writeNumberField("w", width);
+        gen.writeNumberField("h", height);
     }
 
     @Override

--- a/grobid-core/src/test/java/org/grobid/core/visualization/TestCitationsVisualizer.java
+++ b/grobid-core/src/test/java/org/grobid/core/visualization/TestCitationsVisualizer.java
@@ -1,0 +1,105 @@
+package org.grobid.core.visualization;
+
+import org.apache.commons.io.FileUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.grobid.core.document.Document;
+import org.grobid.core.engines.Engine;
+import org.grobid.core.engines.config.GrobidAnalysisConfig;
+import org.grobid.core.factory.GrobidFactory;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Clayton Wheeler
+ */
+public class TestCitationsVisualizer {
+
+    static final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    public void testJSONAnnotationStructure() throws Exception {
+        Engine engine = GrobidFactory.getInstance().getEngine();
+        File inputTmpFile = getInputDocument("/test/test_Grobid_1_05452615.pdf");
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+
+        String refURL = "http://example.com/xyz";
+        List<String> refURLs = Arrays.asList(refURL);
+        String json = CitationsVisualizer.getJsonAnnotations(tei, refURLs);
+        JsonNode root = mapper.readTree(json);
+        assertTrue(root.has("pages"));
+        assertTrue(root.has("refBibs"));
+        assertTrue(root.has("refMarkers"));
+        JsonNode pages = root.get("pages");
+        assertTrue(pages.isArray());
+        assertEquals(tei.getPages().size(), pages.size());
+        assertTrue(pages.size() > 0);
+        JsonNode firstPage = pages.get(0);
+        assertTrue(firstPage.has("page_height"));
+        assertTrue(firstPage.has("page_width"));
+
+        JsonNode bibs = root.get("refBibs");
+        JsonNode firstBib = bibs.get(0);
+        assertTrue(firstBib.has("id"));
+        assertTrue(firstBib.has("url"));
+        assertEquals(refURL, firstBib.get("url").asText());
+        assertTrue(firstBib.has("pos"));
+        JsonNode fbPos = firstBib.get("pos");
+        assertTrue(fbPos.isArray());
+        assertTrue(fbPos.size() > 0);
+
+        for (JsonNode bbox : fbPos) {
+            assertTrue(bbox.isObject());
+            assertTrue(bbox.has("p"));
+            assertTrue(bbox.has("x"));
+            assertTrue(bbox.has("y"));
+            assertTrue(bbox.has("w"));
+            assertTrue(bbox.has("h"));
+        }
+
+        // XXX: this isn't working, not sure if it needs a different
+        // test document or some extra processing step
+        /*
+        JsonNode markers = root.get("refMarkers");
+        JsonNode firstMarker = markers.get(0);
+        assertTrue(firstMarker.has("id"));
+        assertTrue(firstMarker.has("p"));
+        assertTrue(firstMarker.has("x"));
+        assertTrue(firstMarker.has("y"));
+        assertTrue(firstMarker.has("w"));
+        assertTrue(firstMarker.has("h"));
+        */
+    }
+
+    @Test
+    public void testJSONAnnotationEscaping() throws Exception {
+        Engine engine = GrobidFactory.getInstance().getEngine();
+        File inputTmpFile = getInputDocument("/test/test_Grobid_1_05452615.pdf");
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+
+        // check that this embedded backslash is escaped properly
+        String refURL = "http://example.com/xyz?a=ab\\c123";
+        List<String> refURLs = Arrays.asList(refURL);
+        String json = CitationsVisualizer.getJsonAnnotations(tei, refURLs);
+        JsonNode root = mapper.readTree(json);
+    }
+
+    // XXX: copied from TestFullTextParser
+    private File getInputDocument(String inputPath) throws IOException {
+        InputStream is = this.getClass().getResourceAsStream(inputPath);
+        File inputTmpFile  = File.createTempFile("tmpFileTest", "testFullTextParser");
+        inputTmpFile.deleteOnExit();
+
+        FileUtils.copyToFile(is, inputTmpFile);
+
+        return inputTmpFile;
+    }
+}


### PR DESCRIPTION
The reference annotations endpoint returns invalid JSON when, for instance, a reference hyperlink in a PDF contains a backslash. Strings weren't being escaped before being put into the JSON response, so invalid backslash escape sequences could occur and cause parse errors.

This adds a test case and reimplements JSON generation using Jackson, which should avoid all such problems.