### PR TITLE
Lists implementation for fulltext model

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1155,6 +1155,7 @@ public class TEIFormatter {
         }
         divResults.add(curDiv);
         Element curParagraph = null;
+        Element curList = null;
         int equationIndex = 0; // current equation index position 
         for (TaggingTokenCluster cluster : clusters) {
             if (cluster == null) {
@@ -1218,7 +1219,14 @@ public class TEIFormatter {
                 }
             } else if (clusterLabel.equals(TaggingLabels.ITEM)) {
                 String clusterContent = LayoutTokensUtil.normalizeText(cluster.concatTokens());
-                curDiv.appendChild(teiElement("item", clusterContent));
+                Element itemNode = teiElement("item", clusterContent);
+                if (!MARKER_LABELS.contains(lastClusterLabel) && (lastClusterLabel != TaggingLabels.ITEM)) {
+                    curList = teiElement("list");
+                    curDiv.appendChild(curList);
+                }
+                if (curList != null) {
+                    curList.appendChild(itemNode);
+                }
             } else if (clusterLabel.equals(TaggingLabels.OTHER)) {
                 String clusterContent = LayoutTokensUtil.normalizeDehyphenizeText(cluster.concatTokens());
                 Element note = teiElement("note", clusterContent);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/sax/TEIFulltextSaxParser.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/sax/TEIFulltextSaxParser.java
@@ -178,8 +178,8 @@ public class TEIFulltextSaxParser extends DefaultHandler {
 				currentTag = "<table>";
             } 
 			else if (qName.equals("item")) {
-                currentTags.push("<paragraph>");
-				currentTag = "<paragraph>";
+                currentTags.push("<item>");
+				currentTag = "<item>";
             } 
 			else if (qName.equals("figure")) {
 	            figureBlock = true;


### PR DESCRIPTION
Hi @kermitt2,

I've noticed that list items are excluded from being labeled by the fulltext model. Are you interested in their implementation? Maybe you are considering to put them into a separate model, like figures? 

In this PR model.wapiti is trained with the default corpus. 