### PR TITLE
Swap w/h in coordinates documentation

### DIFF
--- a/doc/Coordinates-in-PDF.md
+++ b/doc/Coordinates-in-PDF.md
@@ -128,7 +128,7 @@ Example 1:
 </author>
 ```
 
-"1,53.80,194.57,58.71,9.29" indicates one bounding box with attributes page=1, x=53.80, y=194.57, h=58.71, w=9.29.
+"1,53.80,194.57,58.71,9.29" indicates one bounding box with attributes page=1, x=53.80, y=194.57, w=58.71, h=9.29.
 
 Example 2:
 ```xml


### PR DESCRIPTION
These were the wrong way round.

Also – the "Edit on GitHub" button is broken in the docs. I couldn't find where that is configured in the repo, so I am guessing it is configured in the readthedocs web interface.