### PR TITLE
fixed docker build with latest openjdk:8-jre-slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # -------------------
 # build builder image
 # -------------------
-FROM openjdk:8-jdk as builder
+FROM openjdk:8u212-jdk as builder
 
 USER root
 
@@ -42,7 +42,7 @@ RUN ./gradlew clean assemble --no-daemon  --info --stacktrace
 # -------------------
 # build runtime image
 # -------------------
-FROM openjdk:8-jre-slim
+FROM openjdk:8u212-jre-slim
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install libxml2 unzip

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN ./gradlew clean assemble --no-daemon  --info --stacktrace
 FROM openjdk:8-jre-slim
 
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install libxml2
+    apt-get -y --no-install-recommends install libxml2 unzip
 
 WORKDIR /opt
 


### PR DESCRIPTION
The latest version of openjdk:8-jre-slim doesn't include unzip anymore.

With the latest version

```console
$ docker pull openjdk:8-jre-slim
8-jre-slim: Pulling from library/openjdk
Digest: sha256:39bece5e977d0daeb0510335f2624b929f893c167a09e6fc4e28412bb78eeb90
Status: Image is up to date for openjdk:8-jre-slim
$ docker run --rm openjdk:8-jre-slim unzip -h
docker: Error response from daemon: OCI runtime create failed: container_linux.go:348: starting container process caused "exec: \"unzip\": executable file not found in $PATH": unknown.
```

Previous version:

```console
$ docker run --rm openjdk:8u131-jre-slim unzip -h
UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP.
...
```

Fix:
- install `unzip`
- pin base image to avoid issue in the future (and make it more clear what the base image is)

/cc @lfoppiano
