### PR TITLE
add support for delft layout features for label task

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -52,7 +52,7 @@ public class DeLFTModel {
         public void run() { 
             Jep jep = JEPThreadPool.getInstance().getJEPInstance(); 
             try {
-                LOGGER.debug("DeLFTModel, loading model: {}", modelPath.getAbsolutePath());
+                LOGGER.debug("DeLFTModel, loading model from path: {}", modelPath.getAbsolutePath());
                 jep.eval(this.modelName+" = Sequence('" + this.modelName.replace("_", "-") + "')");
                 jep.eval(this.modelName+".load(dir_path='"+modelPath.getAbsolutePath()+"')");
             } catch(JepException e) {

--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
@@ -86,11 +86,13 @@ public class JEPThreadPool {
         jep.eval("import numpy as np");
         jep.eval("import keras.backend as K");
         jep.eval("os.chdir('" + delftPath.getAbsolutePath() + "')");
-        jep.eval("from delft.utilities.Embeddings import Embeddings");
-        jep.eval("import delft.sequenceLabelling");
-        jep.eval("from delft.sequenceLabelling import Sequence");
-        jep.eval("from delft.sequenceLabelling.reader import load_data_and_labels_crf_file");
-        jep.eval("from delft.sequenceLabelling.reader import load_data_crf_string");
+        String delftPackage = GrobidProperties.getDeLFTPackage();
+        LOGGER.debug("delft package: {}", delftPackage);
+        jep.eval("from " + delftPackage + ".utilities.Embeddings import Embeddings");
+        jep.eval("import " + delftPackage + ".sequenceLabelling");
+        jep.eval("from " + delftPackage + ".sequenceLabelling import Sequence");
+        jep.eval("from " + delftPackage + ".sequenceLabelling.reader import load_data_and_labels_crf_file");
+        jep.eval("from " + delftPackage + ".sequenceLabelling.reader import load_data_crf_string");
         jep.eval("from sklearn.model_selection import train_test_split");
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -35,6 +35,7 @@ public class GrobidProperties {
     static final String FILE_NAME_MODEL = "model";
     private static final String GROBID_VERSION_FILE = "/grobid-version.txt";
     static final String UNKNOWN_VERSION_STR = "unknown";
+    static final String DEFAULT_DELFT_PACKAGE = "delft";
 
     /**
      * A static {@link GrobidProperties} object containing all properties used
@@ -443,6 +444,13 @@ public class GrobidProperties {
     public static boolean isDeLFTRedirectOutput() {
         return Utilities.stringToBoolean(
             getPropertyValue(GrobidPropertyKeys.PROP_GROBID_DELFT_REDIRECT_OUTPUT)
+        );
+    }
+
+    public static String getDeLFTPackage() {
+        return getPropertyValue(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_PACKAGE,
+            DEFAULT_DELFT_PACKAGE
         );
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
@@ -19,6 +19,7 @@ public interface GrobidPropertyKeys {
     String PROP_GROBID_CRF_ENGINE = "grobid.crf.engine";
     String PROP_GROBID_DELFT_PATH = "grobid.delft.install";
     String PROP_GROBID_DELFT_REDIRECT_OUTPUT = "grobid.delft.redirect_output";
+    String PROP_GROBID_DELFT_PACKAGE = "grobid.delft.package";
     String PROP_GROBID_DELFT_ELMO = "grobid.delft.useELMo";
     String PROP_USE_LANG_ID = "grobid.use_language_id";
     String PROP_LANG_DETECTOR_FACTORY = "grobid.language_detector_factory";

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -76,6 +76,25 @@ public class GrobidPropertiesTest {
         assertTrue(GrobidProperties.isDeLFTRedirectOutput());
     }
 
+    @Test
+    public void testDeLFTPackageWithDefaultPackage() throws IOException {
+        GrobidProperties.getProps().remove(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_PACKAGE
+        );
+        assertEquals(
+            GrobidProperties.DEFAULT_DELFT_PACKAGE,
+            GrobidProperties.getDeLFTPackage()
+        );
+    }
+
+    @Test
+    public void testDeLFTPackageWithCustomPackage() throws IOException {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_GROBID_DELFT_PACKAGE, "custom_delft"
+        );
+        assertEquals("custom_delft", GrobidProperties.getDeLFTPackage());
+    }
+
     /*@Test(expected = GrobidPropertyException.class)
     public void testCheckPropertiesException_shouldThrowException() {
         GrobidProperties.getProps().put(


### PR DESCRIPTION
This adds support for DeLFT layout features on the GROBID side.
To actually work, it would also need the support on the DeLFT side (which I have currently implemented in [sciencebeam-trainer-delft](https://github.com/elifesciences/sciencebeam-trainer-delft)).
It should be backward compatible.

I added an optional configuration option for the package, which allows me to use my own Python package rather than `delft` (which I use in part, but currently extend heavily - until a similar change is ported back)

This is currently only implemented for the label task (not the train task).

Not sure whether implementing it for the training task is a priority. Judging by the comments, the JNI method for training doesn't seem to be stable. And the `grobidTagger.py` of the current DeLFT version itself doesn't support it anyway.

/cc @kermitt2 