### PR TITLE
ignore invalid utf-8 sequences by default

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -35,6 +35,7 @@ import org.grobid.core.sax.*;
 
 import org.grobid.core.utilities.BoundingBoxCalculator;
 import org.grobid.core.utilities.ElementCounter;
+import org.grobid.core.utilities.GrobidProperties;
 import org.grobid.core.utilities.LayoutTokensUtil;
 import org.grobid.core.utilities.Pair;
 import org.grobid.core.utilities.TextUtilities;
@@ -43,13 +44,22 @@ import org.grobid.core.utilities.matching.EntityMatcherException;
 import org.grobid.core.utilities.matching.ReferenceMarkerMatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
 
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -335,6 +345,25 @@ public class Document implements Serializable {
         return tokenizations;
     }
 
+    protected static void parseInputStream(
+        InputStream in, SAXParser saxParser, DefaultHandler handler
+    ) throws SAXException, IOException {
+        if (GrobidProperties.isPdfToXMLValidationEnabled()) {
+            saxParser.parse(in, handler);
+        } else {
+            CharsetDecoder utf8Decoder = Charset.forName("UTF-8").newDecoder();
+            utf8Decoder.onMalformedInput(CodingErrorAction.IGNORE);
+            utf8Decoder.onUnmappableCharacter(CodingErrorAction.IGNORE);
+            saxParser.parse(new InputSource(new InputStreamReader(in, utf8Decoder)), handler);
+        }
+    }
+
+    protected static void parseInputStream(
+        InputStream in, SAXParserFactory saxParserFactory, DefaultHandler handler
+    ) throws SAXException, IOException, ParserConfigurationException {
+        parseInputStream(in, saxParserFactory.newSAXParser(), handler);
+    }
+
     /**
      * Parser PDFALTO output representation and get the tokenized form of the document.
      *
@@ -371,9 +400,7 @@ public class Document implements Serializable {
             in = new FileInputStream(file);
             // in = new XMLFilterFileInputStream(file); // -> to filter invalid XML characters
 
-            // get a new instance of parser
-            SAXParser p = spf.newSAXParser();
-            p.parse(in, parser);
+            parseInputStream(in, spf, parser);
             tokenizations = parser.getTokenization();
             if (in != null) {
                 try {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -580,6 +580,12 @@ public class GrobidProperties {
         return Integer.parseInt(getPropertyValue(GrobidPropertyKeys.PROP_3RD_PARTY_PDFTOXML_TIMEOUT_SEC, "60"), 10) * 1000;
     }
 
+    public static boolean isPdfToXMLValidationEnabled() {
+        return Utilities.stringToBoolean(
+            getPropertyValue(GrobidPropertyKeys.PROP_3RD_PARTY_PDFTOXML_VALIDATION_ENABLED
+        ));
+    }
+
     /**
      * Returns the number of threads, given in the grobid-property file.
      *

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
@@ -15,6 +15,7 @@ public interface GrobidPropertyKeys {
     String PROP_3RD_PARTY_PDFTOXML = "grobid.3rdparty.pdf2xml.path";
     String PROP_3RD_PARTY_PDFTOXML_MEMORY_LIMIT = "grobid.3rdparty.pdf2xml.memory.limit.mb";
     String PROP_3RD_PARTY_PDFTOXML_TIMEOUT_SEC = "grobid.3rdparty.pdf2xml.memory.timeout.sec";
+    String PROP_3RD_PARTY_PDFTOXML_VALIDATION_ENABLED = "grobid.3rdparty.pdf2xml.validation.enabled";
 
     String PROP_GROBID_CRF_ENGINE = "grobid.crf.engine";
     String PROP_GROBID_DELFT_PATH = "grobid.delft.install";

--- a/grobid-core/src/test/java/org/grobid/core/document/DocumentTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/DocumentTest.java
@@ -1,0 +1,77 @@
+package org.grobid.core.document;
+
+import org.grobid.core.utilities.GrobidProperties;
+import org.grobid.core.utilities.GrobidPropertyKeys;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ByteArrayInputStream;
+
+import javax.xml.parsers.SAXParserFactory;
+
+public class DocumentTest {
+
+    @BeforeClass
+    public static void setInitialContext() throws Exception {
+        GrobidProperties.getInstance();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        GrobidProperties.getInstance();
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_3RD_PARTY_PDFTOXML_VALIDATION_ENABLED,
+            "false"
+        );
+    }
+
+    private static byte[] getValidXmlBytes() {
+        return "<xml>test</xml>".getBytes();
+    }
+
+    private static byte[] getXmlBytesWithInvalidUtf8Sequence() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write("<xml>".getBytes());
+        out.write(0xe0);
+        out.write(0xd8);
+        out.write(0x35);
+        out.write("</xml>".getBytes());
+        return out.toByteArray();
+    }
+
+    @Test
+    public void shouldNotFailToParseValidXml() throws Exception {
+        Document.parseInputStream(
+            new ByteArrayInputStream(getValidXmlBytes()),
+            SAXParserFactory.newInstance(),
+            new DefaultHandler()
+        );
+    }
+
+    @Test
+    public void shouldNotFailToParseInvalidUtf8ByteSequenceXmlByDefault() throws Exception {
+        Document.parseInputStream(
+            new ByteArrayInputStream(getXmlBytesWithInvalidUtf8Sequence()),
+            SAXParserFactory.newInstance(),
+            new DefaultHandler()
+        );
+    }
+
+    @Test(expected = SAXParseException.class)
+    public void shouldFailToParseInvalidUtf8ByteSequenceXmlWithValidationEnabled() throws Exception {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_3RD_PARTY_PDFTOXML_VALIDATION_ENABLED,
+            "true"
+        );
+        Document.parseInputStream(
+            new ByteArrayInputStream(getXmlBytesWithInvalidUtf8Sequence()),
+            SAXParserFactory.newInstance(),
+            new DefaultHandler()
+        );
+    }
+}

--- a/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/GrobidPropertiesTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class GrobidPropertiesTest {
     @Before
@@ -252,6 +253,20 @@ public class GrobidPropertiesTest {
         GrobidProperties
                 .getPropertyValue(GrobidPropertyKeys.PROP_3RD_PARTY_PDFTOXML);
         GrobidProperties.loadPdf2XMLPath();
+    }
+
+    @Test
+    public void testShouldDisableValidationPdfToXMLByDefault() throws Exception {
+        assertFalse(GrobidProperties.isPdfToXMLValidationEnabled());
+    }
+
+    @Test
+    public void testShouldEnableValidationPdfToXMLIfTrue() throws Exception {
+        GrobidProperties.getProps().put(
+            GrobidPropertyKeys.PROP_3RD_PARTY_PDFTOXML_VALIDATION_ENABLED,
+            "true"
+        );
+        assertTrue(GrobidProperties.isPdfToXMLValidationEnabled());
     }
 
     @Test(expected = GrobidPropertyException.class)


### PR DESCRIPTION
This is a workaround for #472 

By default it will ignore invalid UTF-8 sequences as it did in GROBID 0.5.3 and before.
The validation can be turned on via the properties file (`grobid.3rdparty.pdf2xml.validation.enabled`).

/cc @lfoppiano 