### PR TITLE
Possible change for using embedded PDF metadata

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -988,7 +988,7 @@ public class TEIFormatter {
                                     StringBuilder tei,
                                     Document doc,
                                     GrobidAnalysisConfig config) throws Exception {
-        List<String> allNotes = new ArrayList<String>();
+        List<String> allNotes = new ArrayList<>();
         for (DocumentPiece docPiece : documentNoteParts) {
             
             List<LayoutToken> noteTokens = doc.getDocumentPieceTokenization(docPiece);

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -145,7 +145,7 @@ public class FullTextParser extends AbstractParser {
                 // above, use the segmentation model result
                 if (doc.getMetadata() != null) {
                     Metadata metadata = doc.getMetadata();
-                    if (metadata.getTitle() != null)
+                    if (metadata.getTitle() != null && resHeader.getTitle() == null)
                         resHeader.setTitle(metadata.getTitle());
                     if (metadata.getAuthor() != null) {
                         resHeader.setAuthors(metadata.getAuthor());


### PR DESCRIPTION
Following issue #484 and initial PR #485, this PR addresses the usage of embedded PDF metadata as fall back to set the title and authors when the other extraction approaches failed (with and without heuristics).

The embedded PDF metadata are provided by pdfalto, there is no guarantee that they correspond to the actual article title and authors, but it's sometime the case.

The best approach, based on the average accuracy improvement, should be evaluated with the PMC 1942 dataset or a better dataset.

Note that we could imagine some sort of post-validation to better control the usage of these PDF metadata. 