### PR TITLE
added bin to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+bin
 grobid-home/tmp
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
Visual Studio Code outputs to the `bin` folder. This would exclude those files from git (not sure if there would be any benefit of including it).