### PR TITLE
[WIP] glutton_fatcat consolidation support

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -3699,7 +3699,7 @@ public class BiblioItem {
                     }
 
 			        if ( (author.getFirstName() == null) && (author.getMiddleName() == null) &&
-			                (author.getLastName() == null) ) {
+			                (author.getLastName() == null) && (author.getRawName() == null)) {
 						continue;
 					}
 

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -2150,6 +2150,20 @@ public class BiblioItem {
                 tei.append("<idno type=\"istexId\">" + TextUtilities.HTMLEncode(istexId) + "</idno>\n");
             }
 
+            if (!StringUtils.isEmpty(fatcatIdent)) {
+                for (int i = 0; i < indent + 2; i++) {
+                    tei.append("\t");
+                }
+                tei.append("<idno type=\"fatcat\">" + TextUtilities.HTMLEncode(fatcatIdent) + "</idno>\n");
+            }
+
+            if (!StringUtils.isEmpty(wikidataQid)) {
+                for (int i = 0; i < indent + 2; i++) {
+                    tei.append("\t");
+                }
+                tei.append("<idno type=\"wikidata\">" + TextUtilities.HTMLEncode(wikidataQid) + "</idno>\n");
+            }
+
             if (!StringUtils.isEmpty(pubnum)) {
                 for (int i = 0; i < indent + 2; i++) {
                     tei.append("\t");

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -96,6 +96,8 @@ public class BiblioItem {
                 ", PII='" + PII + '\'' +
                 ", ark='" + ark + '\'' +
                 ", istexId='" + istexId + '\'' +
+                ", fatcatIdent='" + fatcatIdent + '\'' +
+                ", wikidataQid='" + wikidataQid + '\'' +
                 ", inDOI='" + inDOI + '\'' +
                 ", abstract_='" + abstract_ + '\'' +
                 ", authors='" + authors + '\'' +
@@ -238,6 +240,8 @@ public class BiblioItem {
     private String PII = null;
     private String ark = null;
     private String istexId = null;
+    private String fatcatIdent = null;
+    private String wikidataQid = null;
     private String abstract_ = null;
     private String collaboration = null;
 
@@ -492,6 +496,14 @@ public class BiblioItem {
 
     public String getIstexId() {
         return istexId;
+    }
+
+    public String getFatcatIdent() {
+        return fatcatIdent;
+    }
+
+    public String getWikidataQid() {
+        return wikidataQid;
     }
 
     public String getInDOI() {
@@ -991,6 +1003,14 @@ public class BiblioItem {
 
     public void setArk(String id) {
         ark = id;
+    }
+
+    public void setFatcatIdent(String id) {
+        fatcatIdent = id;
+    }
+
+    public void setWikidataQid(String id) {
+        wikidataQid = id;
     }
 
     public void setArticleTitle(String ti) {
@@ -4038,6 +4058,9 @@ public class BiblioItem {
         bib.setPII(bibo.getPII());
         bib.setIstexId(bibo.getIstexId());
         bib.setArk(bibo.getArk());
+        bib.setArXivId(bibo.getArXivId());
+        bib.setFatcatIdent(bibo.getFatcatIdent());
+        bib.setWikidataQid(bibo.getWikidataQid());
     }
 
     /**
@@ -4058,6 +4081,12 @@ public class BiblioItem {
             bib.setIstexId(bibo.getIstexId());
         if (bibo.getArk() != null)
             bib.setArk(bibo.getArk());
+        if (bibo.getArXivId() != null)
+            bib.setArXivId(bibo.getArXivId());
+        if (bibo.getFatcatIdent() != null)
+            bib.setFatcatIdent(bibo.getFatcatIdent());
+        if (bibo.getWikidataQid() != null)
+            bib.setWikidataQid(bibo.getWikidataQid());
 
         if (bibo.getOAURL() != null)
             bib.setOAURL(bibo.getOAURL());

--- a/grobid-core/src/main/java/org/grobid/core/data/Person.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/Person.java
@@ -165,6 +165,8 @@ public class Person {
             res += middleName + " ";
         if (lastName != null)
             res += lastName + " ";
+        if ((firstName == null) && (middleName == null) && (lastName == null) && (rawName != null))
+            res += rawName + " ";
         if (suffix != null)
             res += suffix;
         if (email != null) {
@@ -184,7 +186,7 @@ public class Person {
 
     public String toTEI(boolean withCoordinates) {
         if ( (firstName == null) && (middleName == null) &&
-                (lastName == null) ) {
+                (lastName == null) && (rawName == null)) {
             return null;
         }
 
@@ -208,6 +210,10 @@ public class Person {
         }
         if (lastName != null) {
             persElement.appendChild(XmlBuilderUtils.teiElement("surname", TextUtilities.HTMLEncode(lastName)));
+        }
+        // only include the rawName, plopped right down as text, if no other names are set
+        if ((firstName == null) && (middleName == null) && (lastName == null) && (rawName != null)) {
+            persElement.appendChild(TextUtilities.HTMLEncode(rawName));
         }
         if (suffix != null) {
             persElement.appendChild(XmlBuilderUtils.teiElement("genName", TextUtilities.HTMLEncode(suffix)));
@@ -391,6 +397,12 @@ public class Person {
         if (middleName != null) {
             middleName = middleName.replace(".", ". ");
             middleName = middleName.replace("  ", " ");
+        }
+
+        // cleaning for fatcat rawName
+        if (rawName != null) {
+            rawName = rawName.replace(".", ". ");
+            rawName = rawName.replace("  ", " ");
         }
         
         // other weird stuff: <forename type="first">G. Arjen</forename><surname>de Groot</surname>

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -685,6 +685,14 @@ public class TEIFormatter {
             tei.append("\t\t\t\t\t<idno type=\"istexId\">" + TextUtilities.HTMLEncode(biblio.getIstexId()) + "</idno>\n");
         }
 
+        if (!StringUtils.isEmpty(biblio.getFatcatIdent())) {
+            tei.append("\t\t\t\t\t<idno type=\"fatcat_ident\">" + TextUtilities.HTMLEncode(biblio.getFatcatIdent()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getWikidataQid())) {
+            tei.append("\t\t\t\t\t<idno type=\"wikidata\">" + TextUtilities.HTMLEncode(biblio.getWikidataQid()) + "</idno>\n");
+        }
+
         if (!StringUtils.isEmpty(biblio.getOAURL())) {
             tei.append("\t\t\t\t\t<ptr type=\"open-access\" target=\"").append(TextUtilities.HTMLEncode(biblio.getOAURL())).append("\" />\n");
         }

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -686,7 +686,7 @@ public class TEIFormatter {
         }
 
         if (!StringUtils.isEmpty(biblio.getFatcatIdent())) {
-            tei.append("\t\t\t\t\t<idno type=\"fatcat_ident\">" + TextUtilities.HTMLEncode(biblio.getFatcatIdent()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"fatcat\">" + TextUtilities.HTMLEncode(biblio.getFatcatIdent()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getWikidataQid())) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -50,7 +50,6 @@ public class Consolidation {
     private static volatile Consolidation instance;
 
     private CrossrefClient client = null;
-    // XXX: rename just "deserializer"
     private CrossrefDeserializer workDeserializer = null;
     private CntManager cntManager = null;
 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -11,6 +11,7 @@ import org.grobid.core.exceptions.GrobidException;
 import org.grobid.core.sax.CrossrefUnixrefSaxParser;
 import org.grobid.core.utilities.crossref.*;
 import org.grobid.core.utilities.glutton.*;
+import org.grobid.core.utilities.fatcat.*;
 import org.grobid.core.utilities.counters.CntManager;
 
 import org.slf4j.Logger;
@@ -49,12 +50,14 @@ public class Consolidation {
     private static volatile Consolidation instance;
 
     private CrossrefClient client = null;
-    private WorkDeserializer workDeserializer = null;
+    // XXX: rename just "deserializer"
+    private CrossrefDeserializer workDeserializer = null;
     private CntManager cntManager = null;
 
     public enum GrobidConsolidationService {
         CROSSREF("crossref"),
-        GLUTTON("glutton");
+        GLUTTON("glutton"),
+        GLUTTON_FATCAT("glutton_fatcat");
 
         private final String ext;
 
@@ -101,11 +104,15 @@ public class Consolidation {
      * Hidden constructor
      */
     private Consolidation() {
-        if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON)
-            client = GluttonClient.getInstance();
-        else 
+        if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF)
             client = CrossrefClient.getInstance();
-        workDeserializer = new WorkDeserializer();   
+        else 
+            client = GluttonClient.getInstance();
+
+        if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON_FATCAT)
+            workDeserializer = new FatcatReleaseDeserializer();   
+        else 
+            workDeserializer = new WorkDeserializer();   
     }
 
     public void setCntManager(CntManager cntManager) {
@@ -241,7 +248,8 @@ public class Consolidation {
 
         if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) {
             arguments.put("rows", "1"); // we just request the top-one result
-        } else if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) {
+        } else if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON
+                   || GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON_FATCAT) {
             if (StringUtils.isNotBlank(doi))
                 arguments.put("postValidate", "false");
             // GROBID has already parsed the reference, so no need to redo this in glutton
@@ -289,6 +297,8 @@ public class Consolidation {
                                     StringUtils.isNotBlank(oneRes.getDOI()) &&
                                     doi.equals(oneRes.getDOI())
                                 )
+                                ||
+                                (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON_FATCAT)
                                 ||
                                 ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) && 
                                   (doiQuery) ) 
@@ -454,7 +464,8 @@ public class Consolidation {
 
             if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF)
                 arguments.put("rows", "1"); // we just request the top-one result
-            else if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) {
+            else if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON
+                     || GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON_FATCAT) {
                 // grobid is doing its own post-validation right now
                 //arguments.put("postValidate", "false");
                 // GROBID has already parsed the reference, so no need to redo this in glutton
@@ -483,7 +494,8 @@ public class Consolidation {
                             // we need here to post-check that the found item corresponds
                             // correctly to the one requested in order to avoid false positive
                             for(BiblioItem oneRes : res) {
-                                if ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) ||
+                                if ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON
+                                     || GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON_FATCAT) ||
                                     postValidation(theBiblio, oneRes)) {
                                     results.put(Integer.valueOf(getRank()), oneRes);
                                     if (cntManager != null) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/fatcat/FatcatReleaseDeserializer.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/fatcat/FatcatReleaseDeserializer.java
@@ -1,0 +1,192 @@
+package org.grobid.core.utilities.fatcat;
+
+import java.util.Iterator;
+
+import org.grobid.core.data.BiblioItem;
+import org.grobid.core.data.Person;
+import org.grobid.core.data.Date;
+import org.grobid.core.utilities.crossref.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+/**
+ * Convert a JSON fatcat release model - from a glutton response (or maybe
+ * direct fatcat API response?)- to a BiblioItem
+ *
+ * @author Bryan Newbold, Vincent Kaestle, Patrice
+ */
+public class FatcatReleaseDeserializer extends CrossrefDeserializer<BiblioItem> {
+
+	@Override
+	protected BiblioItem deserializeOneItem(JsonNode item) {
+		BiblioItem biblio = null;
+		String type = null; // the fatcat release_type of the item, which is mostly CSL type, see fatcat docs
+
+		if (item.isObject()) {
+			biblio = new BiblioItem();
+			//System.out.println(item.toString());			
+		
+            biblio.setFatcatIdent("release_" + item.get("ident").asText());
+
+			JsonNode extIdsNode = item.get("ext_ids");
+
+			JsonNode doiNode = extIdsNode.get("doi");
+            if (doiNode != null && (!doiNode.isMissingNode()) ) {
+                String doi = doiNode.asText();
+                biblio.setDOI(doi);
+            }
+
+			JsonNode pmidNode = extIdsNode.get("pmid");
+            if (pmidNode != null && (!pmidNode.isMissingNode()) ) {
+                String pmid = pmidNode.asText();
+                biblio.setPMID(pmid);
+            }
+
+            JsonNode pmcidNode = extIdsNode.get("pmcid");
+            if (pmcidNode != null && (!pmcidNode.isMissingNode()) ) {
+                String pmcid = pmcidNode.asText();
+                biblio.setPMCID(pmcid);
+            }
+
+            // NOTE: not currently part of fatcat schema
+            JsonNode piiNode = extIdsNode.get("pii");
+            if (piiNode != null && (!piiNode.isMissingNode()) ) {
+                String pii = piiNode.asText();
+                biblio.setPII(pii);
+            }
+
+            JsonNode arkNode = extIdsNode.get("ark");
+            if (arkNode != null && (!arkNode.isMissingNode()) ) {
+                String ark = arkNode.asText();
+                biblio.setArk(ark);
+            }
+
+            // NOTE: not currently part of fatcat schema
+            JsonNode istexNode = extIdsNode.get("istex");
+            if (istexNode != null && (!istexNode.isMissingNode()) ) {
+                String istexId = istexNode.asText();
+                biblio.setIstexId(istexId);
+            }
+
+            JsonNode arxivNode = extIdsNode.get("arxiv");
+            if (arxivNode != null && (!arxivNode.isMissingNode()) ) {
+                String arxivId = arxivNode.asText();
+                biblio.setArXivId(arxivId);
+            }
+
+            JsonNode wikidataQidNode = extIdsNode.get("wikidata_qid");
+            if (wikidataQidNode != null && (!wikidataQidNode.isMissingNode()) ) {
+                String wikidataQid = wikidataQidNode.asText();
+                biblio.setWikidataQid(wikidataQid);
+            }
+
+            // NOTE: not currently part of regular fatcat schema
+            // the open access url - if available, from the glorious UnpayWall dataset provided
+            // by biblio-glutton
+            JsonNode oaLinkNode = item.get("oaLink");
+            if (oaLinkNode != null && (!oaLinkNode.isMissingNode()) ) {
+                String oaLink = oaLinkNode.asText();
+                biblio.setOAURL(oaLink);
+            }
+
+			JsonNode typeNode = item.get("release_type");
+			if (typeNode != null && (!typeNode.isMissingNode()) ) {
+                // used below
+				type = typeNode.asText();
+			}
+			
+            JsonNode titleNode = item.get("title");
+            if (titleNode != null && (!titleNode.isMissingNode()) ) {
+                String title = titleNode.asText();
+                biblio.setTitle(title);
+            }
+			
+			JsonNode authorsNode = item.get("contribs");
+			if (authorsNode != null && (!authorsNode.isMissingNode()) && 
+				authorsNode.isArray() && (((ArrayNode)authorsNode).size() > 0)) {
+				Iterator<JsonNode> authorIt = ((ArrayNode)authorsNode).elements();
+				while (authorIt.hasNext()) {
+					JsonNode authorNode = authorIt.next();
+					
+					Person person = new Person();
+					if (authorNode.get("given_name") != null && !authorNode.get("given_name").isMissingNode()) {
+						person.setFirstName(authorNode.get("given_name").asText());
+						person.normalizeCrossRefFirstName();
+					}
+					if (authorNode.get("surname") != null && !authorNode.get("surname").isMissingNode()) {
+						person.setLastName(authorNode.get("family").asText());
+    	   			}
+					if (authorNode.get("raw_name") != null && !authorNode.get("raw_name").isMissingNode()) {
+						person.setRawName(authorNode.get("raw_name").asText());
+    	   			}
+    	   			// for cases like JM Smith and for case normalisation
+    	   			person.normalizeName();
+					biblio.addFullAuthor(person);
+				}
+			}
+
+			JsonNode publisherNode = item.get("publisher");
+			if (publisherNode != null && (!publisherNode.isMissingNode()))
+				biblio.setPublisher(publisherNode.asText());
+
+			JsonNode pageNode = item.get("pages");
+			if (pageNode != null && (!pageNode.isMissingNode()) )
+				biblio.setPageRange(pageNode.asText());
+
+			JsonNode volumeNode = item.get("volume");
+			if (volumeNode != null && (!volumeNode.isMissingNode()))
+				biblio.setVolumeBlock(volumeNode.asText(), false);
+
+			JsonNode issueNode = item.get("issue");
+			if (issueNode != null && (!issueNode.isMissingNode()))
+				biblio.setIssue(issueNode.asText());
+
+			JsonNode containerNode = item.get("container");
+			if (containerNode != null && (!containerNode.isMissingNode())) {
+                JsonNode containerTitleNode = containerNode.get("name");
+                if (containerTitleNode != null && (!containerTitleNode.isMissingNode())) {
+                    // container title depends on the type of object
+                    // if journal
+                    if ( (type != null) && (type.equals("article-journal")) )
+                        biblio.setJournal(containerTitleNode.asText());
+
+                    // if book chapter or proceedings article
+                    if ( (type != null) && (type.equals("paper-conference") || type.equals("chapter")) )
+                        biblio.setBookTitle(containerTitleNode.asText());
+                }
+
+                JsonNode containerAbbrevNode = containerNode.get("abbrev");
+                if (containerAbbrevNode != null && (!containerAbbrevNode.isMissingNode())) {
+                    // container title depends on the type of object
+                    // if journal
+                    if ( (type != null) && (type.equals("article-journal")) )
+                        biblio.setJournalAbbrev(containerAbbrevNode.asText());
+                } 
+                JsonNode containerIssnlNode = containerNode.get("issnl");
+                if (containerIssnlNode != null && (!containerIssnlNode.isMissingNode())) {
+                    // NOTE: just setting the ISSN-L as ISSN, instead of
+                    // electronic/print
+                    biblio.setISSN(containerIssnlNode.asText());
+                }
+			}
+
+			JsonNode yearNode = item.get("release_year");
+			JsonNode dateNode = item.get("release_date");
+            if (yearNode != null && (!yearNode.isMissingNode())) {
+
+                Date date = new Date();
+                date.setYear(yearNode.asInt());
+                
+                // TODO: parse dateNode (ISO datetime string), and populate rest of date from that
+                // date.setMonth(monthInt);
+                // date.setDay(dayInt);
+                biblio.setNormalizedPublicationDate(date);
+
+            }
+            //System.out.println(biblio.toTEI(0));
+		}
+		return biblio;
+	}
+}

--- a/grobid-core/src/main/java/org/grobid/core/visualization/CitationsVisualizer.java
+++ b/grobid-core/src/main/java/org/grobid/core/visualization/CitationsVisualizer.java
@@ -81,12 +81,16 @@ public class CitationsVisualizer {
             else {
                 // by default we put the existing url, doi or arXiv link
                 BiblioItem biblio = cit.getResBib();
-                if (!StringUtils.isEmpty(biblio.getDOI())) {
-                    theUrl = "https://dx.doi.org/" + biblio.getDOI();
-                } else if (!StringUtils.isEmpty(biblio.getArXivId())) {
+                // NOTE: this code block repeated in this file
+                if (!StringUtils.isEmpty(biblio.getArXivId())) {
                     theUrl = "https://arxiv.org/" + biblio.getArXivId();
                 } else if (!StringUtils.isEmpty(biblio.getWeb())) {
                     theUrl = biblio.getWeb();
+                } else if (!StringUtils.isEmpty(biblio.getFatcatIdent())) {
+                    // TODO: see comment at other instance of fatcat link insertion
+                    theUrl = "https://fatcat.wiki/" + biblio.getFatcatIdent();
+                } else if (!StringUtils.isEmpty(biblio.getDOI())) {
+                    theUrl = "https://dx.doi.org/" + biblio.getDOI();
                 }
             }
             if (cit.getResBib().getCoordinates() != null) {
@@ -319,14 +323,19 @@ public class CitationsVisualizer {
                 BiblioItem biblio = cit.getResBib();
                 String theUrl = null;
 
-                if (!StringUtils.isEmpty(biblio.getOAURL())) {
-                    theUrl = biblio.getOAURL();
-                } else if (!StringUtils.isEmpty(biblio.getDOI())) {
-                    theUrl = "https://dx.doi.org/" + biblio.getDOI();
-                } else if (!StringUtils.isEmpty(biblio.getArXivId())) {
+                // NOTE: this code block repeated in this file
+                if (!StringUtils.isEmpty(biblio.getArXivId())) {
                     theUrl = "https://arxiv.org/" + biblio.getArXivId();
                 } else if (!StringUtils.isEmpty(biblio.getWeb())) {
                     theUrl = biblio.getWeb();
+                } else if (!StringUtils.isEmpty(biblio.getFatcatIdent())) {
+                    // TODO: fatcat.wiki will redirect the "release_" prefix,
+                    // but would be better to do that here instead
+                    theUrl = "https://fatcat.wiki/" + biblio.getFatcatIdent();
+                } else if (!StringUtils.isEmpty(biblio.getOAURL())) {
+                    theUrl = biblio.getOAURL();
+                } else if (!StringUtils.isEmpty(biblio.getDOI())) {
+                    theUrl = "https://dx.doi.org/" + biblio.getDOI();
                 }
                 if (theUrl != null)
                     jsonRef.writeStringField("url", theUrl);


### PR DESCRIPTION
This PR probably needs a bit of work, but i'm posting here for an early review if I have taken the correct approach.

These patches add a new consolidation option: `glutton_fatcat`. This calls a patched version of biblio-glutton which returns metadata in the fatcat 'release' schema (instead of the Crossref API schema). The motivation is to support additional works which may not have Crossref DOIs (eg, some JALC or Datacite DOIs not in the Crossref API bulk corpus, or things like arxiv papers with no DOIs at all). The motivation to upstream these changes here is to avoid having to maintain a separate patchset, and to also include some small improvements.

In addition to the consolidation option, these patches include better support for the `rawName` attribute, some extra setters/getters for identifiers (and support for Wikidata QIDs), and a change in how URLs are output.

This entire code path can be publicly tested at: https://grobid.qa.fatcat.wiki

The `glutton_fatcat` biblio-glutton code can be browsed at https://github.com/bnewbold/biblio-glutton, on the branch 'fatcat'. See long comment thread in that repo: https://github.com/kermitt2/biblio-glutton/issues/33. My changes to `biblio-glutton` will probably be harder to merge upstream, but I'm happy to try. I don't think the API (between GROBID/biblio-glutton) would need to change significantly, so these GROBID-side patches should work fine.