### PR TITLE
Change local unit tests server ports 

### DIFF
--- a/grobid-service/src/test/resources/setup/config/test-config.yaml
+++ b/grobid-service/src/test/resources/setup/config/test-config.yaml
@@ -6,10 +6,10 @@ server:
     type: custom
     applicationConnectors:
     - type: http
-      port: 8075
+      port: 5075
     adminConnectors:
     - type: http
-      port: 8076
+      port: 5076
     registerDefaultExceptionMappers: false
 
 logging:


### PR DESCRIPTION
The port 8075 and 8076 are more likely to be used by other services, when deployed in the same server, causing the tests to fail. I propose to modify them. 