### PR TITLE
Remove side-effects when running several proceses of n-fold cross-validation of the same model while sharing the same grobid-home directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,8 @@ subprojects {
         testCompile "org.powermock:powermock-module-junit4:2.0.0-beta.5"
         testCompile "xmlunit:xmlunit:1.6"
         testCompile "org.hamcrest:hamcrest-all:1.3"
+
+        compile 'org.apache.commons:commons-text:1.8'
     }
 
     task sourceJar(type: Jar) {

--- a/grobid-trainer/src/main/java/org/grobid/trainer/AbstractTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/AbstractTrainer.java
@@ -1,8 +1,10 @@
 package org.grobid.trainer;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.text.RandomStringGenerator;
 import org.grobid.core.GrobidModel;
 import org.grobid.core.GrobidModels;
 import org.grobid.core.engines.tagging.GenericTagger;
@@ -51,6 +53,7 @@ public abstract class AbstractTrainer implements Trainer {
     private File trainDataPath;
     private File evalDataPath;
     private GenericTagger tagger;
+    private RandomStringGenerator randomStringGenerator;
 
     public AbstractTrainer(final GrobidModel model) {
         GrobidFactory.getInstance().createEngine();
@@ -61,6 +64,9 @@ public abstract class AbstractTrainer implements Trainer {
         }
         this.trainDataPath = getTempTrainingDataPath();
         this.evalDataPath = getTempEvaluationDataPath();
+        this.randomStringGenerator = new RandomStringGenerator.Builder()
+            .withinRange('a', 'z')
+            .build();
     }
 
     public void setParams(double epsilon, int window, int nbMaxIterations) {
@@ -174,6 +180,8 @@ public abstract class AbstractTrainer implements Trainer {
         createCRFPPData(getCorpusPath(), dataPath);
         GenericTrainer trainer = TrainerFactory.getTrainer();
 
+        String randomString = randomStringGenerator.generate(10);
+
         // Load in memory and Shuffle
         Path dataPath2 = Paths.get(dataPath.getAbsolutePath());
         List<String> trainingData = loadAndShuffle(dataPath2);
@@ -206,7 +214,7 @@ public abstract class AbstractTrainer implements Trainer {
             System.out.println("====================== Fold " + counter.get() + " ====================== ");
 
             final File tempModelPath = new File(tmpDirectory + File.separator + getModel().getModelName()
-                + "_nfold_" + counter.getAndIncrement() + ".wapiti");
+                + "_nfold_" + counter.getAndIncrement() + "_" + randomString + ".wapiti");
             sb.append("Saving model in " + tempModelPath).append("\n");
 
             sb.append("Training input data: " + fold.getLeft()).append("\n");

--- a/grobid-trainer/src/main/java/org/grobid/trainer/TableTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/TableTrainer.java
@@ -220,8 +220,8 @@ public class TableTrainer extends AbstractTrainer {
      */
     public static void main(String[] args) throws Exception {
         GrobidProperties.getInstance();
-        AbstractTrainer.runTraining(new TableTrainer());
-        System.out.println(AbstractTrainer.runEvaluation(new TableTrainer()));
+        System.out.println(AbstractTrainer.runNFoldEvaluation(new TableTrainer(), 2));
+//        System.out.println(AbstractTrainer.runEvaluation(new TableTrainer()));
         System.exit(0);
     }
 }


### PR DESCRIPTION
This PR allows to run the n-fold cross-validation of a specific model several times sharing the same grobid-home. 

Currently the models are named `model_name_nfold_x` with model_name corresponding the name of the model and x the n-ith fold. However if the same model is evaluated at the same time, they will write/overwrite the models in the `grobid-home/tmp` directory. 

This PR: 
 - add a unique random string on the ith-fold model name
 - collect generated files paths and deleted them at the end of the process 