### PR TITLE
65x performance and memory optimisation for process citation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -217,6 +217,7 @@ project("grobid-core") {
         compile "commons-io:commons-io:2.5"
         compile "org.apache.commons:commons-lang3:3.6"
         compile "org.apache.commons:commons-collections4:4.1"
+        compile "org.apache.commons:commons-text:1.8"
         compile "commons-dbutils:commons-dbutils:1.7"
         compile "org.apache.httpcomponents:httpclient:4.5.3"
         compile "xerces:xercesImpl:2.12.0"

--- a/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
@@ -1,5 +1,6 @@
 package org.grobid.core.engines;
 
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -33,6 +34,7 @@ import java.util.StringTokenizer;
  * @author Patrice Lopez
  */
 public class AuthorParser {
+    public static final Pattern REGEX_PATTERN  = Pattern.compile("et\\.? al\\.?.*$");
 	private static Logger LOGGER = LoggerFactory.getLogger(AuthorParser.class);
     private final GenericTagger namesHeaderParser;
     private final GenericTagger namesCitationParser;
@@ -50,7 +52,7 @@ public class AuthorParser {
             return null;
         }
 
-        input = input.trim().replaceAll("et\\.? al\\.?.*$", " ");
+        input = REGEX_PATTERN.matcher(input.trim()).replaceAll(" ");
 
         // for language to English for the analyser to avoid any bad surprises
         List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input, new Language("en", 1.0));
@@ -72,7 +74,7 @@ public class AuthorParser {
             return null;
         }
 
-        input = input.trim().replaceAll("et\\.? al\\.?.*$", " ");
+        input = REGEX_PATTERN.matcher(input.trim()).replaceAll(" ");
 
         // for language to English for the analyser to avoid any bad surprises
         List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input, new Language("en", 1.0));

--- a/grobid-core/src/main/java/org/grobid/core/engines/DateParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/DateParser.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
  * @author Patrice Lopez
  */
 public class DateParser extends AbstractParser {
+    public static final Pattern NEWLINE_REGEX_PATTERN = Pattern.compile("[ \n]");
 
     public DateParser() {
         super(GrobidModels.DATE);
@@ -40,7 +41,7 @@ public class DateParser extends AbstractParser {
 			for(String tok : tokenizations) {
                 if (!tok.equals(" ") && !tok.equals("\n")) {
                     // parano final sanitisation
-                    tok = tok.replaceAll("[ \n]", "");
+                    tok = NEWLINE_REGEX_PATTERN.matcher(tok).replaceAll( "");
                     dateBlocks.add(tok + " <date>");
                 }
             }

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -108,6 +108,11 @@ public class Lexicon {
         initCountryCodes();
         addCountryCodes(GrobidProperties.getGrobidHomePath() + File.separator +
             "lexicon"+File.separator+"countries"+File.separator+"CountryCodes.xml");
+        initJournals();
+        initConferences();
+        initPublishers();
+        initLocations();
+        initCollaborations();
     }
 
     private void initDictionary() {


### PR DESCRIPTION
This PR intends to merge changes related to performance and memory optimisations
The details are posted below

1. pre-compile regex
   --> reduces mem usage
   --> improves performance as regex is precompiled
2. pre-init lexicon dependencies
   --> lazy initialization broke singleton in concurrent environment
   --> decreased memory footprint

We did GROBID performance profiling
Tools used:
Benchmarking tool: visualVM
Testing framework: locustio

Observations before optimisations:
![memory_before_optimisation](https://user-images.githubusercontent.com/65662582/88048831-a8aeea80-cb71-11ea-8ceb-7bdadde40cce.png)
Heap dump before optimisation. 
  
![threads_before_optimisation](https://user-images.githubusercontent.com/65662582/88048880-bcf2e780-cb71-11ea-9267-80653bbd68ea.png)
Thread dump before optimisation. 
  
We discovered following major issues around the code base in focus:
1. Regex Patterns were not precompiled
2. Lazy initialization of Singletons (can cause weak singleton)
3. String manipulations without StringBuilders

Observations after optimisations:
![memory_after_optimisation](https://user-images.githubusercontent.com/65662582/88048974-e3b11e00-cb71-11ea-9438-54359d2e634a.png)
Heap dump after optimisation. 
  

![threads_after_optimisation](https://user-images.githubusercontent.com/65662582/88049038-02171980-cb72-11ea-9480-891d4d6a96d0.png)
Thread dump after optimisations. 
  



  | Before optimization | After optimization
-- | -- | --
GROBID performance | <ul><li>Total users: 100.</li><li>Total runtime: 600s (10 min)</li><li> Total requests: 123<li>Failures: 121</li><li> Throughput: 0.21 requests/sec</li><li> Memory consumption 4 GB </li></ul> | <ul><li> Total users: 100</li><li> Total runtime: 600s (10 min)</li><li> Total requests: 7915</li><li> Failures: 0</li><li> Throughput: 13.17 requests/sec</li><li> Memory consumption 750 MB</li></ul>



Co-authored-by: rvkhakhkhar <rvkhakhkhar@gmail.com>
Co-authored-by: imprashant <imprashantm@gmail.com>