### PR TITLE
Allow overriding org.* properties with env vars

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/EnvironmentVariableProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/EnvironmentVariableProperties.java
@@ -4,16 +4,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class EnvironmentVariableProperties {
-
     private final Map<String, String> properties = new HashMap<>();
 
-    public EnvironmentVariableProperties(String prefix) {
-        this(System.getenv(), prefix);
+    public EnvironmentVariableProperties(String matcher) {
+        this(System.getenv(), matcher);
     }
 
-    public EnvironmentVariableProperties(Map<String, String> environmentVariablesMap, String prefix) {
+    public EnvironmentVariableProperties(Map<String, String> environmentVariablesMap, String matcher) {
         for (Map.Entry<String, String> entry: environmentVariablesMap.entrySet()) {
-            if (!entry.getKey().startsWith(prefix)) {
+            if (!entry.getKey().matches(matcher)) {
                 continue;
             }
             String propertiesKey = getPropertiesKeyForEnvironmentVariableName(entry.getKey());

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -341,7 +341,7 @@ public class GrobidProperties {
 
     protected static Map<String, String> getEnvironmentVariableOverrides(Map<String, String> environmentVariablesMap) {
         Map<String, String> properties = new EnvironmentVariableProperties(
-            environmentVariablesMap, "GROBID__"
+            environmentVariablesMap, "(GROBID__|ORG__GROBID__).+"
         ).getProperties();
         LOGGER.info("environment variables overrides: {}", properties);
         return properties;

--- a/grobid-core/src/test/java/org/grobid/core/utilities/EnvironmentVariablePropertiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/EnvironmentVariablePropertiesTest.java
@@ -18,7 +18,7 @@ public class EnvironmentVariablePropertiesTest {
             Collections.emptyMap(),
             new EnvironmentVariableProperties(
                 environmentVariables,
-                "APP__"
+                "APP__.+"
             ).getProperties()
         );
     }
@@ -30,7 +30,7 @@ public class EnvironmentVariablePropertiesTest {
             Collections.emptyMap(),
             new EnvironmentVariableProperties(
                 environmentVariables,
-                "APP__"
+                "APP__.+"
             ).getProperties()
         );
     }
@@ -42,7 +42,7 @@ public class EnvironmentVariablePropertiesTest {
             Collections.singletonMap("app.abc", "value1"),
             new EnvironmentVariableProperties(
                 environmentVariables,
-                "APP__"
+                "APP__.+"
             ).getProperties()
         );
     }
@@ -54,7 +54,7 @@ public class EnvironmentVariablePropertiesTest {
             Collections.singletonMap("app.abc.xyz", "value1"),
             new EnvironmentVariableProperties(
                 environmentVariables,
-                "APP__"
+                "APP__.+"
             ).getProperties()
         );
     }
@@ -66,7 +66,7 @@ public class EnvironmentVariablePropertiesTest {
             Collections.singletonMap("app.abc_xyz", "value1"),
             new EnvironmentVariableProperties(
                 environmentVariables,
-                "APP__"
+                "APP__.+"
             ).getProperties()
         );
     }


### PR DESCRIPTION
Fixes: https://github.com/kermitt2/grobid/issues/608

This changes `EnvironmentVariableProperties` to allow passing in a regex instead of a prefix, allowing `GrobidProperties` to match both `ORG__GROBID__*` and `GROBID__` environment variables