### PR TITLE
Improve callout to reference match

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/matching/ReferenceMarkerMatcher.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/matching/ReferenceMarkerMatcher.java
@@ -386,7 +386,8 @@ public class ReferenceMarkerMatcher {
     private List<BibDataSet> postFilterMatches(String c, List<BibDataSet> matches) {
         if (c.toLowerCase().contains("et al") || c.toLowerCase().contains(" and ")) {
             String[] sp = c.trim().split(" ");
-            final String author = sp[0].toLowerCase();
+            //callouts often include parentheses as seen in https://grobid.readthedocs.io/en/latest/training/fulltext/
+            final String author = sp[0].replaceAll("[\\(\\[]", "").toLowerCase();
 
             ArrayList<BibDataSet> bibDataSets = Lists.newArrayList(Iterables.filter(matches, new Predicate<BibDataSet>() {
                 @Override


### PR DESCRIPTION
Improve callout to reference match by removing parentheses often seen in callouts.

As seen in the docs, callouts often include parentheses.
https://grobid.readthedocs.io/en/latest/training/fulltext/

I saw many occasions that these parentheses prevent matching the correct references.
See the red boxes when trying arxiv.org/pdf/1801.01290.pdf

<img width="1399" alt="Screen Shot 2020-08-02 at 12 56 29" src="https://user-images.githubusercontent.com/3437/89121225-c2cbbf80-d4c5-11ea-9808-48a4bf7a700e.png">
