### PR TITLE
NPE when Grobid is initialised from a module or test and the property file is not loaded yet (e.g. static context initialisation of GrobidModels)

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -240,18 +240,21 @@ public class GrobidProperties {
     }
 
     /**
-     * Return the value corresponding to the property key. If this value is
-     * null, return the default value.
+     * Return the value corresponding to the property key. If the properties are not initialised, it returns null
      *
      * @param pkey the property key
      * @return the value of the property.
      */
     protected static String getPropertyValue(final String pkey) {
-        return getProps().getProperty(pkey);
+        Properties props = getProps();
+        if (props != null) {
+            return props.getProperty(pkey);
+        }
+        return null;
     }
 
     /**
-     * Return the value corresponding to the property key. If this value is
+     * Return the value corresponding to the property key. If this value or the properties has not been loaded, is
      * null, return the default value.
      *
      * @param pkey        the property key
@@ -259,7 +262,11 @@ public class GrobidProperties {
      * @return the value of the property, pDefaultVal else.
      */
     protected static String getPropertyValue(final String pkey, final String pDefaultVal) {
-        String prop = getProps().getProperty(pkey);
+        Properties props = getProps();
+        if (props == null) {
+            return pDefaultVal;
+        }
+        String prop = props.getProperty(pkey);
         return StringUtils.isNotBlank(prop) ? prop.trim() : pDefaultVal;
     }
 


### PR DESCRIPTION
When we invoke the static context of GrobidModels, all the models declared over there are loaded. Before applying #559 this was working without issues. 559 introduce a lookup on the properties that, at the time of the test is running are not loaded, therefore NPE. 

The first commit fixes right away the issue. However, I'm wondering whether we should have a completely different class for the DUMMY model, because if the test is ran from a directory that has no access to the grobid-home, I fear it will fail anyway. 