### PR TITLE
update call to crossref when title is supplied

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -36,6 +36,8 @@ import java.util.HashMap;
 import com.rockymadden.stringmetric.similarity.RatcliffObershelpMetric;
 import scala.Option;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 /**
  * Singleton class for managing the extraction of bibliographical information from pdf documents.
  * When consolidation operations are realized, be sure to call the close() method
@@ -200,7 +202,7 @@ public class Consolidation {
                 arguments = new HashMap<String,String>();
             if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
                 (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
-                arguments.put("query.title", title);
+                arguments.put("query.bibliographic", title);
         }
         if (StringUtils.isNotBlank(journalTitle)) {
             // call based on partial metadata
@@ -262,11 +264,11 @@ public class Consolidation {
                 doiQuery = false;
             }
 
-            client.<BiblioItem>pushRequest("works", arguments, workDeserializer, threadId, new CrossrefRequestListener<BiblioItem>(0) {
+            client.pushRequest("works", arguments, workDeserializer, threadId, new CrossrefRequestListener<BiblioItem>(0) {
                 
                 @Override
                 public void onSuccess(List<BiblioItem> res) {
-                    if ((res != null) && (res.size() > 0) ) {
+                    if (isNotEmpty(res)) {
                         // we need here to post-check that the found item corresponds
                         // correctly to the one requested in order to avoid false positive
                         for(BiblioItem oneRes : res) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefClient.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefClient.java
@@ -120,11 +120,11 @@ public class CrossrefClient implements Closeable {
 			request.addListener(listener);
 		synchronized(this) {
 			Future<?> f = executorService.submit(new CrossrefRequestTask<T>(this, request));
-			List<Future<?>> localFutures = this.futures.get(new Long(threadId));
+			List<Future<?>> localFutures = this.futures.get(threadId);
 			if (localFutures == null)
-				localFutures = new ArrayList<Future<?>>();
+				localFutures = new ArrayList<>();
 			localFutures.add(f);
-			this.futures.put(new Long(threadId), localFutures);
+			this.futures.put(threadId, localFutures);
 //System.out.println("add request to thread " + threadId + " / current total for the thread: " +  localFutures.size());			
 		}
 	}
@@ -152,7 +152,7 @@ public class CrossrefClient implements Closeable {
 	public void finish(long threadId) {
 		synchronized(this.futures) {
 			try {
-				List<Future<?>> threadFutures = this.futures.get(new Long(threadId));
+				List<Future<?>> threadFutures = this.futures.get(threadId);
 				if (threadFutures != null) {
 //System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< thread: " + threadId + " / waiting for " + threadFutures.size() + " requests to finish...");
 					for(Future<?> future : threadFutures) {


### PR DESCRIPTION
I've noticed that when the title is supplied, grobid uses a deprecated field `query.title` (https://github.com/CrossRef/rest-api-doc#works-field-queries) instead of `query.bibliographic`. 

This results in a 400 Bad request from crossref, and the consolidation is not applied. 