### PR TITLE
enable docker build for the travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,17 @@ env:
 #after_failure:
 #- ./gradlew clean check --debug --info --stacktrace
 
-script:
-  - ./gradlew build --stacktrace --info --no-daemon
+jobs:
+  include:
+    - stage: "Build"
+      script:
+        - ./gradlew build --stacktrace --info --no-daemon
+      after_success:
+      - ./gradlew codeCoverageReport coveralls --no-daemon
+    - stage: "Docker Build"
+      script:
+        - docker build .
 
-after_success:
-- ./gradlew codeCoverageReport coveralls --no-daemon
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
related to #628

This is to check that the docker build still succeeds.
It is meant to run in parallel but didn't seem to have been.

An alternative is to run everything in Docker and just have one build. Apparently that is the more the way to go for GitHub Actions.

(I am not a Travis CI wiz, please take it apart)