### PR TITLE
Add "sentence-segmentation/**" to Gradle package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -302,6 +302,7 @@ project("grobid-home") {
         from('.') {
             include("config/*")
             include("language-detection/**")
+            include("sentence-segmentation/**")
             include("lib/**")
             include("pdf2xml/**")
             include("models/**")


### PR DESCRIPTION
This adds the `sentence-segmentation` folder to the Gradle package definition. Without this, sentence segmentation does not work inside the Docker container (as the Ruby source is not found).