### PR TITLE
Fixing problem in PR 559

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/main/LibraryLoader.java
+++ b/grobid-core/src/main/java/org/grobid/core/main/LibraryLoader.java
@@ -1,5 +1,6 @@
 package org.grobid.core.main;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.grobid.core.engines.tagging.GrobidCRFEngine;
@@ -11,12 +12,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 
@@ -95,8 +96,8 @@ public class LibraryLoader {
 
             }
 
-            if (GrobidProperties.getGrobidCRFEngine() == GrobidCRFEngine.WAPITI ||
-                GrobidProperties.getGrobidCRFEngine() == GrobidCRFEngine.DELFT) {
+            if (CollectionUtils
+                .containsAny(GrobidProperties.getDistinctModels(), Arrays.asList(GrobidCRFEngine.WAPITI, GrobidCRFEngine.DELFT))) {
                 // note: if DeLFT is used, we still make Wapiti available for models not existing in DeLFT (currently segmentation and 
                 // fulltext)
                 File[] wapitiLibFiles = libraryFolder.listFiles(new FilenameFilter() {
@@ -110,7 +111,7 @@ public class LibraryLoader {
                     LOGGER.info("No wapiti library in the Grobid home folder");
                 } else {
                     LOGGER.info("Loading Wapiti native library...");
-                    if (GrobidProperties.getGrobidCRFEngine() == GrobidCRFEngine.DELFT) {
+                    if (CollectionUtils.containsAny(GrobidProperties.getDistinctModels(), Collections.singletonList(GrobidCRFEngine.DELFT))) {
                         // if DeLFT will be used, we must not load libstdc++, it would create a conflict with tensorflow libstdc++ version
                         // so we temporary rename the lib so that it is not loaded in this case
                         // note that we know that, in this case, the local lib can be ignored because as DeFLT and tensorflow are installed
@@ -126,7 +127,7 @@ public class LibraryLoader {
                     try {
                         System.load(wapitiLibFiles[0].getAbsolutePath());
                     } finally {
-                        if (GrobidProperties.getGrobidCRFEngine() == GrobidCRFEngine.DELFT) {
+                        if (CollectionUtils.containsAny(GrobidProperties.getDistinctModels(), Arrays.asList(GrobidCRFEngine.DELFT))) {
                             // restore libstdc++
                             String libstdcppPathNew = libraryFolder.getAbsolutePath() + File.separator + "libstdc++.so.6.new";
                             File libstdcppFileNew = new File(libstdcppPathNew);
@@ -140,7 +141,7 @@ public class LibraryLoader {
             }
 
 
-            if (GrobidProperties.getGrobidCRFEngine() == GrobidCRFEngine.DELFT) {
+            if (CollectionUtils.containsAny(GrobidProperties.getDistinctModels(), Collections.singletonList(GrobidCRFEngine.DELFT))) {
                 LOGGER.info("Loading JEP native library for DeLFT... " + libraryFolder.getAbsolutePath());
                 // actual loading will be made at JEP initialization, so we just need to add the path in the 
                 // java.library.path (JEP will anyway try to load from java.library.path, so explicit file 

--- a/grobid-core/src/main/java/org/grobid/core/main/LibraryLoader.java
+++ b/grobid-core/src/main/java/org/grobid/core/main/LibraryLoader.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Set;
 
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 
@@ -96,8 +97,9 @@ public class LibraryLoader {
 
             }
 
+            Set<GrobidCRFEngine> distinctModels = GrobidProperties.getDistinctModels();
             if (CollectionUtils
-                .containsAny(GrobidProperties.getDistinctModels(), Arrays.asList(GrobidCRFEngine.WAPITI, GrobidCRFEngine.DELFT))) {
+                .containsAny(distinctModels, Arrays.asList(GrobidCRFEngine.WAPITI, GrobidCRFEngine.DELFT))) {
                 // note: if DeLFT is used, we still make Wapiti available for models not existing in DeLFT (currently segmentation and 
                 // fulltext)
                 File[] wapitiLibFiles = libraryFolder.listFiles(new FilenameFilter() {
@@ -111,7 +113,7 @@ public class LibraryLoader {
                     LOGGER.info("No wapiti library in the Grobid home folder");
                 } else {
                     LOGGER.info("Loading Wapiti native library...");
-                    if (CollectionUtils.containsAny(GrobidProperties.getDistinctModels(), Collections.singletonList(GrobidCRFEngine.DELFT))) {
+                    if (CollectionUtils.containsAny(distinctModels, Collections.singletonList(GrobidCRFEngine.DELFT))) {
                         // if DeLFT will be used, we must not load libstdc++, it would create a conflict with tensorflow libstdc++ version
                         // so we temporary rename the lib so that it is not loaded in this case
                         // note that we know that, in this case, the local lib can be ignored because as DeFLT and tensorflow are installed
@@ -127,7 +129,7 @@ public class LibraryLoader {
                     try {
                         System.load(wapitiLibFiles[0].getAbsolutePath());
                     } finally {
-                        if (CollectionUtils.containsAny(GrobidProperties.getDistinctModels(), Arrays.asList(GrobidCRFEngine.DELFT))) {
+                        if (CollectionUtils.containsAny(distinctModels, Arrays.asList(GrobidCRFEngine.DELFT))) {
                             // restore libstdc++
                             String libstdcppPathNew = libraryFolder.getAbsolutePath() + File.separator + "libstdc++.so.6.new";
                             File libstdcppFileNew = new File(libstdcppPathNew);
@@ -141,7 +143,7 @@ public class LibraryLoader {
             }
 
 
-            if (CollectionUtils.containsAny(GrobidProperties.getDistinctModels(), Collections.singletonList(GrobidCRFEngine.DELFT))) {
+            if (CollectionUtils.containsAny(distinctModels, Collections.singletonList(GrobidCRFEngine.DELFT))) {
                 LOGGER.info("Loading JEP native library for DeLFT... " + libraryFolder.getAbsolutePath());
                 // actual loading will be made at JEP initialization, so we just need to add the path in the 
                 // java.library.path (JEP will anyway try to load from java.library.path, so explicit file 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -7,12 +7,15 @@ import org.grobid.core.GrobidModel;
 import org.grobid.core.engines.tagging.GrobidCRFEngine;
 import org.grobid.core.exceptions.GrobidPropertyException;
 import org.grobid.core.exceptions.GrobidResourceException;
-import org.grobid.core.utilities.Consolidation.GrobidConsolidationService;
 import org.grobid.core.main.GrobidHomeFinder;
+import org.grobid.core.utilities.Consolidation.GrobidConsolidationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -313,19 +316,19 @@ public class GrobidProperties {
 
     /** Return the distinct values of all the engines that are needed */
     public static Set<GrobidCRFEngine> getDistinctModels() {
-        List<GrobidCRFEngine> modelSpecificEngines = getModelSpecificEngines();
+        final Set<GrobidCRFEngine> modelSpecificEngines = new HashSet<>(getModelSpecificEngines());
         modelSpecificEngines.add(getGrobidCRFEngine());
 
-        return new HashSet(modelSpecificEngines);
+        return modelSpecificEngines;
     }
 
     /** Return the distinct values of all the engines specified in the individual model configuration in the property file **/
-    public static List<GrobidCRFEngine> getModelSpecificEngines() {
+    public static Set<GrobidCRFEngine> getModelSpecificEngines() {
         return getProps().keySet().stream()
             .filter(k -> ((String) k).startsWith(GrobidPropertyKeys.PROP_GROBID_CRF_ENGINE + '.'))
             .map(k -> GrobidCRFEngine.get(StringUtils.lowerCase(getPropertyValue((String) k))))
             .distinct()
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     }
 
     protected static void loadCrfEngine() {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -312,18 +312,18 @@ public class GrobidProperties {
     }
 
     /** Return the distinct values of all the engines that are needed */
-    public static Set<String> getDistinctModels() {
-        List<String> modelSpecificEngines = getModelSpecificEngines();
-        modelSpecificEngines.add(getGrobidCRFEngine().getExt());
+    public static Set<GrobidCRFEngine> getDistinctModels() {
+        List<GrobidCRFEngine> modelSpecificEngines = getModelSpecificEngines();
+        modelSpecificEngines.add(getGrobidCRFEngine());
 
         return new HashSet(modelSpecificEngines);
     }
 
     /** Return the distinct values of all the engines specified in the individual model configuration in the property file **/
-    public static List<String> getModelSpecificEngines() {
+    public static List<GrobidCRFEngine> getModelSpecificEngines() {
         return getProps().keySet().stream()
             .filter(k -> ((String) k).startsWith(GrobidPropertyKeys.PROP_GROBID_CRF_ENGINE + '.'))
-            .map(k -> StringUtils.lowerCase(getPropertyValue((String) k)))
+            .map(k -> GrobidCRFEngine.get(StringUtils.lowerCase(getPropertyValue((String) k))))
             .distinct()
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
I've added two new methods in the GrobidProperties that allow to: 
 - get all the engines selected individually in the configuration 
 - get all possible engines needed (result of the above point  and the engine selected in the `grobid.crf.engine` property. 

When running LibraryLoader.load() instead of checking only the value of `grobid.crf.engine` I consider the list of specified engines. 