### PR TITLE
replaced space by tab in DeLFTModel.label

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -173,6 +173,9 @@ public class DeLFTModel {
         } catch(ExecutionException e) {
             LOGGER.error("DeLFT model " + this.modelName + " labelling failed", e);
         }
+        // In some areas, GROBID currently expects tabs as feature separators.
+        // (Same as in WapitiModel.label)
+        result = result.replaceAll(" ", "\t");
         return result;
     }
 


### PR DESCRIPTION
See [Mattermost conversation](https://traces1.inria.fr/mattermost/inria-rookies/pl/qhgkwxc9xjd33pip3whe1p6ksh)

When using a DL `fulltext` model, no `figure` and `table` data was generated.

That is because a tab is expected for the [figure data generation](https://github.com/kermitt2/grobid/blob/35c46b0f0db78dc775e5b76c025c9c9d53cf7af2/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java#L1958) and  [table data generation](https://github.com/kermitt2/grobid/blob/35c46b0f0db78dc775e5b76c025c9c9d53cf7af2/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java#L2119).

I haven't test it yet, but might be related to https://github.com/kermitt2/grobid/issues/470 (EDIT: no, doesn't seem to be resolved by this PR)

Since the `WapitiModel.label` function is already replacing spaces with tabs, doing the same in `DeLFTModel.label` seems to make sense.