### PR TITLE
use Crossref-Plus-API-Token instead of Authorization

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefRequest.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefRequest.java
@@ -143,7 +143,7 @@ public class CrossrefRequest<T extends Object> extends Observable {
             
 			// set the authorization token for the Metadata Plus service if available
 			if (GrobidProperties.getCrossrefToken() != null) {
-            	httpget.setHeader("Authorization", 
+            	httpget.setHeader("Crossref-Plus-API-Token", 
             		"Bearer " + GrobidProperties.getCrossrefToken());
 			}
 


### PR DESCRIPTION
CrossRef web API now request the metadata plus token to be put in Crossref-Plus-API-Token header:

https://github.com/CrossRef/rest-api-doc#authorization-token-for-plus-service
