### PR TITLE
[WIP] Exploit batch processing for Deep Learning models

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
@@ -286,57 +286,58 @@ public class CitationParser extends AbstractParser {
             }
 
             List<BiblioItem> bibList = processingStringMultiple(refTexts, 0);
+            if (bibList != null && bibList.size()>0) {
+                int i = 0;
+                for (LabeledReferenceResult ref : references) {
+                    // paranoiac check
+                    if (ref == null) 
+                        continue;
 
-            int i = 0;
-            for (LabeledReferenceResult ref : references) {
-                // paranoiac check
-                if (ref == null) 
-                    continue;
+                    //BiblioItem bib = processingString(ref.getReferenceText(), 0);
+                    BiblioItem bib = bibList.get(i);
+                    i++;
+                    if (bib == null) 
+                        continue;
 
-                //BiblioItem bib = processingString(ref.getReferenceText(), 0);
-                BiblioItem bib = bibList.get(i);
-                i++;
-                if (bib == null) 
-                    continue;
-
-                // check if we have an interesting url annotation over this bib. ref.
-                List<LayoutToken> refTokens = ref.getTokens();
-                if ((refTokens != null) && (refTokens.size() > 0)) {
-                    List<Integer> localPages = new ArrayList<Integer>();
-                    for(LayoutToken token : refTokens) {
-                        if (!localPages.contains(token.getPage())) {
-                            localPages.add(token.getPage());
-                        }
-                    }
-                    for(PDFAnnotation annotation : doc.getPDFAnnotations()) {
-                        if (annotation.getType() != Type.URI) 
-                            continue;
-                        if (!localPages.contains(annotation.getPageNumber()))
-                            continue;
+                    // check if we have an interesting url annotation over this bib. ref.
+                    List<LayoutToken> refTokens = ref.getTokens();
+                    if ((refTokens != null) && (refTokens.size() > 0)) {
+                        List<Integer> localPages = new ArrayList<Integer>();
                         for(LayoutToken token : refTokens) {
-                            if (annotation.cover(token)) {
-                                // annotation covers tokens, let's look at the href
-                                String uri = annotation.getDestination();
-                                // is it a DOI?
-                                Matcher doiMatcher = TextUtilities.DOIPattern.matcher(uri);
-                                if (doiMatcher.find()) { 
-                                    // the BiblioItem setter will take care of the prefix and doi cleaninng 
-                                    bib.setDOI(uri);
+                            if (!localPages.contains(token.getPage())) {
+                                localPages.add(token.getPage());
+                            }
+                        }
+                        for(PDFAnnotation annotation : doc.getPDFAnnotations()) {
+                            if (annotation.getType() != Type.URI) 
+                                continue;
+                            if (!localPages.contains(annotation.getPageNumber()))
+                                continue;
+                            for(LayoutToken token : refTokens) {
+                                if (annotation.cover(token)) {
+                                    // annotation covers tokens, let's look at the href
+                                    String uri = annotation.getDestination();
+                                    // is it a DOI?
+                                    Matcher doiMatcher = TextUtilities.DOIPattern.matcher(uri);
+                                    if (doiMatcher.find()) { 
+                                        // the BiblioItem setter will take care of the prefix and doi cleaninng 
+                                        bib.setDOI(uri);
+                                    }
+                                    // TBD: is it something else? 
                                 }
-                                // TBD: is it something else? 
                             }
                         }
                     }
-                }
 
-                if (!bib.rejectAsReference()) {
-                    BibDataSet bds = new BibDataSet();
-                    bds.setRefSymbol(ref.getLabel());
-                    bds.setResBib(bib);
-                    bib.setReference(ref.getReferenceText());
-                    bds.setRawBib(ref.getReferenceText());
-                    bds.getResBib().setCoordinates(ref.getCoordinates());
-                    results.add(bds);
+                    if (!bib.rejectAsReference()) {
+                        BibDataSet bds = new BibDataSet();
+                        bds.setRefSymbol(ref.getLabel());
+                        bds.setResBib(bib);
+                        bib.setReference(ref.getReferenceText());
+                        bds.setRawBib(ref.getReferenceText());
+                        bds.getResBib().setCoordinates(ref.getCoordinates());
+                        results.add(bds);
+                    }
                 }
             }
         }

--- a/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
@@ -62,34 +62,62 @@ public class CitationParser extends AbstractParser {
         this.parsers = parsers;
     }
 
-    public BiblioItem processing(String input, int consolidate) {
-        if (StringUtils.isBlank(input)) {
+    public BiblioItem processingString(String input, int consolidate) {
+        List<String> inputs = new ArrayList<>();
+        inputs.add(input);
+        List<BiblioItem> result = processingStringMultiple(inputs, consolidate);
+        if (result != null && result.size()>0) 
+            return result.get(0);
+        else
             return null;
-        }
-
-        // some cleaning
-        input = UnicodeUtil.normaliseText(input);
-        //input = TextUtilities.dehyphenize(input);
-        //input = input.replace("\n", " ");
-        //input = input.replaceAll("\\p{Cntrl}", " ").trim();
-
-        List<LayoutToken> tokens = analyzer.tokenizeWithLayoutToken(input);
-        BiblioItem biblioItem = processing(tokens, consolidate);
-        // store original references to enable raw output
-        biblioItem.setReference(input);
-        return biblioItem;
     }
 
-    public BiblioItem processing(List<LayoutToken> tokens, int consolidate) {
-        BiblioItem resCitation;
-        if (CollectionUtils.isEmpty(tokens)) {
+    public List<BiblioItem> processingStringMultiple(List<String> inputs, int consolidate) {
+        if (inputs == null || inputs.size() == 0)
             return null;
+        List<List<LayoutToken>> tokenList = new ArrayList<>();
+        for(String input : inputs) {
+            if (StringUtils.isBlank(input)) 
+                tokenList.add(new ArrayList<LayoutToken>());
+            else {
+                // some cleaning
+                input = UnicodeUtil.normaliseText(input);
+                List<LayoutToken> tokens = analyzer.tokenizeWithLayoutToken(input);
+                tokenList.add(tokens);
+            }
         }
 
-        try {
-            List<String> citationBlocks = new ArrayList<>();
+        List<BiblioItem> results = processingLayoutTokenMultiple(tokenList, consolidate);
+        if (results != null && results.size() == inputs.size()) {
+            // store original references to enable optional raw output
+            int i = 0;
+            for (BiblioItem result : results) {
+                if (result != null)
+                    result.setReference(inputs.get(i));
+                i++;
+            }
+        }
+        return results;
+    }
 
-            //tokens = LayoutTokensUtil.dehyphenize(tokens);
+    public BiblioItem processingLayoutToken(List<LayoutToken> tokens, int consolidate) {
+        List<List<LayoutToken>> tokenList = new ArrayList<>();
+        tokenList.add(tokens);
+        List<BiblioItem> result = processingLayoutTokenMultiple(tokenList, consolidate);
+        if (result != null && result.size()>0) 
+            return result.get(0);
+        else
+            return null;
+    }
+
+    public List<BiblioItem> processingLayoutTokenMultiple(List<List<LayoutToken>> tokenList, int consolidate) {
+        if (tokenList == null || tokenList.size() == 0)
+            return null;
+        List<BiblioItem> results = new ArrayList<>();
+        StringBuilder featuredInput = new StringBuilder();
+        for (List<LayoutToken> tokens : tokenList) {
+            if (CollectionUtils.isEmpty(tokens))
+                continue;
 
             List<OffsetPosition> journalsPositions = lexicon.tokenPositionsJournalNames(tokens);
             List<OffsetPosition> abbrevJournalsPositions = lexicon.tokenPositionsAbbrevJournalNames(tokens);
@@ -100,74 +128,117 @@ public class CitationParser extends AbstractParser {
             List<OffsetPosition> identifiersPositions = lexicon.tokenPositionsIdentifierPattern(tokens);
             List<OffsetPosition> urlPositions = lexicon.tokenPositionsUrlPattern(tokens);
 
-            String ress = FeaturesVectorCitation.addFeaturesCitation(tokens, null, journalsPositions, 
-                abbrevJournalsPositions, conferencesPositions, publishersPositions, locationsPositions,
-                collaborationsPositions, identifiersPositions, urlPositions);
+            try {
+                String featuredBlock = FeaturesVectorCitation.addFeaturesCitation(tokens, null, journalsPositions, 
+                    abbrevJournalsPositions, conferencesPositions, publishersPositions, locationsPositions,
+                    collaborationsPositions, identifiersPositions, urlPositions);
 
-            String res = label(ress);
-            resCitation = resultExtractionLayoutTokens(res, true, tokens);
-            // post-processing (additional field parsing and cleaning)
-            if (resCitation != null) {
-                BiblioItem.cleanTitles(resCitation);
+                featuredInput.append(featuredBlock);
+                featuredInput.append("\n\n");
+            } catch (Exception e) {
+                LOGGER.error("An exception occured while adding features for processing a citation.", e);
+            }
+        }
+        
+        String allRes = null;
+        try {
+            allRes = label(featuredInput.toString());
+        } catch (Exception e) {
+            LOGGER.error("An exception occured while labeling a citation.", e);
+            throw new GrobidException(
+                    "An exception occured while labeling a citation.", e);
+        }
 
-                resCitation.setOriginalAuthors(resCitation.getAuthors());
-                resCitation.setFullAuthors(parsers.getAuthorParser().processingCitation(resCitation.getAuthors()));
-                if (resCitation.getPublicationDate() != null) {
-                    List<Date> dates = parsers.getDateParser().processing(resCitation
-                            .getPublicationDate());
-                    if (dates != null) {
-                        Date bestDate = null;
-                        if (dates.size() > 0) {
-                            // we take the earliest most specified date
-                            for (Date theDate : dates) {
-                                if (bestDate == null) {
-                                    bestDate = theDate;
-                                } else {
-                                    if (bestDate.compareTo(theDate) == 1) {
+        if (allRes == null || allRes.length() == 0)
+            return null;
+        String[] resBlocks = allRes.split("\n\n");
+        int i = 0;
+        for (List<LayoutToken> tokens : tokenList) {
+            if (CollectionUtils.isEmpty(tokens))
+                results.add(null);
+            else {
+                String res = resBlocks[i];
+                i++;
+                BiblioItem resCitation = resultExtractionLayoutTokens(res, true, tokens);
+            
+                // post-processing (additional field parsing and cleaning)
+                if (resCitation != null) {
+                    BiblioItem.cleanTitles(resCitation);
+
+                    resCitation.setOriginalAuthors(resCitation.getAuthors());
+                    try {
+                        resCitation.setFullAuthors(parsers.getAuthorParser().processingCitation(resCitation.getAuthors()));
+                    } catch (Exception e) {
+                        LOGGER.error("An exception occured when processing author names of a citation.", e);
+                    }
+                    if (resCitation.getPublicationDate() != null) {
+                        List<Date> dates = parsers.getDateParser().processing(resCitation
+                                .getPublicationDate());
+                        if (dates != null) {
+                            Date bestDate = null;
+                            if (dates.size() > 0) {
+                                // we take the earliest most specified date
+                                for (Date theDate : dates) {
+                                    if (bestDate == null) {
                                         bestDate = theDate;
+                                    } else {
+                                        if (bestDate.compareTo(theDate) == 1) {
+                                            bestDate = theDate;
+                                        }
                                     }
                                 }
-                            }
-                            if (bestDate != null) {
-                                resCitation
-                                        .setNormalizedPublicationDate(bestDate);
+                                if (bestDate != null) {
+                                    resCitation.setNormalizedPublicationDate(bestDate);
+                                }
                             }
                         }
                     }
+
+                    resCitation.setPageRange(TextUtilities.cleanField(
+                            resCitation.getPageRange(), true));
+                    resCitation.setPublisher(TextUtilities.cleanField(
+                            resCitation.getPublisher(), true));
+                    resCitation.setJournal(TextUtilities.cleanField(
+                            resCitation.getJournal(), true));
+                    resCitation.postProcessPages();
+
+                    // editors (they are human persons in theory)
+                    resCitation.setOriginalEditors(resCitation.getEditors());
+                    try {
+                        resCitation.setFullEditors(parsers.getAuthorParser().processingCitation(resCitation.getEditors()));
+                    } catch (Exception e) {
+                        LOGGER.error("An exception occured when processing editor names of a citation.", e);
+                    }
                 }
 
-                resCitation.setPageRange(TextUtilities.cleanField(
-                        resCitation.getPageRange(), true));
-                resCitation.setPublisher(TextUtilities.cleanField(
-                        resCitation.getPublisher(), true));
-                resCitation.setJournal(TextUtilities.cleanField(
-                        resCitation.getJournal(), true));
-                resCitation.postProcessPages();
-
-                // editors (they are human persons in theory)
-                resCitation.setOriginalEditors(resCitation.getEditors());
-                resCitation.setFullEditors(parsers.getAuthorParser().processingCitation(resCitation.getEditors()));
-            }
-
-            //if (consolidate != 0) 
-            {
                 resCitation = consolidateCitation(resCitation, LayoutTokensUtil.toText(tokens), consolidate);
+                results.add(resCitation);
             }
-
-            return resCitation;
-        } catch (Exception e) {
-            LOGGER.error("An exception occured while running Grobid.", e);
-            throw new GrobidException(
-                    "An exception occured while running Grobid.", e);
         }
+
+        return results;
     }
 
     public List<BibDataSet> processingReferenceSection(String referenceTextBlock, ReferenceSegmenter referenceSegmenter) {
         List<LabeledReferenceResult> segm = referenceSegmenter.extract(referenceTextBlock);
 
         List<BibDataSet> results = new ArrayList<>();
+        List<List<LayoutToken>> allRefBlocks = new ArrayList<>();
+        if (segm == null || segm.size() == 0)
+            return results;
         for (LabeledReferenceResult ref : segm) {
-            BiblioItem bib = processing(ref.getTokens(), 0);
+            if (ref.getTokens() == null || ref.getTokens().size() == 0)
+                continue;
+            allRefBlocks.add(ref.getTokens());
+        }
+
+        List<BiblioItem> bibList = processingLayoutTokenMultiple(allRefBlocks, 0);
+        int i = 0;
+        for (LabeledReferenceResult ref : segm) {
+            if (ref.getTokens() == null || ref.getTokens().size() == 0)
+                continue;
+            BiblioItem bib = bibList.get(i);
+            i++;
             if ((bib != null) && !bib.rejectAsReference()) {
                 BibDataSet bds = new BibDataSet();
                 bds.setRefSymbol(ref.getLabel());
@@ -205,12 +276,26 @@ public class CitationParser extends AbstractParser {
         // consolidation: if selected, is not done individually for each citation but 
         // in a second stage for all citations
         if (references != null) {
+            List<String> refTexts = new ArrayList<>();
             for (LabeledReferenceResult ref : references) {
                 // paranoiac check
                 if (ref == null) 
                     continue;
 
-                BiblioItem bib = processing(ref.getReferenceText(), 0);
+                refTexts.add(ref.getReferenceText());
+            }
+
+            List<BiblioItem> bibList = processingStringMultiple(refTexts, 0);
+
+            int i = 0;
+            for (LabeledReferenceResult ref : references) {
+                // paranoiac check
+                if (ref == null) 
+                    continue;
+
+                //BiblioItem bib = processingString(ref.getReferenceText(), 0);
+                BiblioItem bib = bibList.get(i);
+                i++;
                 if (bib == null) 
                     continue;
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
@@ -170,7 +170,7 @@ public class Engine implements Closeable {
         if (reference != null) {
             reference = reference.replaceAll("\\\\", "");
         }
-        return parsers.getCitationParser().processing(reference, consolidate);
+        return parsers.getCitationParser().processingString(reference, consolidate);
     }
 
     /**
@@ -188,7 +188,7 @@ public class Engine implements Closeable {
         if (references == null || references.size() == 0)
             return finalResults;
         for (String reference : references) {
-            BiblioItem bib = parsers.getCitationParser().processing(reference, 0);
+            BiblioItem bib = parsers.getCitationParser().processingString(reference, 0);
             //if ((bib != null) && !bib.rejectAsReference()) 
             {
                 BibDataSet bds = new BibDataSet();

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -279,7 +279,6 @@ public class FullTextParser extends AbstractParser {
 				LOGGER.debug("Fulltext model: The featured body is empty");
 			}
 
-
 			// possible annexes (view as a piece of full text similar to the body)
 			documentBodyParts = doc.getDocumentPart(SegmentationLabels.ANNEX);
             featSeg = getBodyTextFeatured(doc, documentBodyParts);
@@ -1134,7 +1133,7 @@ public class FullTextParser extends AbstractParser {
 
                     for (LabeledReferenceResult ref : references) {
                         if ( (ref.getReferenceText() != null) && (ref.getReferenceText().trim().length() > 0) ) {
-                            BiblioItem bib = parsers.getCitationParser().processing(ref.getReferenceText(), 0);
+                            BiblioItem bib = parsers.getCitationParser().processingString(ref.getReferenceText(), 0);
                             String authorSequence = bib.getAuthors();
                             if ((authorSequence != null) && (authorSequence.trim().length() > 0) ) {
                                 /*List<String> inputs = new ArrayList<String>();

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -208,7 +208,7 @@ public class FullTextParser extends AbstractParser {
                 processingReferenceSection(doc, parsers.getReferenceSegmenterParser(), 0);
 
             // consolidate the set
-            if (config.getConsolidateCitations() != 0) {
+            if (config.getConsolidateCitations() != 0 && resCitations != null) {
                 Consolidation consolidator = Consolidation.getInstance();
                 if (consolidator.getCntManager() == null)
                     consolidator.setCntManager(Engine.getCntManager());

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -288,7 +288,7 @@ public class HeaderParser extends AbstractParser {
                     // below using the reference strings to improve the metadata extraction, it will have to
                     // be reviewed for something safer as just a straightforward correction
                     /*if (resHeader.getReference() != null) {
-                        BiblioItem refer = parsers.getCitationParser().processing(resHeader.getReference(), 0);
+                        BiblioItem refer = parsers.getCitationParser().processingString(resHeader.getReference(), 0);
                         BiblioItem.correct(resHeader, refer);
                     }*/
                 }

--- a/grobid-core/src/main/java/org/grobid/core/engines/patent/ReferenceExtractor.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/patent/ReferenceExtractor.java
@@ -725,8 +725,13 @@ public class ReferenceExtractor implements Closeable {
 
             if (articles != null) {
                 int k = 0;
+                List<BiblioItem> bibResults = parsers.getCitationParser().processingStringMultiple(referencesNPL, consolidate);
                 for (String ref : referencesNPL) {
-                    BiblioItem result = parsers.getCitationParser().processing(ref, consolidate);
+                    BiblioItem result = bibResults.get(k);
+                    if (result == null) {
+                        k++;
+                        continue;
+                    }
                     BibDataSet bds = new BibDataSet();
                     result.setReference(ref);
                     bds.setResBib(result);
@@ -1243,8 +1248,13 @@ public class ReferenceExtractor implements Closeable {
 
             if (articles != null) {
                 int k = 0;
+                List<BiblioItem> bibResults = parsers.getCitationParser().processingStringMultiple(referencesNPL, consolidate);
                 for (String ref : referencesNPL) {
-                    BiblioItem result = parsers.getCitationParser().processing(ref, consolidate);
+                    BiblioItem result = bibResults.get(k);
+                    if (result == null) {
+                        k++;
+                        continue;
+                    }
                     BibDataSet bds = new BibDataSet();
                     result.setReference(ref);
                     bds.setResBib(result);

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -131,36 +131,38 @@ public class DeLFTModel {
                 String inputLine;
                 int i = 0; // sentence index
                 int j = 0; // word index in the sentence
-                List<List<String>> result = results.get(0);
-                while ((inputLine = bufReader.readLine()) != null) {
-                    inputLine = inputLine.trim();
-                    if ((inputLine.length() == 0) && (j != 0)) {
-                        j = 0;
-                        i++;
-                        if (i == results.size())
-                            break;
-                        result = results.get(i);
-                        continue;
-                    }
+                if (results.size() > 0) {
+                    List<List<String>> result = results.get(0);
+                    while ((inputLine = bufReader.readLine()) != null) {
+                        inputLine = inputLine.trim();
+                        if ((inputLine.length() == 0) && (j != 0)) {
+                            j = 0;
+                            i++;
+                            if (i == results.size())
+                                break;
+                            result = results.get(i);
+                            continue;
+                        }
 
-                    if (inputLine.length() == 0) {
+                        if (inputLine.length() == 0) {
+                            labelledData.append("\n");
+                            continue;
+                        }
+                        labelledData.append(inputLine);
+                        labelledData.append(" ");
+
+                        if (j >= result.size()) {
+                            labelledData.append(TaggingLabels.OTHER_LABEL);
+                        } else {
+                            List<String> pair = result.get(j);
+                            // first is the token, second is the label (DeLFT format)
+                            String token = pair.get(0);
+                            String label = pair.get(1);
+                            labelledData.append(DeLFTModel.delft2grobidLabel(label));
+                        }
                         labelledData.append("\n");
-                        continue;
+                        j++;
                     }
-                    labelledData.append(inputLine);
-                    labelledData.append(" ");
-
-                    if (j >= result.size()) {
-                        labelledData.append(TaggingLabels.OTHER_LABEL);
-                    } else {
-                        List<String> pair = result.get(j);
-                        // first is the token, second is the label (DeLFT format)
-                        String token = pair.get(0);
-                        String label = pair.get(1);
-                        labelledData.append(DeLFTModel.delft2grobidLabel(label));
-                    }
-                    labelledData.append("\n");
-                    j++;
                 }
                 
                 // cleaning
@@ -189,7 +191,8 @@ public class DeLFTModel {
         }
         // In some areas, GROBID currently expects tabs as feature separators.
         // (Same as in WapitiModel.label)
-        result = result.replaceAll(" ", "\t");
+        if (result != null)
+            result = result.replaceAll(" ", "\t");
         return result;
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -143,8 +143,10 @@ public class DeLFTModel {
                         continue;
                     }
 
-                    if (inputLine.length() == 0)
+                    if (inputLine.length() == 0) {
+                        labelledData.append("\n");
                         continue;
+                    }
                     labelledData.append(inputLine);
                     labelledData.append(" ");
 

--- a/grobid-trainer/doc/PMC_sample_1943.results.grobid-0.6.2-SNAPSHOT-Glutton-DeLFT-WAPITI-MIXED-BidLSTM-CRF-FEATURES-23.12.2020
+++ b/grobid-trainer/doc/PMC_sample_1943.results.grobid-0.6.2-SNAPSHOT-Glutton-DeLFT-WAPITI-MIXED-BidLSTM-CRF-FEATURES-23.12.2020
@@ -1,0 +1,361 @@
+-------------> GROBID failed on 0 PDF
+
+1943 PDF files processed in 821.408 seconds, 0.4227524446731858 seconds per PDF file
+
+Evaluation metrics produced in 929.19 seconds
+
+======= Header metadata ======= 
+
+Evaluation on 1943 random PDF files out of 1943 PDF (ratio 1.0).
+
+======= Strict Matching ======= (exact matches)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+abstract             82.28        15.9         15.65        15.77        1911   
+authors              98.28        92.15        91.91        92.03        1941   
+first_author         99.06        95.87        95.62        95.74        1941   
+keywords             93.31        66.5         58.12        62.03        1380   
+title                96.99        86.51        85.8         86.15        1943   
+
+all (micro avg.)     93.98        72.12        70.29        71.2         9116   
+all (macro avg.)     93.98        71.39        69.42        70.34        9116   
+
+
+======== Soft Matching ======== (ignoring punctuation, case and space characters mismatches)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+abstract             91.16        59.2         58.24        58.72        1911   
+authors              98.37        92.61        92.38        92.49        1941   
+first_author         99.08        95.97        95.72        95.85        1941   
+keywords             94.49        75.46        65.94        70.38        1380   
+title                98.61        94.24        93.46        93.85        1943   
+
+all (micro avg.)     96.34        84.3         82.16        83.22        9116   
+all (macro avg.)     96.34        83.5         81.15        82.26        9116   
+
+
+==== Levenshtein Matching ===== (Minimum Levenshtein distance at 0.8)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+abstract             96.82        86.81        85.4         86.1         1911   
+authors              99.04        95.76        95.52        95.64        1941   
+first_author         99.15        96.28        96.03        96.16        1941   
+keywords             95.78        85.24        74.49        79.51        1380   
+title                99.27        97.35        96.55        96.95        1943   
+
+all (micro avg.)     98.01        92.9         90.54        91.71        9116   
+all (macro avg.)     98.01        92.29        89.6         90.87        9116   
+
+
+= Ratcliff/Obershelp Matching = (Minimum Ratcliff/Obershelp similarity at 0.95)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+abstract             95.9         82.29        80.95        81.61        1911   
+authors              98.71        94.21        93.97        94.09        1941   
+first_author         99.06        95.87        95.62        95.74        1941   
+keywords             95.22        81.01        70.8         75.56        1380   
+title                99.17        96.89        96.09        96.49        1943   
+
+all (micro avg.)     97.61        90.84        88.54        89.67        9116   
+all (macro avg.)     97.61        90.05        87.49        88.7         9116   
+
+===== Instance-level results =====
+
+Total expected instances:       1943
+Total correct instances:        204 (strict) 
+Total correct instances:        799 (soft) 
+Total correct instances:        1258 (Levenshtein) 
+Total correct instances:        1152 (ObservedRatcliffObershelp) 
+
+Instance-level recall:  10.5    (strict) 
+Instance-level recall:  41.12   (soft) 
+Instance-level recall:  64.75   (Levenshtein) 
+Instance-level recall:  59.29   (RatcliffObershelp) 
+
+======= Citation metadata ======= 
+
+Evaluation on 1943 random PDF files out of 1943 PDF (ratio 1.0).
+
+======= Strict Matching ======= (exact matches)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+authors              97.5         82.96        76.02        79.34        85778  
+date                 99.11        94.17        83           88.23        87067  
+first_author         98.38        89.21        81.73        85.31        85778  
+inTitle              95.95        71.75        70.94        71.34        81007  
+issue                99.56        87.99        83.29        85.58        16635  
+page                 98.89        95.65        85.14        90.09        80501  
+title                97.06        78.93        74.58        76.69        80736  
+volume               99.36        95.44        88.99        92.1         80067  
+
+all (micro avg.)     98.23        86.7         80.14        83.29        597569 
+all (macro avg.)     98.23        87.01        80.46        83.59        597569 
+
+
+======== Soft Matching ======== (ignoring punctuation, case and space characters mismatches)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+authors              97.6         83.63        76.63        79.98        85778  
+date                 99.11        94.17        83           88.23        87067  
+first_author         98.42        89.47        81.97        85.55        85778  
+inTitle              97.57        83.09        82.14        82.61        81007  
+issue                99.56        87.99        83.29        85.58        16635  
+page                 98.89        95.65        85.14        90.09        80501  
+title                98.63        90.37        85.39        87.81        80736  
+volume               99.36        95.44        88.99        92.1         80067  
+
+all (micro avg.)     98.64        90.06        83.24        86.52        597569 
+all (macro avg.)     98.64        89.98        83.32        86.5         597569 
+
+
+==== Levenshtein Matching ===== (Minimum Levenshtein distance at 0.8)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+authors              98.24        88.22        80.84        84.37        85778  
+date                 99.11        94.17        83           88.23        87067  
+first_author         98.43        89.57        82.06        85.65        85778  
+inTitle              97.75        84.35        83.4         83.87        81007  
+issue                99.56        87.99        83.29        85.58        16635  
+page                 98.89        95.65        85.14        90.09        80501  
+title                98.94        92.61        87.5         89.98        80736  
+volume               99.36        95.44        88.99        92.1         80067  
+
+all (micro avg.)     98.79        91.22        84.32        87.63        597569 
+all (macro avg.)     98.79        91           84.28        87.49        597569 
+
+
+= Ratcliff/Obershelp Matching = (Minimum Ratcliff/Obershelp similarity at 0.95)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+authors              97.89        85.74        78.57        81.99        85778  
+date                 99.11        94.17        83           88.23        87067  
+first_author         98.38        89.23        81.75        85.33        85778  
+inTitle              97.38        81.73        80.8         81.26        81007  
+issue                99.56        87.99        83.29        85.58        16635  
+page                 98.89        95.65        85.14        90.09        80501  
+title                98.88        92.19        87.11        89.58        80736  
+volume               99.36        95.44        88.99        92.1         80067  
+
+all (micro avg.)     98.68        90.38        83.54        86.82        597569 
+all (macro avg.)     98.68        90.27        83.58        86.77        597569 
+
+===== Instance-level results =====
+
+Total expected instances:               90125
+Total extracted instances:              88760
+Total correct instances:                39460 (strict) 
+Total correct instances:                51469 (soft) 
+Total correct instances:                55839 (Levenshtein) 
+Total correct instances:                52695 (RatcliffObershelp) 
+
+Instance-level precision:       44.46 (strict) 
+Instance-level precision:       57.99 (soft) 
+Instance-level precision:       62.91 (Levenshtein) 
+Instance-level precision:       59.37 (RatcliffObershelp) 
+
+Instance-level recall:  43.78   (strict) 
+Instance-level recall:  57.11   (soft) 
+Instance-level recall:  61.96   (Levenshtein) 
+Instance-level recall:  58.47   (RatcliffObershelp) 
+
+Instance-level f-score: 44.12 (strict) 
+Instance-level f-score: 57.54 (soft) 
+Instance-level f-score: 62.43 (Levenshtein) 
+Instance-level f-score: 58.91 (RatcliffObershelp) 
+
+Matching 1 :    67274
+
+Matching 2 :    4018
+
+Matching 3 :    2291
+
+Matching 4 :    732
+
+Total matches : 74315
+
+======= Citation context resolution ======= 
+
+Total expected references:       90125 - 46.38 references per article
+Total predicted references:      88760 - 45.68 references per article
+
+Total expected citation contexts:        139835 - 71.97 citation contexts per article
+Total predicted citation contexts:       120892 - 62.22 citation contexts per article
+
+Total correct predicted citation contexts:       99662 - 51.29 citation contexts per article
+Total wrong predicted citation contexts:         21230 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
+
+Precision citation contexts:     82.44
+Recall citation contexts:        71.27
+fscore citation contexts:        76.45
+
+======= Fulltext structures ======= 
+
+Evaluation on 1943 random PDF files out of 1943 PDF (ratio 1.0).
+
+======= Strict Matching ======= (exact matches)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+figure_title         96.6         28.26        22.06        24.78        7058   
+reference_citation   59.01        57.3         58.99        58.14        134196 
+reference_figure     94.95        63.54        63.96        63.75        19330  
+reference_table      99.13        82.85        84.4         83.62        7327   
+section_title        94.57        75.5         67.15        71.08        27619  
+table_title          98.84        57.87        55.1         56.45        3784   
+
+all (micro avg.)     90.52        60.33        60.16        60.24        199314 
+all (macro avg.)     90.52        60.89        58.61        59.64        199314 
+
+
+======== Soft Matching ======== (ignoring punctuation, case and space characters mismatches)
+
+===== Field-level results =====
+
+label                accuracy     precision    recall       f1           support
+
+figure_title         98.34        73.7         57.54        64.62        7058   
+reference_citation   61.69        61.45        63.27        62.35        134196 
+reference_figure     94.83        64.07        64.5         64.28        19330  
+reference_table      99.1         83.03        84.58        83.79        7327   
+section_title        95.29        80.43        71.53        75.72        27619  
+table_title          99.41        80.46        76.61        78.49        3784   
+
+all (micro avg.)     91.44        65.55        65.36        65.46        199314 
+all (macro avg.)     91.44        73.86        69.67        71.54        199314 
+
+
+************************************************************************************
+COUNTER: org.grobid.core.engines.counters.ReferenceMarkerMatcherCounters
+************************************************************************************
+------------------------------------------------------------------------------------
+  UNMATCHED_REF_MARKERS:                    7514
+  MATCHED_REF_MARKERS_AFTER_POST_FILTERING: 2737
+  STYLE_AUTHORS:                            37328
+  STYLE_NUMBERED:                           53428
+  MANY_CANDIDATES:                          4120
+  MANY_CANDIDATES_AFTER_POST_FILTERING:     535
+  NO_CANDIDATES:                            16085
+  INPUT_REF_STRINGS_CNT:                    93217
+  MATCHED_REF_MARKERS:                      120892
+  NO_CANDIDATES_AFTER_POST_FILTERING:       576
+  STYLE_OTHER:                              2461
+====================================================================================
+
+************************************************************************************
+COUNTER: org.grobid.core.engines.counters.TableRejectionCounters
+************************************************************************************
+------------------------------------------------------------------------------------
+  CANNOT_PARSE_LABEL_TO_INT:          134
+  CONTENT_SIZE_TOO_SMALL:             83
+  CONTENT_WIDTH_TOO_SMALL:            10
+  EMPTY_LABEL_OR_HEADER_OR_CONTENT:   2301
+  HEADER_NOT_STARTS_WITH_TABLE_WORD:  142
+  HEADER_NOT_CONSECUTIVE:             939
+  HEADER_AND_CONTENT_DIFFERENT_PAGES: 3
+  HEADER_AND_CONTENT_INTERSECT:       674
+  FEW_TOKENS_IN_HEADER:               6
+====================================================================================
+
+************************************************************************************
+COUNTER: org.grobid.core.engines.label.TaggingLabelImpl
+************************************************************************************
+------------------------------------------------------------------------------------
+  HEADER_DOCTYPE:           2081
+  CITATION_TITLE:           84095
+  HEADER_DATE:              1077
+  HEADER_KEYWORD:           1285
+  NAME-HEADER_MIDDLENAME:   5978
+  TABLE_FIGDESC:            4168
+  NAME-HEADER_SURNAME:      13948
+  NAME-CITATION_OTHER:      439426
+  CITATION_BOOKTITLE:       3998
+  HEADER_FUNDING:           77
+  HEADER_ADDRESS:           6064
+  HEADER_AFFILIATION:       6225
+  FULLTEXT_SECTION_MARKER:  2
+  CITATION_NOTE:            3730
+  FULLTEXT_CITATION_MARKER: 182098
+  TABLE_NOTE:               2658
+  HEADER_EMAIL:             2146
+  FULLTEXT_TABLE_MARKER:    14829
+  CITATION_WEB:             1379
+  HEADER_GROUP:             1
+  FULLTEXT_SECTION:         51820
+  TABLE_LABEL:              3549
+  NAME-HEADER_FORENAME:     14081
+  TABLE_CONTENT:            5470
+  CITATION_COLLABORATION:   174
+  HEADER_MEETING:           23
+  CITATION_ISSUE:           17096
+  HEADER_EDITOR:            108
+  CITATION_SERIES:          65
+  CITATION_JOURNAL:         79465
+  NAME-CITATION_SURNAME:    333626
+  TABLE_FIGURE_HEAD:        4992
+  FULLTEXT_EQUATION_MARKER: 1682
+  CITATION_OTHER:           448430
+  FULLTEXT_FIGURE_MARKER:   38814
+  HEADER_TITLE:             2143
+  CITATION_TECH:            383
+  FIGURE_CONTENT:           2851
+  FIGURE_LABEL:             5661
+  FULLTEXT_EQUATION_LABEL:  1832
+  HEADER_OTHER:             11780
+  FULLTEXT_EQUATION:        4132
+  CITATION_DATE:            85931
+  CITATION_AUTHOR:          87238
+  FULLTEXT_FIGURE:          14443
+  FULLTEXT_TABLE:           11503
+  CITATION_EDITOR:          2185
+  FULLTEXT_OTHER:           290
+  HEADER_SUBMISSION:        1216
+  NAME-HEADER_OTHER:        17324
+  FIGURE_FIGDESC:           6857
+  NAME-HEADER_SUFFIX:       14
+  CITATION_VOLUME:          76408
+  NAME-CITATION_SUFFIX:     569
+  CITATION_LOCATION:        8126
+  NAME-HEADER_TITLE:        757
+  HEADER_WEB:               348
+  CITATION_INSTITUTION:     2164
+  HEADER_ABSTRACT:          2575
+  HEADER_REFERENCE:         2909
+  CITATION_PAGES:           80649
+  HEADER_AUTHOR:            4102
+  NAME-HEADER_MARKER:       7900
+  NAME-CITATION_FORENAME:   314399
+  CITATION_PUBLISHER:       5363
+  HEADER_PUBNUM:            1653
+  NAME-CITATION_MIDDLENAME: 68882
+  CITATION_PUBNUM:          10388
+  HEADER_COPYRIGHT:         1874
+  FULLTEXT_PARAGRAPH:       380173
+  FIGURE_FIGURE_HEAD:       9447
+====================================================================================
+====================================================================================


### PR DESCRIPTION
With this PR (related to issue #665), sequences can now be grouped and passed in set to the sequence labeling algorithm. For the deep learning sequence labeling, batch of size runtime `batch_size` as defined in the DL model config are used as sequences are provided. For CRF, we simply apply the model to several sequences at the time, instead of one - but this is usual business. 

Grouping is at document-level, so this change won't improve sequences that are processed only one time per document (header, reference segmenter, fulltext, segmentation, header author name) - they will remain alone in their batch :) The improvement is relevant in practice to bibliographical references and affiliation+address blocks.

In this implementation, we modify the way the sequences are collected and we don't use some sort of asynchronous accumulation at the level of the JNI - which would have been more elegant and generic but would require much more development time. 

Here are the runtime improvements when processing complete full texts, with a different model implementation assigned to bibliographical reference processing on the PMC 1943 set (1943 PDF from PMC) (i.e. only `citation` model is running a different model, all the other 8 ones are with CRF):

- CRF: unchanged runtime 
`1943 PDF files processed in 728.804 seconds, 0.3750921255790015 seconds per PDF file`

- BidLSTM-CRF: 
before PR:
`1943 PDF files processed in 3172.017 seconds, 1.6325357694287184 seconds per PDF file`
with PR:
`1943 PDF files processed in 821.408 seconds, 0.4227524446731858 seconds per PDF file` 

- SciBERT-CRF: 
before PR:
`1943 PDF files processed in 19804.0 seconds, 10.192485846628925 seconds per PDF file`
with PR:
`1943 PDF files processed in 3392.553 seconds, 1.7460386001029335 seconds per PDF file`

Runtimes with GPU 1080Ti. 

Side note: for bibliographical references, BidLSTM-CRF-FEATURES has the same runtime as BidLSTM-CRF and gives the best accuracy of all models (f-score `87.63` with Levenshtein Matching as compared to `86.53` with CRF, SciBERT is at `87.45`). Overall, we can have now some accuracy gain as compared to CRF with a very similar runtime, but we still need to buy GPUs and get broke.
