### PR TITLE
Dockerfile enhancements

### DIFF
--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -41,7 +41,6 @@ COPY grobid-trainer/ ./grobid-trainer/
 RUN ./gradlew clean assemble --no-daemon  --info --stacktrace
 
 WORKDIR /opt/grobid
-RUN cp /opt/grobid-source/grobid-core/build/libs/grobid-core-*-onejar.jar ./grobid-core-onejar.jar
 RUN unzip -o /opt/grobid-source/grobid-service/build/distributions/grobid-service-*.zip && \
     mv grobid-service* grobid-service
 RUN unzip -o /opt/grobid-source/grobid-home/build/distributions/grobid-home-*.zip && \

--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -22,9 +22,6 @@ RUN apt-get update && \
 
 WORKDIR /opt/grobid-source
 
-RUN mkdir -p .gradle
-VOLUME /opt/grobid-source/.gradle
-
 # gradle
 COPY gradle/ ./gradle/
 COPY gradlew ./
@@ -59,12 +56,6 @@ RUN apt-get update && \
 WORKDIR /opt/grobid
 
 COPY --from=builder /opt/grobid .
-
-# below to allow logs to be written in the container
-# RUN mkdir -p logs
-
-VOLUME ["/opt/grobid/grobid-home/tmp"]
-RUN chmod 777 /opt/grobid/grobid-home/tmp
 
 ENV JAVA_OPTS=-Xmx4g
 

--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -47,7 +47,7 @@ RUN rm -rf grobid-source
 # -------------------
 # build runtime image
 # -------------------
-FROM openjdk:8u212-jre-slim
+FROM openjdk:11-jre-slim
 
 RUN apt-get update && \
     apt-get -y --no-install-recommends install libxml2 && \
@@ -56,8 +56,6 @@ RUN apt-get update && \
 WORKDIR /opt/grobid
 
 COPY --from=builder /opt/grobid .
-
-ENV JAVA_OPTS=-Xmx4g
 
 # Add Tini
 ENV TINI_VERSION v0.18.0

--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -18,7 +18,7 @@ FROM openjdk:8u212-jdk as builder
 USER root
 
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install libxml2
+    apt-get -y --no-install-recommends install unzip
 
 WORKDIR /opt/grobid-source
 
@@ -40,34 +40,32 @@ COPY grobid-trainer/ ./grobid-trainer/
 
 RUN ./gradlew clean assemble --no-daemon  --info --stacktrace
 
+WORKDIR /opt/grobid
+RUN cp /opt/grobid-source/grobid-core/build/libs/grobid-core-*-onejar.jar ./grobid-core-onejar.jar
+RUN unzip -o /opt/grobid-source/grobid-service/build/distributions/grobid-service-*.zip && \
+    mv grobid-service* grobid-service
+RUN unzip -o /opt/grobid-source/grobid-home/build/distributions/grobid-home-*.zip && \
+    chmod -R 755 /opt/grobid/grobid-home/pdf2xml
+RUN rm -rf grobid-source
+
 # -------------------
 # build runtime image
 # -------------------
 FROM openjdk:8u212-jre-slim
 
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install libxml2 unzip
+    apt-get -y --no-install-recommends install libxml2 && \
+    rm -rf /var/lib/apt/lists/*
 
-WORKDIR /opt
+WORKDIR /opt/grobid
 
-COPY --from=builder /opt/grobid-source/grobid-core/build/libs/grobid-core-*-onejar.jar ./grobid/grobid-core-onejar.jar
-COPY --from=builder /opt/grobid-source/grobid-service/build/distributions/grobid-service-*.zip ./grobid-service.zip
-COPY --from=builder /opt/grobid-source/grobid-home/build/distributions/grobid-home-*.zip ./grobid-home.zip
-
-RUN unzip -o ./grobid-service.zip -d ./grobid && \
-    mv ./grobid/grobid-service-* ./grobid/grobid-service
-
-RUN unzip ./grobid-home.zip -d ./grobid && \
-    mkdir -p /opt/grobid/grobid-home/tmp
-
-RUN rm *.zip
+COPY --from=builder /opt/grobid .
 
 # below to allow logs to be written in the container
 # RUN mkdir -p logs
 
 VOLUME ["/opt/grobid/grobid-home/tmp"]
-
-WORKDIR /opt/grobid
+RUN chmod 777 /opt/grobid/grobid-home/tmp
 
 ENV JAVA_OPTS=-Xmx4g
 
@@ -76,10 +74,6 @@ ENV TINI_VERSION v0.18.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "-s", "--"]
-
-RUN chmod -R 755 /opt/grobid/grobid-home/pdf2xml 
-RUN chmod 777 /opt/grobid/grobid-home/tmp
-
 CMD ["./grobid-service/bin/grobid-service", "server", "grobid-service/config/config.yaml"]
 
 ARG GROBID_VERSION


### PR DESCRIPTION
https://github.com/kermitt2/grobid/issues/697

Shrunk the container from 1.66 GB to 912.5 MB. Most of the change is achieved in the first commit, which maintains total parity of output with the previous version. Later commits are remove unused artifacts, volume, & disable logging into the container (which in production environments would cause it to fail over after running for long periods).