### PR TITLE
Add more tests on sentence segmentation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -203,7 +203,7 @@ subprojects {
     test {
         testLogging.showStandardStreams = true
         // enable for having separate test executor for different tests
-        //  forkEvery = 1
+        forkEvery = 1
         maxHeapSize = "1024m"
     }
 

--- a/grobid-core/src/test/java/org/grobid/core/utilities/SentenceUtilitiesTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/SentenceUtilitiesTest.java
@@ -1,23 +1,44 @@
 package org.grobid.core.utilities;
 
+import org.grobid.core.lang.SentenceDetector;
+import org.grobid.core.lang.SentenceDetectorFactory;
 import org.grobid.core.main.LibraryLoader;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 
+import static org.easymock.EasyMock.expect;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.powermock.api.easymock.PowerMock.*;
 
+@RunWith(PowerMockRunner.class)
+@SuppressStaticInitializationFor("org.grobid.core.lang.SentenceDetectorFactory")
+@PrepareForTest({SentenceUtilities.class})
 public class SentenceUtilitiesTest {
 
+    SentenceDetectorFactory sentenceDetectorFactoryMock;
+    SentenceDetector sentenceDetectorMock;
+    SentenceUtilities target;
     @Before
     public void setUp() {
         LibraryLoader.load();
         GrobidProperties.getInstance();
+
+        sentenceDetectorFactoryMock = createMock(SentenceDetectorFactory.class);
+        sentenceDetectorMock = createMock(SentenceDetector.class);
+        target = SentenceUtilities.getInstance();
+        Whitebox.setInternalState(target, sentenceDetectorFactoryMock);
     }
 
     @Test
@@ -30,21 +51,36 @@ public class SentenceUtilitiesTest {
     @Test
     public void testEmptyText() throws Exception {
         String text = "";
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(text)).andReturn(new ArrayList<>());
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
         List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(text);
+
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
         assertThat(theSentences.size(), is(0));
     }
 
     @Test
     public void testOneSentenceText() throws Exception {
         String text = "Bla bla bla.";
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(text)).andReturn(Arrays.asList(new OffsetPosition(0, 12)));
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
         List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(text);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
         assertThat(theSentences.size(), is(1));
     }
 
     @Test
     public void testTwoSentencesText() throws Exception {
         String text = "Bla bla bla. Bli bli bli.";
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(text)).andReturn(Arrays.asList(new OffsetPosition(0, 12), new OffsetPosition(13, 24)));
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
         List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(text);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
         assertThat(theSentences.size(), is(2));
     }
 
@@ -53,7 +89,13 @@ public class SentenceUtilitiesTest {
         String text = "Bla bla bla. Bli bli bli.";
         List<OffsetPosition> forbidden = new ArrayList<>();
         forbidden.add(new OffsetPosition(2, 8));
+
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(text, null)).andReturn(Arrays.asList(new OffsetPosition(0, 12), new OffsetPosition(13, 24)));
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
         List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(text, forbidden);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
         assertThat(theSentences.size(), is(2));
     }
 
@@ -63,7 +105,104 @@ public class SentenceUtilitiesTest {
         List<OffsetPosition> forbidden = new ArrayList<>();
         forbidden.add(new OffsetPosition(2, 8));
         forbidden.add(new OffsetPosition(9, 15));
+
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(text, null)).andReturn(Arrays.asList(new OffsetPosition(0, 12), new OffsetPosition(13, 24)));
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
         List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(text, forbidden);
+
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
         assertThat(theSentences.size(), is(1));
+    }
+
+    @Test
+    public void testCorrectSegmentation_shouldNotCancelSegmentation() throws Exception {
+        String paragraph = "This is a sentence. [3] Another sentence.";
+
+        List<String> refs = Arrays.asList("[3]");
+        List<String> sentences = Arrays.asList("This is a sentence.", "Another sentence.");
+
+        List<OffsetPosition> refSpans = getPositions(paragraph, refs);
+        List<OffsetPosition> sentenceSpans = getPositions(paragraph, sentences);
+
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(paragraph, null)).andReturn(sentenceSpans);
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
+        List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(paragraph, refSpans);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
+        assertThat(theSentences.size(), is(2));
+    }
+
+    @Test
+    public void testCorrectSegmentation_shouldNotCancelSegmentation2() throws Exception {
+        String paragraph = "This is a sentence [3] and the continuing sentence.";
+
+        List<String> refs = Arrays.asList("[3]");
+        List<String> sentences = Arrays.asList("This is a sentence", "and the continuing sentence.");
+
+        List<OffsetPosition> refSpans = getPositions(paragraph, refs);
+        List<OffsetPosition> sentenceSpans = getPositions(paragraph, sentences);
+
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(paragraph, null)).andReturn(sentenceSpans);
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
+        List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(paragraph, refSpans);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
+        assertThat(theSentences.size(), is(2));
+    }
+
+    @Test
+    public void testCorrectSegmentation_shouldCancelWrongSegmentation() throws Exception {
+        String paragraph = "(Foppiano and al. 2021) explains what he's thinking.";
+
+        List<String> refs = Arrays.asList("(Foppiano and al. 2021)");
+        List<String> sentences = Arrays.asList("(Foppiano and al.", "2021) explains what he's thinking.");
+
+        List<OffsetPosition> refSpans = getPositions(paragraph, refs);
+        List<OffsetPosition> sentenceSpans = getPositions(paragraph, sentences);
+
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(paragraph, null)).andReturn(sentenceSpans);
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
+        List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(paragraph, refSpans);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
+        assertThat(theSentences.size(), is(1));
+    }
+
+    @Test
+    public void testCorrectSegmentation_shouldCancelWrongSegmentation2() throws Exception {
+        String paragraph = "What we claim corresponds with what (Foppiano and al. 2021) explains what he's thinking.";
+
+        List<String> refs = Arrays.asList("(Foppiano and al. 2021)");
+        List<String> sentences = Arrays.asList("What we claim corresponds with what (Foppiano and al.", "2021) explains what he's thinking.");
+
+        List<OffsetPosition> refSpans = getPositions(paragraph, refs);
+        List<OffsetPosition> sentenceSpans = getPositions(paragraph, sentences);
+
+        expect(sentenceDetectorFactoryMock.getInstance()).andReturn(sentenceDetectorMock);
+        expect(sentenceDetectorMock.detect(paragraph, null)).andReturn(sentenceSpans);
+        replay(sentenceDetectorFactoryMock, sentenceDetectorMock);
+
+        List<OffsetPosition> theSentences = SentenceUtilities.getInstance().runSentenceDetection(paragraph, refSpans);
+        verify(sentenceDetectorFactoryMock, sentenceDetectorMock);
+        assertThat(theSentences.size(), is(1));
+    }
+
+    private List<OffsetPosition> getPositions(String paragraph, List<String> refs) {
+        List<OffsetPosition> positions = new ArrayList<>();
+        int previousRefEnd = 0;
+        for (String ref : refs) {
+            int startRef = paragraph.indexOf(ref, previousRefEnd);
+            int endRef = startRef + ref.length();
+
+            positions.add(new OffsetPosition(startRef, endRef));
+            previousRefEnd = endRef;
+        }
+
+        return positions;
     }
 }


### PR DESCRIPTION
I'm adding more tests for testing that the sentence segmentation correction works fine. 

Actually I though there was a bug, but then after I've added tests I realised it was fine. The tests have more realistic examples and they allow to be independent than the sentence segmenter (which might change the results in future). 