### PR TITLE
Fix NullPointer exception in PDFALTOOutlineSaxHandler

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/sax/PDFALTOOutlineSaxHandler.java
+++ b/grobid-core/src/main/java/org/grobid/core/sax/PDFALTOOutlineSaxHandler.java
@@ -92,10 +92,22 @@ public class PDFALTOOutlineSaxHandler extends DefaultHandler {
 			nodes.put(currentId,currentNode);
 			if (currentParentId != -1) {
 				DocumentNode father = nodes.get(currentParentId);
+                // Correction proposed by Luc Bougé @lucbouge
+                // If father is null, then one should not access any method of father.
+                /*************************
 				if (father == null)
 					System.out.println("Warning, father not yet encountered! id is " + currentParentId);
 				currentNode.setFather(father);
 				father.addChild(currentNode);
+                *************************/
+                if (father == null)
+					System.out.println("Warning, father not yet encountered! id is " + currentParentId);
+                else {
+				    currentNode.setFather(father);
+				    father.addChild(currentNode);
+                }
+                /************************/
+                // End of correction   
 			} else {
 				// parent is the root node
 				currentNode.setFather(root);

--- a/grobid-core/src/main/java/org/grobid/core/sax/PDFALTOOutlineSaxHandler.java
+++ b/grobid-core/src/main/java/org/grobid/core/sax/PDFALTOOutlineSaxHandler.java
@@ -92,22 +92,12 @@ public class PDFALTOOutlineSaxHandler extends DefaultHandler {
 			nodes.put(currentId,currentNode);
 			if (currentParentId != -1) {
 				DocumentNode father = nodes.get(currentParentId);
-                // Correction proposed by Luc Bougé @lucbouge
-                // If father is null, then one should not access any method of father.
-                /*************************
-				if (father == null)
-					System.out.println("Warning, father not yet encountered! id is " + currentParentId);
-				currentNode.setFather(father);
-				father.addChild(currentNode);
-                *************************/
                 if (father == null)
 					System.out.println("Warning, father not yet encountered! id is " + currentParentId);
                 else {
 				    currentNode.setFather(father);
 				    father.addChild(currentNode);
                 }
-                /************************/
-                // End of correction   
 			} else {
 				// parent is the root node
 				currentNode.setFather(root);


### PR DESCRIPTION
I observed the following error. 

févr. 12, 2021 3:20:44 PM org.grobid.core.document.Document addTokenizedDocument
GRAVE: Cannot parse file: my_dir/grobid-0.6.1/grobid-home/tmp/ZW3PpM4E9g.lxml_outline.xml

févr. 12, 2021 3:20:44 PM org.grobid.core.document.Document addTokenizedDocument
GRAVE: Cannot parse file: my_dir/grobid-0.6.1/grobid-home/tmp/ZW3PpM4E9g.lxml_outline.xml

févr. 12, 2021 3:20:46 PM org.grobid.core.engines.ProcessEngine createTraining
INFOS: 2 files processed.

it originates in an illegal nullPointer access in file PDFALTOOutlineSaxHandler.java. 

In understand that the error is not  that "GRAVE". According to @kermitt2, it is simply one of the generated XML file resulting from the PDF parsing which is not XML valid (very frequent) - it has no impact because the outline file (containing the table of content outline if available embedded in the PDF) is not exploited by GROBID for the moment - it's to allow some possible improvements in the future. The error is more a reminder for the developers... the XML parser that classifies it as "GRAVE" but it would be rather INFO for us.

Unfortunately, a side effect might have been overlooked. If father is null, then father.addChild(currentNode) is called with a nullPointer exception.

This exception is caught by catch (Exception e) at line 372 in grobid-core/src/main/java/org/grobid/core/document/Document.java where the error message "Cannot parse" is misleading.

I think an additional else is just missing.