### PR TITLE
Remove the logging while building the docker image

### DIFF
--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -4,7 +4,8 @@
 
 ## See https://grobid.readthedocs.io/en/latest/Grobid-docker/
 
-## docker build -t grobid/grobid:GROBID_VERSION --build-arg GROBID_VERSION=GROBID_VERSION .
+## docker build -t grobid/grobid:GROBID_VERSION --build-arg GROBID_VERSION=GROBID_VERSION -f Dockerfile.crf .
+## docker build -t grobid/grobid:GROBID_VERSION --build-arg GROBID_VERSION=GROBID_VERSION -f Dockerfile.delft .
 ## docker run -t --rm -p 8080:8070 -p 8081:8071 {image_name}
 
 # To connect to the container with a bash shell
@@ -42,6 +43,10 @@ RUN unzip -o /opt/grobid-source/grobid-service/build/distributions/grobid-servic
     mv grobid-service* grobid-service
 RUN unzip -o /opt/grobid-source/grobid-home/build/distributions/grobid-home-*.zip && \
     chmod -R 755 /opt/grobid/grobid-home/pdf2xml
+
+# Adjust config
+RUN sed -i '/#Docker-ignore-log-start/,/#Docker-ignore-log-end/d'  grobid-service/config/config.yaml
+
 RUN rm -rf grobid-source
 
 # -------------------

--- a/grobid-service/config/config.yaml
+++ b/grobid-service/config/config.yaml
@@ -31,6 +31,8 @@ logging:
     - type: console
       threshold: ALL
       timeZone: UTC
+# The following line is used to remove the logger in the docker image, please don't modify it
+#Docker-ignore-log-start
     - type: file
       currentLogFilename: logs/grobid-service.log
       threshold: ALL
@@ -38,3 +40,4 @@ logging:
       archivedLogFilenamePattern: logs/grobid-service-%d.log
       archivedFileCount: 5
       timeZone: UTC
+#Docker-ignore-log-end


### PR DESCRIPTION
This PR removes the log on a file of the application. It's performed at runtime while building so that the log file can be kept for other usages. 

It requires just that the two marks in the `config.yml` are not removed or modified 