### PR TITLE
added configuration to be able to consolidate only with crossref doi.

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -601,6 +601,18 @@ public class GrobidProperties {
     }
 
     /**
+     * whether to desambiguate with only when doi is extracted otherwise also with the metadata (title + author..)
+     * @return boolean false if use fuzzy matching is not wanted , true by default
+     */
+    public static boolean useFuzzyMatchingConsolidation() {
+        String rawValue = getPropertyValue(GrobidPropertyKeys.PROP_CROSSREF_FUZZY_MATCH);
+        if (rawValue != null) {
+            return !rawValue.equals("false");
+        }
+        return true;
+    }
+
+    /**
      * Sets the port for a proxy connection, given in the grobid-property file.
      *
      * @param port for connecting crossref

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidPropertyKeys.java
@@ -41,6 +41,11 @@ public interface GrobidPropertyKeys {
      */
     String PROP_CROSSREF_TOKEN = "org.grobid.crossref.token";
 
+    /**
+     * For indicating that we don t try fuzzy matching when using crossref for consolidation
+     */
+    String PROP_CROSSREF_FUZZY_MATCH = "org.grobid.crossref.fuzzymatching";
+
     String PROP_PROXY_HOST = "grobid.proxy_host";
     String PROP_PROXY_PORT = "grobid.proxy_port";
 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefRequest.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefRequest.java
@@ -82,6 +82,9 @@ public class CrossrefRequest<T extends Object> extends Observable {
 	 * Execute request, handle response by sending to listeners a CrossrefRequestListener.Response
 	 */
 	public void execute() {
+
+		if(!GrobidProperties.useFuzzyMatchingConsolidation() && params.get("DOI") == null && params.get("doi") == null)
+			return;
 		if (params == null) {
             // this should not happen
             CrossrefRequestListener.Response<T> message = new CrossrefRequestListener.Response<T>();

--- a/grobid-home/config/grobid.properties
+++ b/grobid-home/config/grobid.properties
@@ -20,6 +20,7 @@ org.grobid.glutton.host=localhost
 org.grobid.glutton.port=8080
 #org.grobid.crossref.mailto=toto@titi.tutu
 #org.grobid.crossref.token=yourmysteriouscrossrefmetadataplusauthorizationtokentobeputhere
+#org.grobid.crossref.fuzzymatching=true
 
 #-------------------- proxy --------------------
 #proxy to be used for external call to the crossref REST API service or Glutton service if not deployed under proxy ("null" when no proxy)


### PR DESCRIPTION
Hello

When using consolidation and the doi is not present in the document, we proceed with fuzzy matching, the problem is that while this should be very helpful in most cases, there are some cases where it gives some understandable results (from the point of view of general users), because it depends first on the quality of the metadata extraction and especially on the consolidation service..

I've been running the crossref apis benchmark, and it seems that the matching scores have decreased, so I think we should be able to deactivate the consolidation when we don't the doi in this case to make sure users are not going to be surprised, here are some exemples :

For this one , the original title is in french, in the resulting TEI , the title is in english and we have doi added and journal..

[exemple1.pdf](https://github.com/kermitt2/grobid/files/6323876/exemple1.pdf)

This one, it is obvious that the result has nothing to do with the pdf content:

[exemple3.pdf](https://github.com/kermitt2/grobid/files/6323875/exemple3.pdf)
