### PR TITLE
Add MD5 for PDF files 

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1572,4 +1572,11 @@ public class Document implements Serializable {
     public void setByteSize(double size) {
         byteSize = size;
     }
+
+    public String getMD5() {
+        if (documentSource != null)
+            return documentSource.getMD5();
+        else
+            return null;
+    }
 }

--- a/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
@@ -33,6 +33,7 @@ public class DocumentSource {
     private File xmlFile;
     boolean cleanupXml = false;
 
+    private String md5Str = null;
 
     private DocumentSource() {
     }
@@ -388,6 +389,14 @@ public class DocumentSource {
         if (pdfFile != null)
             return pdfFile.length();
         return 0;
+    }
+
+    public String getMD5() {
+        return this.md5Str;
+    }
+
+    public void setMD5(String md5Str) {
+        this.md5Str = md5Str;
     }
 
 }

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -634,6 +634,10 @@ public class TEIFormatter {
             tei.append("\t\t\t\t\t</monogr>\n");
         }
 
+        if (!StringUtils.isEmpty(doc.getMD5())) {
+            tei.append("\t\t\t\t\t<idno type=\"MD5\">" + doc.getMD5() + "</idno>\n");
+        }
+
         if (!StringUtils.isEmpty(biblio.getDOI())) {
             String theDOI = TextUtilities.HTMLEncode(biblio.getDOI());
             if (theDOI.endsWith(".xml")) {

--- a/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
@@ -388,9 +388,11 @@ public class CitationParser extends AbstractParser {
     }
 
     public List<BibDataSet> processingReferenceSection(File input,
+                                                       String md5Str,
                                                        ReferenceSegmenter referenceSegmenter,
                                                        int consolidate) {
         DocumentSource documentSource = DocumentSource.fromPdf(input);
+        documentSource.setMD5(md5Str);
         return processingReferenceSection(documentSource, referenceSegmenter, consolidate);
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
@@ -256,7 +256,23 @@ public class Engine implements Closeable {
      */
     public List<BibDataSet> processReferences(File inputFile, int consolidate) {
         return parsers.getCitationParser()
-			.processingReferenceSection(inputFile, parsers.getReferenceSegmenterParser(), consolidate);
+            .processingReferenceSection(inputFile, null, parsers.getReferenceSegmenterParser(), consolidate);
+    }
+
+    /**
+     * Apply a parsing model to the reference block of a PDF file based on CRF
+     *
+     * @param inputFile   the path of the PDF file to be processed
+     * @param md5Str      MD5 digest of the PDF file to be processed
+     * @param consolidate the consolidation option allows GROBID to exploit Crossref web services for improving header
+     *                    information. 0 (no consolidation, default value), 1 (consolidate the citation and inject extra
+     *                    metadata) or 2 (consolidate the citation and inject DOI only)
+     * @return the list of parsed references as bibliographical objects enriched
+     *         with citation contexts
+     */
+    public List<BibDataSet> processReferences(File inputFile, String md5Str, int consolidate) {
+        return parsers.getCitationParser()
+			.processingReferenceSection(inputFile, md5Str, parsers.getReferenceSegmenterParser(), consolidate);
     }
 
     /**
@@ -357,7 +373,36 @@ public class Engine implements Closeable {
             .consolidateHeader(consolidate)
             .includeRawAffiliations(includeRawAffiliations)
             .build();
-        return processHeader(inputFile, config, result);
+        return processHeader(inputFile, null, config, result);
+    }
+
+    /**
+     * Apply a parsing model for the header of a PDF file based on CRF, using
+     * first three pages of the PDF
+     *
+     * @param inputFile   the path of the PDF file to be processed
+     * @param md5Str      MD5 digest of the processed file
+     * @param consolidate the consolidation option allows GROBID to exploit Crossref web services for improving header
+     *                    information. 0 (no consolidation, default value), 1 (consolidate the citation and inject extra
+     *                    metadata) or 2 (consolidate the citation and inject DOI only)
+     * @param result      bib result
+     * @return the TEI representation of the extracted bibliographical
+     *         information
+     */
+    public String processHeader(
+        String inputFile,
+        String md5Str,
+        int consolidate,
+        boolean includeRawAffiliations,
+        BiblioItem result
+    ) {
+        GrobidAnalysisConfig config = new GrobidAnalysisConfig.GrobidAnalysisConfigBuilder()
+            .startPage(0)
+            .endPage(2)
+            .consolidateHeader(consolidate)
+            .includeRawAffiliations(includeRawAffiliations)
+            .build();
+        return processHeader(inputFile, md5Str, config, result);
     }
 
     /**
@@ -365,16 +410,23 @@ public class Engine implements Closeable {
      * dynamic range of pages as header
      *
      * @param inputFile   : the path of the PDF file to be processed
+     * @param consolidate the consolidation option allows GROBID to exploit Crossref web services for improving header
+     *                    information. 0 (no consolidation, default value), 1 (consolidate the citation and inject extra
+     *                    metadata) or 2 (consolidate the citation and inject DOI only)
      * @param result      bib result
      *
      * @return the TEI representation of the extracted bibliographical
      *         information
      */
     public String processHeader(String inputFile, int consolidate, BiblioItem result) {
-        return processHeader(inputFile, GrobidAnalysisConfig.defaultInstance(), result);
+        return processHeader(inputFile, null, GrobidAnalysisConfig.defaultInstance(), result);
     }
 
     public String processHeader(String inputFile, GrobidAnalysisConfig config, BiblioItem result) {
+        return processHeader(inputFile, null, config, result);
+    }
+
+    public String processHeader(String inputFile, String md5Str, GrobidAnalysisConfig config, BiblioItem result) {
         // normally the BiblioItem reference must not be null, but if it is the
         // case, we still continue
         // with a new instance, so that the resulting TEI string is still
@@ -382,7 +434,7 @@ public class Engine implements Closeable {
         if (result == null) {
             result = new BiblioItem();
         }
-        Pair<String, Document> resultTEI = parsers.getHeaderParser().processing(new File(inputFile), result, config);
+        Pair<String, Document> resultTEI = parsers.getHeaderParser().processing(new File(inputFile), md5Str, result, config);
         return resultTEI.getLeft();
     }
 
@@ -444,16 +496,35 @@ public class Engine implements Closeable {
      */
     public String fullTextToTEI(File inputFile,
                                 GrobidAnalysisConfig config) throws Exception {
-        return fullTextToTEIDoc(inputFile, config).getTei();
+        return fullTextToTEIDoc(inputFile, null, config).getTei();
+    }
+
+    /**
+     *
+     * //TODO: remove invalid JavaDoc once refactoring is done and tested (left for easier reference)
+     * Parse and convert the current article into TEI, this method performs the
+     * whole parsing and conversion process. If onlyHeader is true, than only
+     * the tei header data will be created.
+     *
+     * @param inputFile            - absolute path to the pdf to be processed
+     * @param md5Str               - MD5 digest of the PDF file to be processed
+     * @param config               - Grobid config
+     * @return the resulting structured document as a TEI string.
+     */
+    public String fullTextToTEI(File inputFile,
+                                String md5Str,
+                                GrobidAnalysisConfig config) throws Exception {
+        return fullTextToTEIDoc(inputFile, md5Str, config).getTei();
     }
 
     public Document fullTextToTEIDoc(File inputFile,
+                                     String md5Str,
                                      GrobidAnalysisConfig config) throws Exception {
         FullTextParser fullTextParser = parsers.getFullTextParser();
         Document resultDoc;
         LOGGER.debug("Starting processing fullTextToTEI on " + inputFile);
         long time = System.currentTimeMillis();
-        resultDoc = fullTextParser.processing(inputFile, config);
+        resultDoc = fullTextParser.processing(inputFile, md5Str, config);
         LOGGER.debug("Ending processing fullTextToTEI on " + inputFile + ". Time to process: "
 			+ (System.currentTimeMillis() - time) + "ms");
         return resultDoc;

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -106,10 +106,12 @@ public class FullTextParser extends AbstractParser {
     }
 
 	public Document processing(File inputPdf,
+                               String md5Str,
 							   GrobidAnalysisConfig config) throws Exception {
 		DocumentSource documentSource =
 			DocumentSource.fromPdf(inputPdf, config.getStartPage(), config.getEndPage(),
 				config.getPdfAssetPath() != null, true, false);
+        documentSource.setMD5(md5Str);
 		return processing(documentSource, config);
 	}
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -95,10 +95,11 @@ public class HeaderParser extends AbstractParser {
     /**
      * Processing with application of the segmentation model
      */
-    public Pair<String, Document> processing(File input, BiblioItem resHeader, GrobidAnalysisConfig config) {
+    public Pair<String, Document> processing(File input, String md5Str, BiblioItem resHeader, GrobidAnalysisConfig config) {
         DocumentSource documentSource = null;
         try {
             documentSource = DocumentSource.fromPdf(input, config.getStartPage(), config.getEndPage());
+            documentSource.setMD5(md5Str);
             Document doc = parsers.getSegmentationParser().processing(documentSource, config);
 
             String tei = processingHeaderSection(config, doc, resHeader, true);

--- a/grobid-core/src/main/java/org/grobid/core/engines/ProcessEngine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/ProcessEngine.java
@@ -577,7 +577,7 @@ public class ProcessEngine implements Closeable {
                             .generateTeiCoordinates(elementWithCoords)
                             .build();
 
-                    Document teiDoc = getEngine().fullTextToTEIDoc(currPDF, config);
+                    Document teiDoc = getEngine().fullTextToTEIDoc(currPDF, null, config);
                     document = PDDocument.load(currPDF);
                     //If no pages, skip the document
                     if (document.getNumberOfPages() > 0) {

--- a/grobid-core/src/main/java/org/grobid/core/visualization/BlockVisualizer.java
+++ b/grobid-core/src/main/java/org/grobid/core/visualization/BlockVisualizer.java
@@ -35,27 +35,9 @@ import static org.grobid.core.layout.VectorGraphicBoxCalculator.mergeBoxes;
  */
 public class BlockVisualizer {
 
-    public static void main(String[] args) {
+    /*public static void main(String[] args) {
         try {
-//            File input = new File("/Work/temp/context/coords/2.pdf");
-//            File input = new File("/Work/temp/figureExtraction/vector/5.pdf");
-//            File input = new File("/Work/temp/figureExtraction/6.pdf");
-//            File input = new File("/Work/temp/context/1000k/AS_97568985976833_1400273667294.pdf");
-//            File input = new File("/Work/temp/figureExtraction/newtest/3.pdf");
-//            File input = new File("/Users/zholudev/Downloads/pone.0005635.pdf");
-//            File input = new File("/Work/temp/figureExtraction/newtest/1.pdf");
-//            File input = new File("/Users/zholudev/Downloads/TIA_2011_Partie8.pdf");
-
-            //small vector things in text
-
-//            File input = new File("/Users/zholudev/Downloads/AS-355068814610434@1461666410721_content_1.pdf");
-//            File input = new File("/Users/zholudev/Downloads/AS-347805261549578@1459934645097_content_1.pdf");
             File input = new File("/Users/zholudev/Downloads/AS-301642189688834@1448928510544_content_1.pdf");
-
-//
-//
-//
-// File input = new File("/Users/zholudev/Downloads/journal.pone.0146695.pdf");
 
             final PDDocument document = PDDocument.load(input);
             File outPdf = new File("/tmp/test.pdf");
@@ -68,14 +50,11 @@ public class BlockVisualizer {
                     .pdfAssetPath(new File("/tmp/x"))
                     .build();
 
-//            File tempFile = File.createTempFile("temp", ".xml", new File("/tmp"));
             DocumentSource documentSource = DocumentSource.fromPdf(input);
-
 
             Document teiDoc = engine.fullTextToTEIDoc(input, config);
 
             PDDocument out = annotateBlocks(document, documentSource.getXmlFile(), teiDoc, false, false, true);
-//            PDDocument out = annotateBlocks(document, documentSource.getXmlFile(), null);
 
             if (out != null) {
                 out.save(outPdf);
@@ -90,7 +69,7 @@ public class BlockVisualizer {
             System.exit(1);
         }
 
-    }
+    }*/
 
     public static PDDocument annotateBlocks(PDDocument document, File xmlFile, Document teiDoc,
                                             boolean visualizeBlocks,

--- a/grobid-core/src/test/java/org/grobid/core/engines/EngineTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/EngineTest.java
@@ -686,7 +686,7 @@ public class EngineTest {
 //        System.out.println(resHeader.getAbstract());
 //
         Document d =
-                engine.fullTextToTEIDoc(input, GrobidAnalysisConfig.defaultInstance());
+                engine.fullTextToTEIDoc(input, null, GrobidAnalysisConfig.defaultInstance());
 
         d.getBlocks();
         System.out.println(d.getTei());
@@ -699,7 +699,7 @@ public class EngineTest {
     public void testEmailPDF() throws Exception {
         Engine engine = GrobidFactory.getInstance().getEngine();
         BiblioItem resHeader = new BiblioItem();
-        engine.getParsers().getHeaderParser().processing(new File("/Work/temp/1.pdf"), resHeader, GrobidAnalysisConfig.defaultInstance());
+        engine.getParsers().getHeaderParser().processing(new File("/Work/temp/1.pdf"), null, resHeader, GrobidAnalysisConfig.defaultInstance());
         System.out.println(resHeader);
 //        System.out.println(engine.fullTextToTEI("/tmp/2.pdf", false, false));
 

--- a/grobid-core/src/test/java/org/grobid/core/test/TestFullTextParser.java
+++ b/grobid-core/src/test/java/org/grobid/core/test/TestFullTextParser.java
@@ -46,7 +46,7 @@ public class TestFullTextParser extends EngineTest {
     public void testFullTextParser_1() throws Exception {
         File inputTmpFile = getInputDocument("/test/Wang-paperAVE2008.pdf");
 
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
         assertTei(tei);
     }
 
@@ -64,35 +64,35 @@ public class TestFullTextParser extends EngineTest {
     public void testFullTextParser_2() throws Exception {
         File inputTmpFile = getInputDocument("/test/two_pages.pdf");
 
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
         assertTei(tei);
     }
 
     @Test
     public void testFullTextParser_3() throws Exception {
         File inputTmpFile = getInputDocument("/test/MullenJSSv18i03.pdf");
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
         assertTei(tei);
     }
 
     @Test
     public void testFullTextParser_4() throws Exception {
         File inputTmpFile = getInputDocument("/test/1001._0908.0054.pdf");
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
         assertTei(tei);
     }
 
     @Test
     public void testFullTextParser_5() throws Exception {
         File inputTmpFile = getInputDocument("/test/submission_161.pdf");
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
         assertTei(tei);
     }
 
     @Test
     public void testFullTextParser_6() throws Exception {
         File inputTmpFile = getInputDocument("/test/submission_363.pdf");
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
         assertTei(tei);
     }
 

--- a/grobid-core/src/test/java/org/grobid/core/visualization/TestCitationsVisualizer.java
+++ b/grobid-core/src/test/java/org/grobid/core/visualization/TestCitationsVisualizer.java
@@ -37,7 +37,7 @@ public class TestCitationsVisualizer {
     public void testJSONAnnotationStructure() throws Exception {
         Engine engine = GrobidFactory.getInstance().getEngine();
         File inputTmpFile = getInputDocument("/test/test_Grobid_1_05452615.pdf");
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
 
         String refURL = "http://example.com/xyz";
         List<String> refURLs = Arrays.asList(refURL);
@@ -91,7 +91,7 @@ public class TestCitationsVisualizer {
     public void testJSONAnnotationEscaping() throws Exception {
         Engine engine = GrobidFactory.getInstance().getEngine();
         File inputTmpFile = getInputDocument("/test/test_Grobid_1_05452615.pdf");
-        Document tei = engine.fullTextToTEIDoc(inputTmpFile, GrobidAnalysisConfig.defaultInstance());
+        Document tei = engine.fullTextToTEIDoc(inputTmpFile, null, GrobidAnalysisConfig.defaultInstance());
 
         // check that this embedded backslash is escaped properly
         String refURL = "http://example.com/xyz?a=ab\\c123";


### PR DESCRIPTION
Compute the MD5 digest of a PDF file processed by the web services and add it in the resulting TEI.

see #740

MD5 is processed when the file is loaded by the service (very nice feature of Java!). To avoid reading an extra time the PDF files, we don't compute MD5 digests for the batch/command lines, so it's a web service only feature. 
 