### PR TITLE
Finalize getting Layout token lists for header fields

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -14,15 +14,11 @@ import org.grobid.core.layout.BoundingBox;
 import org.grobid.core.layout.LayoutToken;
 import org.grobid.core.tokenization.TaggingTokenCluster;
 import org.grobid.core.tokenization.TaggingTokenClusteror;
-import org.grobid.core.utilities.LayoutTokensUtil;
 import org.grobid.core.engines.label.TaggingLabel;
-import org.grobid.core.engines.label.TaggingLabels;
-import org.grobid.core.engines.tagging.GenericTaggerUtils;
 import org.grobid.core.lexicon.Lexicon;
 import org.grobid.core.utilities.LanguageUtilities;
 import org.grobid.core.utilities.TextUtilities;
 import org.grobid.core.utilities.KeyGen;
-import org.grobid.core.utilities.Pair;
 import org.grobid.core.GrobidModels;
 
 import java.net.URLEncoder;
@@ -52,6 +48,13 @@ public class BiblioItem {
 
     // map of labels (e.g. <title> or <abstract>) to LayoutToken
     private Map<String, List<LayoutToken>> labeledTokens;
+
+    /**
+     * This is an internal structure not meant to be used outside. This is also modified with respect of other structures
+     * For collecting layout tokens of the various bibliographical component, please refers to @See(getLayoutTokens(TaggingLabels label)
+     */
+    private List<LayoutToken> authorsLayoutTokensworkingCopy = new ArrayList<>();
+
 
     @Override
     public String toString() {
@@ -1171,6 +1174,15 @@ public class BiblioItem {
     // temp
     public void setAuthors(String aut) {
         authors = aut;
+    }
+
+    public BiblioItem addAuthorsToken(LayoutToken lt) {
+        authorsLayoutTokensworkingCopy.add(lt);
+        return this;
+    }
+
+    public void addAuthorsTokens(List<LayoutToken> layoutTokens) {
+        this.authorsLayoutTokensworkingCopy.addAll(layoutTokens);
     }
 
     public void addAuthor(String aut) {
@@ -4617,4 +4629,7 @@ public class BiblioItem {
         }
     }
 
+    public List<LayoutToken> getAuthorsWorkingCopyTokens() {
+        return authorsLayoutTokensworkingCopy;
+    }
 }

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -53,7 +53,7 @@ public class BiblioItem {
      * This is an internal structure not meant to be used outside. This is also modified with respect of other structures
      * For collecting layout tokens of the various bibliographical component, please refers to @See(getLayoutTokens(TaggingLabels label)
      */
-    private List<LayoutToken> authorsLayoutTokensworkingCopy = new ArrayList<>();
+    private List<LayoutToken> authorsTokensWorkingCopy = new ArrayList<>();
 
 
     @Override
@@ -1176,13 +1176,13 @@ public class BiblioItem {
         authors = aut;
     }
 
-    public BiblioItem addAuthorsToken(LayoutToken lt) {
-        authorsLayoutTokensworkingCopy.add(lt);
+    public BiblioItem collectAuthorsToken(LayoutToken lt) {
+        authorsTokensWorkingCopy.add(lt);
         return this;
     }
 
-    public void addAuthorsTokens(List<LayoutToken> layoutTokens) {
-        this.authorsLayoutTokensworkingCopy.addAll(layoutTokens);
+    public void collectAuthorsTokens(List<LayoutToken> layoutTokens) {
+        this.authorsTokensWorkingCopy.addAll(layoutTokens);
     }
 
     public void addAuthor(String aut) {
@@ -4629,7 +4629,7 @@ public class BiblioItem {
         }
     }
 
-    public List<LayoutToken> getAuthorsWorkingCopyTokens() {
-        return authorsLayoutTokensworkingCopy;
+    public List<LayoutToken> getAuthorsTokensWorkingCopy() {
+        return authorsTokensWorkingCopy;
     }
 }

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -53,10 +53,6 @@ public class BiblioItem {
     // map of labels (e.g. <title> or <abstract>) to LayoutToken
     private Map<String, List<LayoutToken>> labeledTokens;
 
-    private List<LayoutToken> titleLayoutTokens = new ArrayList<>();
-    private List<LayoutToken> authorsLayoutTokens = new ArrayList<>();
-    private List<LayoutToken> abstractLayoutTokens = new ArrayList<>();
-
     @Override
     public String toString() {
         return "BiblioItem{" +
@@ -1175,15 +1171,6 @@ public class BiblioItem {
     // temp
     public void setAuthors(String aut) {
         authors = aut;
-    }
-
-    public BiblioItem addAuthorsToken(LayoutToken lt) {
-        authorsLayoutTokens.add(lt);
-        return this;
-    }
-
-    public List<LayoutToken> getAuthorsTokens() {
-        return authorsLayoutTokens;
     }
 
     public void addAuthor(String aut) {
@@ -4606,7 +4593,7 @@ public class BiblioItem {
         labeledTokens.put(headerLabel.getLabel(), tokens);
     }
 
-    public void generalResultMapping(Document doc, String labeledResult, List<LayoutToken> tokenizations) {
+    public void generalResultMapping(String labeledResult, List<LayoutToken> tokenizations) {
         if (labeledTokens == null)
             labeledTokens = new TreeMap<>();
 
@@ -4630,19 +4617,4 @@ public class BiblioItem {
         }
     }
 
-    public void addTitleTokens(List<LayoutToken> layoutTokens) {
-        this.titleLayoutTokens.addAll(layoutTokens);
-    }
-
-    public void addAuthorsTokens(List<LayoutToken> layoutTokens) {
-        this.authorsLayoutTokens.addAll(layoutTokens);
-    }
-
-    public void addAbstractTokens(List<LayoutToken> layoutTokens) {
-        this.abstractLayoutTokens.addAll(layoutTokens);
-    }
-
-    public List<LayoutToken> getAbstractTokens() {
-        return this.abstractLayoutTokens;
-    }
 }

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -51,7 +51,7 @@ public class BiblioItem {
     private List<BoundingBox> coordinates = null;
 
     // map of labels (e.g. <title> or <abstract>) to LayoutToken
-    private Map<String, List<LayoutToken>> labeledTokens = new HashMap<>();
+    private Map<String, List<LayoutToken>> labeledTokens;
 
     private List<LayoutToken> titleLayoutTokens = new ArrayList<>();
     private List<LayoutToken> authorsLayoutTokens = new ArrayList<>();
@@ -4606,7 +4606,7 @@ public class BiblioItem {
         labeledTokens.put(headerLabel.getLabel(), tokens);
     }
 
-    public void generalResultMapping(String labeledResult, List<LayoutToken> tokenizations) {
+    public void generalResultMapping(Document doc, String labeledResult, List<LayoutToken> tokenizations) {
         if (labeledTokens == null)
             labeledTokens = new TreeMap<>();
 
@@ -4632,18 +4632,6 @@ public class BiblioItem {
 
     public void addTitleTokens(List<LayoutToken> layoutTokens) {
         this.titleLayoutTokens.addAll(layoutTokens);
-    }
-
-    public List<LayoutToken> getTitleLayoutTokens() {
-        return titleLayoutTokens;
-    }
-
-    public List<LayoutToken> getAuthorsLayoutTokens() {
-        return authorsLayoutTokens;
-    }
-
-    public List<LayoutToken> getAbstractLayoutTokens() {
-        return abstractLayoutTokens;
     }
 
     public void addAuthorsTokens(List<LayoutToken> layoutTokens) {

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -51,7 +51,7 @@ public class BiblioItem {
     private List<BoundingBox> coordinates = null;
 
     // map of labels (e.g. <title> or <abstract>) to LayoutToken
-    private Map<String, List<LayoutToken>> labeledTokens;
+    private Map<String, List<LayoutToken>> labeledTokens = new HashMap<>();
 
     private List<LayoutToken> titleLayoutTokens = new ArrayList<>();
     private List<LayoutToken> authorsLayoutTokens = new ArrayList<>();
@@ -4556,7 +4556,7 @@ public class BiblioItem {
 		// normally properties authors and authorList are null in the current Grobid version
 		if (!titleSet && !authorSet && (url == null) && (doi == null))
 			return true;
-		else 
+		else
 			return false;
 	}
 
@@ -4606,7 +4606,7 @@ public class BiblioItem {
         labeledTokens.put(headerLabel.getLabel(), tokens);
     }
 
-    public void generalResultMapping(Document doc, String labeledResult, List<LayoutToken> tokenizations) {
+    public void generalResultMapping(String labeledResult, List<LayoutToken> tokenizations) {
         if (labeledTokens == null)
             labeledTokens = new TreeMap<>();
 
@@ -4624,16 +4624,26 @@ public class BiblioItem {
             List<LayoutToken> clusterTokens = cluster.concatTokens();
             List<LayoutToken> theList = labeledTokens.get(clusterLabel.getLabel());
 
-            if (theList == null)
-                theList = new ArrayList<>();
-            for (LayoutToken token : clusterTokens)
-                theList.add(token);
+            theList = theList == null ? new ArrayList<>() : theList;
+            theList.addAll(clusterTokens);
             labeledTokens.put(clusterLabel.getLabel(), theList);
         }
     }
 
     public void addTitleTokens(List<LayoutToken> layoutTokens) {
         this.titleLayoutTokens.addAll(layoutTokens);
+    }
+
+    public List<LayoutToken> getTitleLayoutTokens() {
+        return titleLayoutTokens;
+    }
+
+    public List<LayoutToken> getAuthorsLayoutTokens() {
+        return authorsLayoutTokens;
+    }
+
+    public List<LayoutToken> getAbstractLayoutTokens() {
+        return abstractLayoutTokens;
     }
 
     public void addAuthorsTokens(List<LayoutToken> layoutTokens) {

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -21,7 +21,6 @@ import org.grobid.core.engines.label.TaggingLabel;
 import org.grobid.core.exceptions.GrobidException;
 import org.grobid.core.exceptions.GrobidExceptionStatus;
 import org.grobid.core.features.FeatureFactory;
-import org.grobid.core.features.FeaturesVectorHeader;
 import org.grobid.core.layout.Block;
 import org.grobid.core.layout.BoundingBox;
 import org.grobid.core.layout.Cluster;
@@ -71,7 +70,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
@@ -829,7 +827,7 @@ public class Document implements Serializable {
         if (documentParts == null)
             return null;
 
-        List<LayoutToken> tokenizationParts = new ArrayList<LayoutToken>();
+        List<LayoutToken> tokenizationParts = new ArrayList<>();
         for (DocumentPiece docPiece : documentParts) {
             DocumentPointer dp1 = docPiece.getLeft();
             DocumentPointer dp2 = docPiece.getRight();

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -186,8 +186,7 @@ public class FullTextParser extends AbstractParser {
 
             // structure the abstract using the fulltext model
             if (isNotBlank(resHeader.getAbstract())) {
-                //List<LayoutToken> abstractTokens = resHeader.getLayoutTokens(TaggingLabels.HEADER_ABSTRACT);
-                List<LayoutToken> abstractTokens = resHeader.getAbstractTokens();
+                List<LayoutToken> abstractTokens = resHeader.getLayoutTokens(TaggingLabels.HEADER_ABSTRACT);
                 if (CollectionUtils.isNotEmpty(abstractTokens)) {
                     abstractTokens = BiblioItem.cleanAbstractLayoutTokens(abstractTokens);
                     Pair<String, List<LayoutToken>> abstractProcessed = processShort(abstractTokens, doc);

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -170,7 +170,7 @@ public class HeaderParser extends AbstractParser {
                 boolean hasMarker = false;
                 List<Integer> authorsBlocks = new ArrayList<>();
                 List<List<LayoutToken>> authorSegments = new ArrayList<>();
-                List<LayoutToken> authorLayoutTokens = resHeader.getAuthorsWorkingCopyTokens();
+                List<LayoutToken> authorLayoutTokens = resHeader.getAuthorsTokensWorkingCopy();
                 if (isNotEmpty(authorLayoutTokens)) {
                     // split the list of layout tokens when token "\t" is met
                     List<LayoutToken> currentSegment = new ArrayList<>();
@@ -794,15 +794,15 @@ public class HeaderParser extends AbstractParser {
                 if (biblio.getAuthors() != null) {
                     biblio.setAuthors(biblio.getAuthors() + "\t" + clusterNonDehypenizedContent);
                     //biblio.addAuthorsToken(new LayoutToken("\n", TaggingLabels.HEADER_AUTHOR));
-                    biblio.addAuthorsToken(new LayoutToken("\t", TaggingLabels.HEADER_AUTHOR));
+                    biblio.collectAuthorsToken(new LayoutToken("\t", TaggingLabels.HEADER_AUTHOR));
 
                     List<LayoutToken> tokens = cluster.concatTokens();
-                    biblio.addAuthorsTokens(tokens);
+                    biblio.collectAuthorsTokens(tokens);
                 } else {
                     biblio.setAuthors(clusterNonDehypenizedContent);
 
                     List<LayoutToken> tokens = cluster.concatTokens();
-                    biblio.addAuthorsTokens(tokens);
+                    biblio.collectAuthorsTokens(tokens);
                 }
             } /*else if (clusterLabel.equals(TaggingLabels.HEADER_TECH)) {
                 biblio.setItem(BiblioItem.TechReport);

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -1,61 +1,40 @@
 package org.grobid.core.engines;
 
-import com.google.common.base.Splitter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.grobid.core.GrobidModels;
 import org.grobid.core.data.BiblioItem;
 import org.grobid.core.data.Date;
-import org.grobid.core.data.Affiliation;
 import org.grobid.core.data.Keyword;
 import org.grobid.core.data.Person;
-import org.grobid.core.document.Document;
-import org.grobid.core.document.DocumentPiece;
-import org.grobid.core.document.DocumentPointer;
-import org.grobid.core.document.DocumentSource;
-import org.grobid.core.document.TEIFormatter;
+import org.grobid.core.document.*;
 import org.grobid.core.engines.config.GrobidAnalysisConfig;
 import org.grobid.core.engines.label.SegmentationLabels;
 import org.grobid.core.engines.label.TaggingLabel;
 import org.grobid.core.engines.label.TaggingLabels;
 import org.grobid.core.exceptions.GrobidException;
-import org.grobid.core.exceptions.GrobidExceptionStatus;
 import org.grobid.core.features.FeatureFactory;
 import org.grobid.core.features.FeaturesVectorHeader;
 import org.grobid.core.lang.Language;
-import org.grobid.core.lexicon.Lexicon;
 import org.grobid.core.layout.Block;
-import org.grobid.core.layout.BoundingBox;
 import org.grobid.core.layout.LayoutToken;
-import org.grobid.core.layout.PDFAnnotation;
+import org.grobid.core.lexicon.Lexicon;
 import org.grobid.core.tokenization.LabeledTokensContainer;
 import org.grobid.core.tokenization.TaggingTokenCluster;
 import org.grobid.core.tokenization.TaggingTokenClusteror;
-import org.grobid.core.utilities.Consolidation;
-import org.grobid.core.utilities.GrobidProperties;
-import org.grobid.core.utilities.LanguageUtilities;
-import org.grobid.core.utilities.OffsetPosition;
-import org.grobid.core.utilities.LayoutTokensUtil;
-import org.grobid.core.utilities.TextUtilities;
+import org.grobid.core.utilities.*;
 import org.grobid.core.utilities.counters.CntManager;
-import org.grobid.core.GrobidModels.Collection;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 
@@ -822,15 +801,6 @@ public class HeaderParser extends AbstractParser {
 
             String clusterContent = LayoutTokensUtil.normalizeDehyphenizeText(cluster.concatTokens());
             String clusterNonDehypenizedContent = LayoutTokensUtil.toText(cluster.concatTokens());
-
-            List<LayoutToken> clusterTokens = cluster.concatTokens();
-            List<LayoutToken> theList = biblio.getLabeledTokens().get(clusterLabel.getLabel());
-
-            theList = theList == null ? new ArrayList<>() : theList;
-            theList.addAll(clusterTokens);
-
-            biblio.getLabeledTokens().put(clusterLabel.getLabel(), theList);
-
             if (clusterLabel.equals(TaggingLabels.HEADER_TITLE)) {
                 /*if (biblio.getTitle() != null && isDifferentContent(biblio.getTitle(), clusterContent))
                     biblio.setTitle(biblio.getTitle() + clusterContent);

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -1,40 +1,21 @@
 package org.grobid.core.utilities;
 
-import org.apache.commons.io.IOUtils;
+import com.rockymadden.stringmetric.similarity.RatcliffObershelpMetric;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.commons.collections4.CollectionUtils;
-
-import org.grobid.core.data.BiblioItem;
 import org.grobid.core.data.BibDataSet;
-import org.grobid.core.exceptions.GrobidException;
-import org.grobid.core.sax.CrossrefUnixrefSaxParser;
-import org.grobid.core.utilities.crossref.*;
-import org.grobid.core.utilities.glutton.*;
+import org.grobid.core.data.BiblioItem;
 import org.grobid.core.utilities.counters.CntManager;
-
+import org.grobid.core.utilities.crossref.CrossrefClient;
+import org.grobid.core.utilities.crossref.CrossrefRequestListener;
+import org.grobid.core.utilities.crossref.WorkDeserializer;
+import org.grobid.core.utilities.glutton.GluttonClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.xml.sax.InputSource;
-import org.xml.sax.helpers.DefaultHandler;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.List;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.StringTokenizer;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.HashMap;
-
-import com.rockymadden.stringmetric.similarity.RatcliffObershelpMetric;
 import scala.Option;
+
+import java.util.*;
 
 /**
  * Singleton class for managing the extraction of bibliographical information from pdf documents.
@@ -308,7 +289,7 @@ public class Consolidation {
 
                 @Override
                 public void onError(int status, String message, Exception exception) {
-                    LOGGER.info("Consolidation service returns error ("+status+") : "+message);
+                    LOGGER.info("Consolidation service returns error ("+status+") : "+message, exception);
                 }
             });
         } catch(Exception e) {


### PR DESCRIPTION
In this PR, I 
 ~~- added a method to fill up the layoutTokens map that contains the layout tokens of the various component (title, abstract, etc..) and it's filled up when the clusteror is processed~~
~~- added getter of `titleLayoutToken`, `abstractLayoutToken` and `authorsLayoutToken` lists. 
(probably these two items are duplicated but they are used in different part so I did not feel like to remove one of them...~~

 - call the method `generalResultMapping()` in `resultExtraction` of HeaderParser 
 - remove lists of layout tokens for abstract, title and authors, from the BiblioItem class
 - various cosmetic improvements, removed some not-needed nulls-checks
 - removed unused parameters in certain methods
 - added a way to better understand the exception when calling glutton 

The use case is that I process the header to get, let's say title, abstract, keywords and I want to process through their layout tokens.. 

**Update**: See [comment](https://github.com/kermitt2/grobid/pull/746#issuecomment-824442101)