### PR TITLE
improving methods that clean doi for consolidation

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -1004,50 +1004,47 @@ public class BiblioItem {
         }
     }
 
-    private static String cleanDOI(String bibl) {
-        if (bibl != null) {
-            bibl = StringUtils.normalizeSpace(bibl);
-            bibl = bibl.replace(" ", "");
-
-            if (bibl.startsWith("http://dx.doi.org/") || 
-                bibl.startsWith("https://dx.doi.org/") || 
-                bibl.startsWith("http://doi.org/") || 
-                bibl.startsWith("https://doi.org/")) {
-                bibl = bibl.replaceAll("http(s)?\\://(dx\\.)?doi\\.org/", "");
-            }
-
-            //bibl = bibl.replace("//", "/");
-            if (bibl.toLowerCase().startsWith("doi:") || bibl.toLowerCase().startsWith("doi/")) {
-                bibl = bibl.substring(4);
-            } 
-            if (bibl.toLowerCase().startsWith("doi")) {
-                bibl = bibl.substring(3);
-            }
-            // pretty common wrong extraction pattern: 
-            // 43-61.DOI:10.1093/jpepsy/14.1.436/7
-            // 367-74.DOI:10.1080/14034940210165064
-            // (pages concatenated to the DOI) - easy/safe to fix
-            if ( (bibl.indexOf("DOI:10.") != -1) || (bibl.indexOf("doi:10.") != -1) ) {
-                int ind = bibl.indexOf("DOI:10.");
-                if (ind == -1) 
-                    ind = bibl.indexOf("doi:10.");
-                bibl = bibl.substring(ind+4);
-            }
-
-            // for DOI coming from PDF links, we have some prefix cleaning to make 
-            if (bibl.startsWith("file://") || bibl.startsWith("https://") || bibl.startsWith("http://")) {
-                int ind = bibl.indexOf("/10.");
-                if (ind != -1)
-                    bibl = bibl.substring(ind+1);
-            }
-            
-            bibl = bibl.trim();
-            int ind = bibl.indexOf("http://");
-            if (ind != -1 && ind > 10) {
-                bibl = bibl.substring(0,ind);
-            }
+    public static String cleanDOI(String doi) {
+        if (doi == null) {
+            return doi;
         }
-        return bibl;
+
+        doi = StringUtils.normalizeSpace(doi);
+        doi = doi.replace(" ", "");
+        doi = doi.replaceAll("https?\\://(dx\\.)?doi\\.org/", "");
+
+        //bibl = bibl.replace("//", "/");
+        if (doi.toLowerCase().startsWith("doi:") || doi.toLowerCase().startsWith("doi/")) {
+            doi = doi.substring(4);
+        }
+        if (doi.toLowerCase().startsWith("doi")) {
+            doi = doi.substring(3);
+        }
+        // pretty common wrong extraction pattern:
+        // 43-61.DOI:10.1093/jpepsy/14.1.436/7
+        // 367-74.DOI:10.1080/14034940210165064
+        // (pages concatenated to the DOI) - easy/safe to fix
+        if (StringUtils.containsIgnoreCase(doi, "doi:10.")) {
+            doi = doi.substring(StringUtils.indexOfIgnoreCase(doi, "doi:10.")+4);
+        }
+
+        // for DOI coming from PDF links, we have some prefix cleaning to make
+        if (doi.startsWith("file://") || doi.startsWith("https://") || doi.startsWith("http://")) {
+            int ind = doi.indexOf("/10.");
+            if (ind != -1)
+                doi = doi.substring(ind+1);
+        }
+
+        doi = doi.trim();
+        int ind = doi.indexOf("http://");
+        if (ind > 10) {
+            doi = doi.substring(0, ind);
+        }
+
+        doi = doi.replaceAll("[\\p{M}]", "");
+        doi = doi.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
+
+        return doi;
     }
 
     public void setArXivId(String id) {
@@ -4313,16 +4310,16 @@ public class BiblioItem {
     }
 
     /**
-     * Correct/add only the DOI of the first biblio item based on the second one 
+     * Correct/add identifiers of the first biblio item based on the second one
      */
-    public static void injectDOI(BiblioItem bib, BiblioItem bibo) {
-        bib.setDOI(bibo.getDOI());
+    public static void injectIdentifiers(BiblioItem destination, BiblioItem source) {
+        destination.setDOI(source.getDOI());
         // optionally associated strong identifiers are also injected
-        bib.setPMID(bibo.getPMID());
-        bib.setPMCID(bibo.getPMCID());
-        bib.setPII(bibo.getPII());
-        bib.setIstexId(bibo.getIstexId());
-        bib.setArk(bibo.getArk());
+        destination.setPMID(source.getPMID());
+        destination.setPMCID(source.getPMCID());
+        destination.setPII(source.getPII());
+        destination.setIstexId(source.getIstexId());
+        destination.setArk(source.getArk());
     }
 
     /**

--- a/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/CitationParser.java
@@ -38,10 +38,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.StringTokenizer;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Patrice Lopez
@@ -376,7 +374,7 @@ public class CitationParser extends AbstractParser {
                         if (consolidate == 1)
                             BiblioItem.correct(resCitation, bibo);
                         else if (consolidate == 2)
-                            BiblioItem.injectDOI(resCitation, bibo);
+                            BiblioItem.injectIdentifiers(resCitation, bibo);
                     }
                 }
             }
@@ -567,7 +565,7 @@ public class CitationParser extends AbstractParser {
                 if (consolidate == 1)
                     BiblioItem.correct(resCitation, bibo);
                 else if (consolidate == 2)
-                    BiblioItem.injectDOI(resCitation, bibo);
+                    BiblioItem.injectIdentifiers(resCitation, bibo);
             }
         } catch (Exception e) {
             LOGGER.error("An exception occurred while running bibliographical data consolidation.", e);

--- a/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/Engine.java
@@ -15,8 +15,6 @@
 
 package org.grobid.core.engines;
 
-import com.google.common.io.Files;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.grobid.core.data.Affiliation;
@@ -29,14 +27,10 @@ import org.grobid.core.data.Person;
 import org.grobid.core.document.Document;
 import org.grobid.core.document.DocumentSource;
 import org.grobid.core.engines.config.GrobidAnalysisConfig;
-import org.grobid.core.engines.label.SegmentationLabels;
 import org.grobid.core.exceptions.GrobidException;
-import org.grobid.core.exceptions.GrobidResourceException;
-import org.grobid.core.factory.GrobidFactory;
 import org.grobid.core.factory.GrobidPoolingFactory;
 import org.grobid.core.lang.Language;
 import org.grobid.core.utilities.Consolidation;
-import org.grobid.core.utilities.GrobidProperties;
 import org.grobid.core.utilities.LanguageUtilities;
 import org.grobid.core.utilities.Utilities;
 import org.grobid.core.utilities.counters.CntManager;
@@ -220,7 +214,7 @@ public class Engine implements Closeable {
                         if (consolidate == 1)
                             BiblioItem.correct(resCitation, bibo);
                         else if (consolidate == 2)
-                            BiblioItem.injectDOI(resCitation, bibo);
+                            BiblioItem.injectIdentifiers(resCitation, bibo);
                     }
                     finalResults.add(resCitation);
                 }

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -14,8 +14,6 @@ import org.grobid.core.data.BiblioItem;
 import org.grobid.core.data.Figure;
 import org.grobid.core.data.Table;
 import org.grobid.core.data.Equation;
-import org.grobid.core.data.Metadata;
-import org.grobid.core.data.Person;
 import org.grobid.core.document.Document;
 import org.grobid.core.document.DocumentPiece;
 import org.grobid.core.document.DocumentPointer;
@@ -55,12 +53,10 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.SortedSet;
 import java.util.StringTokenizer;
 import java.util.TreeSet;
@@ -221,7 +217,7 @@ public class FullTextParser extends AbstractParser {
                             if (config.getConsolidateCitations() == 1)
                                 BiblioItem.correct(resCitation, bibo);
                             else if (config.getConsolidateCitations() == 2)
-                                BiblioItem.injectDOI(resCitation, bibo);
+                                BiblioItem.injectIdentifiers(resCitation, bibo);
                         }
                     }
                 } catch(Exception e) {

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -1394,7 +1394,7 @@ public class HeaderParser extends AbstractParser {
                 if (consolidate == 1)
                     BiblioItem.correct(resHeader, bib);
                 else if (consolidate == 2)
-                    BiblioItem.injectDOI(resHeader, bib);
+                    BiblioItem.injectIdentifiers(resHeader, bib);
             }
         } catch (Exception e) {
             throw new GrobidException("An exception occured while running bibliographical data consolidation.", e);

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -17,6 +17,8 @@ import scala.Option;
 
 import java.util.*;
 
+import static org.grobid.core.data.BiblioItem.cleanDOI;
+
 /**
  * Singleton class for managing the extraction of bibliographical information from pdf documents.
  * When consolidation operations are realized, be sure to call the close() method
@@ -115,7 +117,7 @@ public class Consolidation {
 
         String theDOI = bib.getDOI();
         if (StringUtils.isNotBlank(theDOI)) {
-            theDOI = cleanDoi(theDOI);
+            theDOI = cleanDOI(theDOI);
         }
         final String doi = theDOI;
         String aut = bib.getFirstAuthorSurname();
@@ -327,7 +329,7 @@ public class Consolidation {
             // first we get the exploitable metadata
             String doi = theBiblio.getDOI();
             if (StringUtils.isNotBlank(doi)) {
-                doi = cleanDoi(doi);
+                doi = BiblioItem.cleanDOI(doi);
             }
             String aut = theBiblio.getFirstAuthorSurname();
             String title = theBiblio.getTitle();
@@ -608,24 +610,6 @@ public class Consolidation {
         else
             return false;
     }*/
-
-    /**
-     * This is a DOI cleaning specifically adapted to CrossRef call
-     */
-    protected static String cleanDoi(String doi) {
-        doi = doi.replace("\"", "");
-        doi = doi.replace("\n", "");
-        if (StringUtils.lowerCase(doi).startsWith("doi:") || StringUtils.lowerCase(doi).startsWith("doi/")) {
-            doi = doi.substring(4);
-            doi = doi.trim();
-        }
-        doi = doi.replaceAll("[\\p{M}]", "");
-        doi = doi.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
-
-        doi = doi.replace(" ", "");
-        return doi;
-    }
-
 
     /**
      * The new public CrossRef API is a search API, and thus returns

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -293,7 +293,7 @@ public class Consolidation {
                 }
             });
         } catch(Exception e) {
-            LOGGER.info("Consolidation error - ",e);
+            LOGGER.info("Consolidation error - ", e);
         }
 
         client.finish(threadId);

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -59,7 +59,7 @@ public class Consolidation {
                 }
             }
             throw new IllegalArgumentException("No consolidation service with name '" + name +
-                    "', possible values are: " + Arrays.toString(values()));
+                "', possible values are: " + Arrays.toString(values()));
         }
     }
 
@@ -84,9 +84,9 @@ public class Consolidation {
     private Consolidation() {
         if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON)
             client = GluttonClient.getInstance();
-        else 
+        else
             client = CrossrefClient.getInstance();
-        workDeserializer = new WorkDeserializer();   
+        workDeserializer = new WorkDeserializer();
     }
 
     public void setCntManager(CntManager cntManager) {
@@ -147,7 +147,7 @@ public class Consolidation {
         if (journalTitle != null) {
             journalTitle = TextUtilities.removeAccents(journalTitle);
         }*/
-        if (cntManager != null) 
+        if (cntManager != null)
             cntManager.i(ConsolidationCounters.CONSOLIDATION);
 
         long threadId = Thread.currentThread().getId();
@@ -155,39 +155,39 @@ public class Consolidation {
 
         if (StringUtils.isNotBlank(doi)) {
             // call based on the identified DOI
-            arguments = new HashMap<String,String>();
+            arguments = new HashMap<String, String>();
             arguments.put("doi", doi);
-        } 
+        }
         if (StringUtils.isNotBlank(rawCitation)) {
             // call with full raw string
             if (arguments == null)
-                arguments = new HashMap<String,String>();
-            if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
-                     StringUtils.isBlank(doi) )
+                arguments = new HashMap<String, String>();
+            if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                StringUtils.isBlank(doi))
                 arguments.put("query.bibliographic", rawCitation);
             //arguments.put("query", rawCitation);
         }
         if (StringUtils.isNotBlank(aut)) {
             // call based on partial metadata
             if (arguments == null)
-                arguments = new HashMap<String,String>();
-            if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
-                 (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
+                arguments = new HashMap<String, String>();
+            if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
                 arguments.put("query.author", aut);
         }
         if (StringUtils.isNotBlank(title)) {
             // call based on partial metadata
             if (arguments == null)
-                arguments = new HashMap<String,String>();
-            if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
-                (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
+                arguments = new HashMap<String, String>();
+            if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
                 arguments.put("query.title", title);
         }
         if (StringUtils.isNotBlank(journalTitle)) {
             // call based on partial metadata
             if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                 if (arguments == null)
-                    arguments = new HashMap<String,String>();
+                    arguments = new HashMap<String, String>();
                 arguments.put("query.container-title", journalTitle);
             }
         }
@@ -195,7 +195,7 @@ public class Consolidation {
             // call based on partial metadata
             if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                 if (arguments == null)
-                    arguments = new HashMap<String,String>();
+                    arguments = new HashMap<String, String>();
                 arguments.put("volume", volume);
             }
         }
@@ -203,7 +203,7 @@ public class Consolidation {
             // call based on partial metadata
             if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                 if (arguments == null)
-                    arguments = new HashMap<String,String>();
+                    arguments = new HashMap<String, String>();
                 arguments.put("firstPage", firstPage);
             }
         }
@@ -213,8 +213,8 @@ public class Consolidation {
         }
 
         if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) {
-            if (StringUtils.isBlank(doi) && StringUtils.isBlank(rawCitation) && 
-                 (StringUtils.isBlank(aut) || StringUtils.isBlank(title)) ) {
+            if (StringUtils.isBlank(doi) && StringUtils.isBlank(rawCitation) &&
+                (StringUtils.isBlank(aut) || StringUtils.isBlank(title))) {
                 // there's not enough information for a crossref request, which might always return a result
                 return null;
             }
@@ -236,7 +236,7 @@ public class Consolidation {
                 cntManager.i(ConsolidationCounters.CONSOLIDATION);
             }
 
-            if ( StringUtils.isNotBlank(doi) && (cntManager != null) ) {
+            if (StringUtils.isNotBlank(doi) && (cntManager != null)) {
                 cntManager.i(ConsolidationCounters.CONSOLIDATION_PER_DOI);
                 doiQuery = true;
             } else {
@@ -244,13 +244,13 @@ public class Consolidation {
             }
 
             client.<BiblioItem>pushRequest("works", arguments, workDeserializer, threadId, new CrossrefRequestListener<BiblioItem>(0) {
-                
+
                 @Override
                 public void onSuccess(List<BiblioItem> res) {
-                    if ((res != null) && (res.size() > 0) ) {
+                    if ((res != null) && (res.size() > 0)) {
                         // we need here to post-check that the found item corresponds
                         // correctly to the one requested in order to avoid false positive
-                        for(BiblioItem oneRes : res) {
+                        for (BiblioItem oneRes : res) {
                             /* 
                               Glutton integrates its own post-validation, so we can skip post-validation in GROBID when it is used as 
                               consolidation service - except in specific case where the DOI is failing and the consolidation is based on 
@@ -261,20 +261,20 @@ public class Consolidation {
 
                               For all the other case of matching with CrossRef, we require a post-validation. 
                             */
-                            if ( 
-                                ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) && 
+                            if (
+                                ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) &&
                                     !doiQuery
                                 )
-                                ||
-                                ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) && 
-                                    StringUtils.isNotBlank(oneRes.getDOI()) &&
-                                    doi.equals(oneRes.getDOI())
-                                )
-                                ||
-                                ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) && 
-                                  (doiQuery) ) 
-                                ||
-                                postValidation(bib, oneRes)) {
+                                    ||
+                                    ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) &&
+                                        StringUtils.isNotBlank(oneRes.getDOI()) &&
+                                        doi.equals(oneRes.getDOI())
+                                    )
+                                    ||
+                                    ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) &&
+                                        (doiQuery))
+                                    ||
+                                    postValidation(bib, oneRes)) {
                                 results.add(oneRes);
                                 if (cntManager != null) {
                                     cntManager.i(ConsolidationCounters.CONSOLIDATION_SUCCESS);
@@ -284,17 +284,17 @@ public class Consolidation {
                                 break;
                             }
                         }
-                    } 
+                    }
                 }
 
                 @Override
                 public void onError(int status, String message, Exception exception) {
-                    LOGGER.info("Consolidation service returns error ("+status+") : "+message, exception);
+                    LOGGER.info("Consolidation service returns error (" + status + ") : " + message, exception);
                 }
             });
-        } catch(Exception e) {
+        } catch (Exception e) {
             LOGGER.info("Consolidation error - " + ExceptionUtils.getStackTrace(e));
-        } 
+        }
 
         client.finish(threadId);
         if (results.size() == 0)
@@ -307,21 +307,21 @@ public class Consolidation {
     /**
      * Try tp consolidate a list of bibliographical objects in one operation with consolidation services
      */
-    public Map<Integer,BiblioItem> consolidate(List<BibDataSet> biblios) {   
+    public Map<Integer, BiblioItem> consolidate(List<BibDataSet> biblios) {
         if (CollectionUtils.isEmpty(biblios))
             return null;
-        final Map<Integer,BiblioItem> results = new HashMap<Integer,BiblioItem>();
+        final Map<Integer, BiblioItem> results = new HashMap<Integer, BiblioItem>();
         // init the results
         int n = 0;
-        for(n=0; n<biblios.size(); n++) {
+        for (n = 0; n < biblios.size(); n++) {
             results.put(Integer.valueOf(n), null);
         }
         n = 0;
         long threadId = Thread.currentThread().getId();
-        for(BibDataSet bibDataSet : biblios) {
+        for (BibDataSet bibDataSet : biblios) {
             final BiblioItem theBiblio = bibDataSet.getResBib();
 
-            if (cntManager != null) 
+            if (cntManager != null)
                 cntManager.i(ConsolidationCounters.TOTAL_BIB_REF);
 
             // first we get the exploitable metadata
@@ -332,7 +332,7 @@ public class Consolidation {
             String aut = theBiblio.getFirstAuthorSurname();
             String title = theBiblio.getTitle();
             String journalTitle = theBiblio.getJournal();
-           
+
             // and the row string
             String rawCitation = bibDataSet.getRawBib();
 
@@ -367,38 +367,38 @@ public class Consolidation {
 
             if (StringUtils.isNotBlank(doi)) {
                 // call based on the identified DOI
-                arguments = new HashMap<String,String>();
+                arguments = new HashMap<String, String>();
                 arguments.put("doi", doi);
-            } 
+            }
             if (StringUtils.isNotBlank(rawCitation)) {
                 // call with full raw string
                 if (arguments == null)
-                    arguments = new HashMap<String,String>();
-                if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
-                     StringUtils.isBlank(doi) )
+                    arguments = new HashMap<String, String>();
+                if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                    StringUtils.isBlank(doi))
                     arguments.put("query.bibliographic", rawCitation);
             }
             if (StringUtils.isNotBlank(title)) {
                 // call based on partial metadata
                 if (arguments == null)
-                    arguments = new HashMap<String,String>();
-                if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
-                     (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
+                    arguments = new HashMap<String, String>();
+                if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                    (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
                     arguments.put("query.title", title);
             }
             if (StringUtils.isNotBlank(aut)) {
                 // call based on partial metadata
                 if (arguments == null)
-                    arguments = new HashMap<String,String>();
-                if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) || 
-                     (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
+                    arguments = new HashMap<String, String>();
+                if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                    (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
                     arguments.put("query.author", aut);
             }
             if (StringUtils.isNotBlank(journalTitle)) {
                 // call based on partial metadata
                 if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                     if (arguments == null)
-                        arguments = new HashMap<String,String>();
+                        arguments = new HashMap<String, String>();
                     arguments.put("query.container-title", journalTitle);
                 }
             }
@@ -406,7 +406,7 @@ public class Consolidation {
                 // call based on partial metadata
                 if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                     if (arguments == null)
-                        arguments = new HashMap<String,String>();
+                        arguments = new HashMap<String, String>();
                     arguments.put("volume", volume);
                 }
             }
@@ -414,19 +414,19 @@ public class Consolidation {
                 // call based on partial metadata
                 if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                     if (arguments == null)
-                        arguments = new HashMap<String,String>();
+                        arguments = new HashMap<String, String>();
                     arguments.put("firstPage", firstPage);
                 }
             }
-            
+
             if (arguments == null || arguments.size() == 0) {
                 n++;
                 continue;
             }
 
             if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) {
-                if (StringUtils.isBlank(doi) && StringUtils.isBlank(rawCitation) && 
-                     (StringUtils.isBlank(aut) || StringUtils.isBlank(title)) ) {
+                if (StringUtils.isBlank(doi) && StringUtils.isBlank(rawCitation) &&
+                    (StringUtils.isBlank(aut) || StringUtils.isBlank(title))) {
                     // there's not enough information for a crossref request, which might always return a result
                     n++;
                     continue;
@@ -449,7 +449,7 @@ public class Consolidation {
                     cntManager.i(ConsolidationCounters.CONSOLIDATION);
                 }
 
-                if ( StringUtils.isNotBlank(doi) && (cntManager != null) ) {
+                if (StringUtils.isNotBlank(doi) && (cntManager != null)) {
                     cntManager.i(ConsolidationCounters.CONSOLIDATION_PER_DOI);
                     doiQuery = true;
                 } else {
@@ -457,13 +457,13 @@ public class Consolidation {
                 }
 
                 client.<BiblioItem>pushRequest("works", arguments, workDeserializer, threadId, new CrossrefRequestListener<BiblioItem>(n) {
-                    
+
                     @Override
                     public void onSuccess(List<BiblioItem> res) {
-                        if ((res != null) && (res.size() > 0) ) {
+                        if ((res != null) && (res.size() > 0)) {
                             // we need here to post-check that the found item corresponds
                             // correctly to the one requested in order to avoid false positive
-                            for(BiblioItem oneRes : res) {
+                            for (BiblioItem oneRes : res) {
                                 if ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) ||
                                     postValidation(theBiblio, oneRes)) {
                                     results.put(Integer.valueOf(getRank()), oneRes);
@@ -475,17 +475,17 @@ public class Consolidation {
                                     break;
                                 }
                             }
-                        } 
+                        }
                     }
 
                     @Override
                     public void onError(int status, String message, Exception exception) {
-                        LOGGER.info("Consolidation service returns error ("+status+") : "+message);
+                        LOGGER.info("Consolidation service returns error (" + status + ") : " + message);
                     }
                 });
-            } catch(Exception e) {
+            } catch (Exception e) {
                 LOGGER.info("Consolidation error - " + ExceptionUtils.getStackTrace(e));
-            } 
+            }
             n++;
         }
         client.finish(threadId);
@@ -612,14 +612,15 @@ public class Consolidation {
     /**
      * This is a DOI cleaning specifically adapted to CrossRef call
      */
-    private static String cleanDoi(String doi) {
+    protected static String cleanDoi(String doi) {
         doi = doi.replace("\"", "");
         doi = doi.replace("\n", "");
-        if (doi.startsWith("doi:") || doi.startsWith("DOI:") || 
-            doi.startsWith("doi/") || doi.startsWith("DOI/") ) {
-            doi.substring(4, doi.length());
+        if (StringUtils.lowerCase(doi).startsWith("doi:") || StringUtils.lowerCase(doi).startsWith("doi/")) {
+            doi = doi.substring(4);
             doi = doi.trim();
         }
+        doi = doi.replaceAll("[\\p{M}]", "");
+        doi = doi.replaceAll("\\p{InCombiningDiacriticalMarks}+", "");
 
         doi = doi.replace(" ", "");
         return doi;
@@ -627,10 +628,10 @@ public class Consolidation {
 
 
     /**
-     * The new public CrossRef API is a search API, and thus returns 
-     * many false positives. It is necessary to validate return results 
-     * against the (incomplete) source bibliographic item to block 
-     * inconsistent results.  
+     * The new public CrossRef API is a search API, and thus returns
+     * many false positives. It is necessary to validate return results
+     * against the (incomplete) source bibliographic item to block
+     * inconsistent results.
      */
     private boolean postValidation(BiblioItem source, BiblioItem result) {
         boolean valid = true;
@@ -642,11 +643,11 @@ public class Consolidation {
                 return false;
         }*/
 
-        if (!StringUtils.isBlank(source.getFirstAuthorSurname()) && 
+        if (!StringUtils.isBlank(source.getFirstAuthorSurname()) &&
             !StringUtils.isBlank(result.getFirstAuthorSurname())) {
 //System.out.println(source.getFirstAuthorSurname() + " / " + result.getFirstAuthorSurname() + " = " + 
 //    ratcliffObershelpDistance(source.getFirstAuthorSurname(), result.getFirstAuthorSurname(), false)); 
-            if (ratcliffObershelpDistance(source.getFirstAuthorSurname(),result.getFirstAuthorSurname(), false) < 0.8)
+            if (ratcliffObershelpDistance(source.getFirstAuthorSurname(), result.getFirstAuthorSurname(), false) < 0.8)
                 return false;
         }
 
@@ -660,7 +661,7 @@ public class Consolidation {
     }
 
     private double ratcliffObershelpDistance(String string1, String string2, boolean caseDependent) {
-        if ( StringUtils.isBlank(string1) || StringUtils.isBlank(string2) )
+        if (StringUtils.isBlank(string1) || StringUtils.isBlank(string2))
             return 0.0;
         Double similarity = 0.0;
         if (!caseDependent) {
@@ -669,13 +670,13 @@ public class Consolidation {
         }
         if (string1.equals(string2))
             similarity = 1.0;
-        if ( (string1.length() > 0) && (string2.length() > 0) ) {
-            Option<Object> similarityObject = 
+        if ((string1.length() > 0) && (string2.length() > 0)) {
+            Option<Object> similarityObject =
                 RatcliffObershelpMetric.compare(string1, string2);
-            if ( (similarityObject != null) && (similarityObject.get() != null) )
-                 similarity = (Double)similarityObject.get();
+            if ((similarityObject != null) && (similarityObject.get() != null))
+                similarity = (Double) similarityObject.get();
         }
-    
+
         return similarity.doubleValue();
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -59,7 +59,7 @@ public class Consolidation {
                 }
             }
             throw new IllegalArgumentException("No consolidation service with name '" + name +
-                "', possible values are: " + Arrays.toString(values()));
+                    "', possible values are: " + Arrays.toString(values()));
         }
     }
 
@@ -155,39 +155,39 @@ public class Consolidation {
 
         if (StringUtils.isNotBlank(doi)) {
             // call based on the identified DOI
-            arguments = new HashMap<String, String>();
+            arguments = new HashMap<String,String>();
             arguments.put("doi", doi);
         }
         if (StringUtils.isNotBlank(rawCitation)) {
             // call with full raw string
             if (arguments == null)
-                arguments = new HashMap<String, String>();
-            if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
-                StringUtils.isBlank(doi))
+                arguments = new HashMap<String,String>();
+            if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                     StringUtils.isBlank(doi) )
                 arguments.put("query.bibliographic", rawCitation);
             //arguments.put("query", rawCitation);
         }
         if (StringUtils.isNotBlank(aut)) {
             // call based on partial metadata
             if (arguments == null)
-                arguments = new HashMap<String, String>();
-            if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
-                (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
+                arguments = new HashMap<String,String>();
+            if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                 (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
                 arguments.put("query.author", aut);
         }
         if (StringUtils.isNotBlank(title)) {
             // call based on partial metadata
             if (arguments == null)
-                arguments = new HashMap<String, String>();
-            if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
-                (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
+                arguments = new HashMap<String,String>();
+            if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
                 arguments.put("query.title", title);
         }
         if (StringUtils.isNotBlank(journalTitle)) {
             // call based on partial metadata
             if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                 if (arguments == null)
-                    arguments = new HashMap<String, String>();
+                    arguments = new HashMap<String,String>();
                 arguments.put("query.container-title", journalTitle);
             }
         }
@@ -195,7 +195,7 @@ public class Consolidation {
             // call based on partial metadata
             if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                 if (arguments == null)
-                    arguments = new HashMap<String, String>();
+                    arguments = new HashMap<String,String>();
                 arguments.put("volume", volume);
             }
         }
@@ -203,7 +203,7 @@ public class Consolidation {
             // call based on partial metadata
             if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                 if (arguments == null)
-                    arguments = new HashMap<String, String>();
+                    arguments = new HashMap<String,String>();
                 arguments.put("firstPage", firstPage);
             }
         }
@@ -214,7 +214,7 @@ public class Consolidation {
 
         if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) {
             if (StringUtils.isBlank(doi) && StringUtils.isBlank(rawCitation) &&
-                (StringUtils.isBlank(aut) || StringUtils.isBlank(title))) {
+                 (StringUtils.isBlank(aut) || StringUtils.isBlank(title)) ) {
                 // there's not enough information for a crossref request, which might always return a result
                 return null;
             }
@@ -236,7 +236,7 @@ public class Consolidation {
                 cntManager.i(ConsolidationCounters.CONSOLIDATION);
             }
 
-            if (StringUtils.isNotBlank(doi) && (cntManager != null)) {
+            if ( StringUtils.isNotBlank(doi) && (cntManager != null) ) {
                 cntManager.i(ConsolidationCounters.CONSOLIDATION_PER_DOI);
                 doiQuery = true;
             } else {
@@ -247,10 +247,10 @@ public class Consolidation {
 
                 @Override
                 public void onSuccess(List<BiblioItem> res) {
-                    if ((res != null) && (res.size() > 0)) {
+                    if ((res != null) && (res.size() > 0) ) {
                         // we need here to post-check that the found item corresponds
                         // correctly to the one requested in order to avoid false positive
-                        for (BiblioItem oneRes : res) {
+                        for(BiblioItem oneRes : res) {
                             /* 
                               Glutton integrates its own post-validation, so we can skip post-validation in GROBID when it is used as 
                               consolidation service - except in specific case where the DOI is failing and the consolidation is based on 
@@ -262,19 +262,19 @@ public class Consolidation {
                               For all the other case of matching with CrossRef, we require a post-validation. 
                             */
                             if (
-                                ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) &&
+                                ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) &&
                                     !doiQuery
                                 )
-                                    ||
-                                    ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) &&
-                                        StringUtils.isNotBlank(oneRes.getDOI()) &&
-                                        doi.equals(oneRes.getDOI())
-                                    )
-                                    ||
-                                    ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) &&
-                                        (doiQuery))
-                                    ||
-                                    postValidation(bib, oneRes)) {
+                                ||
+                                ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) &&
+                                    StringUtils.isNotBlank(oneRes.getDOI()) &&
+                                    doi.equals(oneRes.getDOI())
+                                )
+                                ||
+                                ( (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) &&
+                                  (doiQuery) )
+                                ||
+                                postValidation(bib, oneRes)) {
                                 results.add(oneRes);
                                 if (cntManager != null) {
                                     cntManager.i(ConsolidationCounters.CONSOLIDATION_SUCCESS);
@@ -289,11 +289,11 @@ public class Consolidation {
 
                 @Override
                 public void onError(int status, String message, Exception exception) {
-                    LOGGER.info("Consolidation service returns error (" + status + ") : " + message, exception);
+                    LOGGER.info("Consolidation service returns error ("+status+") : "+message, exception);
                 }
             });
-        } catch (Exception e) {
-            LOGGER.info("Consolidation error - " + ExceptionUtils.getStackTrace(e));
+        } catch(Exception e) {
+            LOGGER.info("Consolidation error - ", e);
         }
 
         client.finish(threadId);
@@ -307,18 +307,18 @@ public class Consolidation {
     /**
      * Try tp consolidate a list of bibliographical objects in one operation with consolidation services
      */
-    public Map<Integer, BiblioItem> consolidate(List<BibDataSet> biblios) {
+    public Map<Integer,BiblioItem> consolidate(List<BibDataSet> biblios) {
         if (CollectionUtils.isEmpty(biblios))
             return null;
-        final Map<Integer, BiblioItem> results = new HashMap<Integer, BiblioItem>();
+        final Map<Integer,BiblioItem> results = new HashMap<Integer,BiblioItem>();
         // init the results
         int n = 0;
-        for (n = 0; n < biblios.size(); n++) {
+        for(n=0; n<biblios.size(); n++) {
             results.put(Integer.valueOf(n), null);
         }
         n = 0;
         long threadId = Thread.currentThread().getId();
-        for (BibDataSet bibDataSet : biblios) {
+        for(BibDataSet bibDataSet : biblios) {
             final BiblioItem theBiblio = bibDataSet.getResBib();
 
             if (cntManager != null)
@@ -367,38 +367,38 @@ public class Consolidation {
 
             if (StringUtils.isNotBlank(doi)) {
                 // call based on the identified DOI
-                arguments = new HashMap<String, String>();
+                arguments = new HashMap<String,String>();
                 arguments.put("doi", doi);
             }
             if (StringUtils.isNotBlank(rawCitation)) {
                 // call with full raw string
                 if (arguments == null)
-                    arguments = new HashMap<String, String>();
-                if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
-                    StringUtils.isBlank(doi))
+                    arguments = new HashMap<String,String>();
+                if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                     StringUtils.isBlank(doi) )
                     arguments.put("query.bibliographic", rawCitation);
             }
             if (StringUtils.isNotBlank(title)) {
                 // call based on partial metadata
                 if (arguments == null)
-                    arguments = new HashMap<String, String>();
-                if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
-                    (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
+                    arguments = new HashMap<String,String>();
+                if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                     (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
                     arguments.put("query.title", title);
             }
             if (StringUtils.isNotBlank(aut)) {
                 // call based on partial metadata
                 if (arguments == null)
-                    arguments = new HashMap<String, String>();
-                if ((GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
-                    (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)))
+                    arguments = new HashMap<String,String>();
+                if ( (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) ||
+                     (StringUtils.isBlank(rawCitation) && StringUtils.isBlank(doi)) )
                     arguments.put("query.author", aut);
             }
             if (StringUtils.isNotBlank(journalTitle)) {
                 // call based on partial metadata
                 if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                     if (arguments == null)
-                        arguments = new HashMap<String, String>();
+                        arguments = new HashMap<String,String>();
                     arguments.put("query.container-title", journalTitle);
                 }
             }
@@ -406,7 +406,7 @@ public class Consolidation {
                 // call based on partial metadata
                 if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                     if (arguments == null)
-                        arguments = new HashMap<String, String>();
+                        arguments = new HashMap<String,String>();
                     arguments.put("volume", volume);
                 }
             }
@@ -414,7 +414,7 @@ public class Consolidation {
                 // call based on partial metadata
                 if (GrobidProperties.getInstance().getConsolidationService() != GrobidConsolidationService.CROSSREF) {
                     if (arguments == null)
-                        arguments = new HashMap<String, String>();
+                        arguments = new HashMap<String,String>();
                     arguments.put("firstPage", firstPage);
                 }
             }
@@ -426,7 +426,7 @@ public class Consolidation {
 
             if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.CROSSREF) {
                 if (StringUtils.isBlank(doi) && StringUtils.isBlank(rawCitation) &&
-                    (StringUtils.isBlank(aut) || StringUtils.isBlank(title))) {
+                     (StringUtils.isBlank(aut) || StringUtils.isBlank(title)) ) {
                     // there's not enough information for a crossref request, which might always return a result
                     n++;
                     continue;
@@ -449,7 +449,7 @@ public class Consolidation {
                     cntManager.i(ConsolidationCounters.CONSOLIDATION);
                 }
 
-                if (StringUtils.isNotBlank(doi) && (cntManager != null)) {
+                if ( StringUtils.isNotBlank(doi) && (cntManager != null) ) {
                     cntManager.i(ConsolidationCounters.CONSOLIDATION_PER_DOI);
                     doiQuery = true;
                 } else {
@@ -460,10 +460,10 @@ public class Consolidation {
 
                     @Override
                     public void onSuccess(List<BiblioItem> res) {
-                        if ((res != null) && (res.size() > 0)) {
+                        if ((res != null) && (res.size() > 0) ) {
                             // we need here to post-check that the found item corresponds
                             // correctly to the one requested in order to avoid false positive
-                            for (BiblioItem oneRes : res) {
+                            for(BiblioItem oneRes : res) {
                                 if ((GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) ||
                                     postValidation(theBiblio, oneRes)) {
                                     results.put(Integer.valueOf(getRank()), oneRes);
@@ -480,11 +480,11 @@ public class Consolidation {
 
                     @Override
                     public void onError(int status, String message, Exception exception) {
-                        LOGGER.info("Consolidation service returns error (" + status + ") : " + message);
+                        LOGGER.info("Consolidation service returns error ("+status+") : "+message);
                     }
                 });
-            } catch (Exception e) {
-                LOGGER.info("Consolidation error - " + ExceptionUtils.getStackTrace(e));
+            } catch(Exception e) {
+                LOGGER.info("Consolidation error - ", e);
             }
             n++;
         }
@@ -647,7 +647,7 @@ public class Consolidation {
             !StringUtils.isBlank(result.getFirstAuthorSurname())) {
 //System.out.println(source.getFirstAuthorSurname() + " / " + result.getFirstAuthorSurname() + " = " + 
 //    ratcliffObershelpDistance(source.getFirstAuthorSurname(), result.getFirstAuthorSurname(), false)); 
-            if (ratcliffObershelpDistance(source.getFirstAuthorSurname(), result.getFirstAuthorSurname(), false) < 0.8)
+            if (ratcliffObershelpDistance(source.getFirstAuthorSurname(),result.getFirstAuthorSurname(), false) < 0.8)
                 return false;
         }
 
@@ -661,7 +661,7 @@ public class Consolidation {
     }
 
     private double ratcliffObershelpDistance(String string1, String string2, boolean caseDependent) {
-        if (StringUtils.isBlank(string1) || StringUtils.isBlank(string2))
+        if ( StringUtils.isBlank(string1) || StringUtils.isBlank(string2) )
             return 0.0;
         Double similarity = 0.0;
         if (!caseDependent) {
@@ -670,11 +670,11 @@ public class Consolidation {
         }
         if (string1.equals(string2))
             similarity = 1.0;
-        if ((string1.length() > 0) && (string2.length() > 0)) {
+        if ( (string1.length() > 0) && (string2.length() > 0) ) {
             Option<Object> similarityObject =
                 RatcliffObershelpMetric.compare(string1, string2);
-            if ((similarityObject != null) && (similarityObject.get() != null))
-                similarity = (Double) similarityObject.get();
+            if ( (similarityObject != null) && (similarityObject.get() != null) )
+                 similarity = (Double)similarityObject.get();
         }
 
         return similarity.doubleValue();

--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -293,7 +293,7 @@ public class Consolidation {
                 }
             });
         } catch(Exception e) {
-            LOGGER.info("Consolidation error - ", e);
+            LOGGER.info("Consolidation error - ",e);
         }
 
         client.finish(threadId);

--- a/grobid-core/src/main/java/org/grobid/core/utilities/glutton/GluttonClient.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/glutton/GluttonClient.java
@@ -1,24 +1,14 @@
 package org.grobid.core.utilities.glutton;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.Future;
-import java.util.concurrent.ExecutionException;
 
-import org.apache.commons.lang3.concurrent.TimedSemaphore;
 import org.apache.http.client.ClientProtocolException;
-import org.grobid.core.utilities.crossref.CrossrefRequestListener.Response;
 import org.grobid.core.utilities.crossref.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +20,7 @@ import org.slf4j.LoggerFactory;
  */
 //public class GluttonClient implements Closeable {
 public class GluttonClient extends CrossrefClient {
-    public static final Logger logger = LoggerFactory.getLogger(GluttonClient.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(GluttonClient.class);
     
     private static volatile GluttonClient instance;
 
@@ -54,7 +44,7 @@ public class GluttonClient extends CrossrefClient {
      * Creates a new instance.
      */
     private static synchronized void getNewInstance() {
-        logger.debug("Get new instance of GluttonClient");
+        LOGGER.debug("Get new instance of GluttonClient");
         instance = new GluttonClient();
     }
 
@@ -72,7 +62,7 @@ public class GluttonClient extends CrossrefClient {
         this.futures = new HashMap<>();*/
         int nThreads = Runtime.getRuntime().availableProcessors();
         //int nThreads = (int) Math.ceil((double)Runtime.getRuntime().availableProcessors() / 2);
-        System.out.println("nThreads: " + nThreads);
+        LOGGER.info("nThreads: " + nThreads);
         this.executorService = Executors.newFixedThreadPool(nThreads*2);
         //setLimits(20, 1000); // default calls per second
     }
@@ -104,7 +94,7 @@ public class GluttonClient extends CrossrefClient {
     }*/
 
     public static void printLog(GluttonRequest<?> request, String message) {
-        logger.info((request != null ? request+": " : "")+message);
+        LOGGER.info((request != null ? request+": " : "")+message);
         //System.out.println((request != null ? request+": " : "")+message);
     }
 

--- a/grobid-core/src/test/java/org/grobid/core/utilities/ConsolidationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/ConsolidationTest.java
@@ -1,0 +1,43 @@
+package org.grobid.core.utilities;
+
+import org.grobid.core.data.BiblioItem;
+import org.grobid.core.main.LibraryLoader;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class ConsolidationTest {
+
+
+    @Test
+    public void testCleanDoiPrefix1_shouldRemovePrefix() throws Exception {
+
+        String doi = "doi:10.1063/1.1905789";
+        String cleanDoi = Consolidation.cleanDoi(doi);
+
+        assertThat(cleanDoi, is("10.1063/1.1905789"));
+    }
+
+    @Test
+    public void testCleanDoiPrefix2_shouldRemovePrefix() throws Exception {
+
+        String doi = "doi/10.1063/1.1905789";
+        String cleanDoi = Consolidation.cleanDoi(doi);
+
+        assertThat(cleanDoi, is("10.1063/1.1905789"));
+    }
+
+    @Test
+    public void testCleanDoi_diactric() throws Exception {
+        String doi = "10.1063/1.1905789͔";
+
+        String cleanDoi = Consolidation.cleanDoi(doi);
+
+        assertThat(cleanDoi, is("10.1063/1.1905789"));
+    }
+
+}

--- a/grobid-core/src/test/java/org/grobid/core/utilities/ConsolidationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/utilities/ConsolidationTest.java
@@ -13,31 +13,6 @@ import static org.junit.Assert.assertThat;
 public class ConsolidationTest {
 
 
-    @Test
-    public void testCleanDoiPrefix1_shouldRemovePrefix() throws Exception {
 
-        String doi = "doi:10.1063/1.1905789";
-        String cleanDoi = Consolidation.cleanDoi(doi);
-
-        assertThat(cleanDoi, is("10.1063/1.1905789"));
-    }
-
-    @Test
-    public void testCleanDoiPrefix2_shouldRemovePrefix() throws Exception {
-
-        String doi = "doi/10.1063/1.1905789";
-        String cleanDoi = Consolidation.cleanDoi(doi);
-
-        assertThat(cleanDoi, is("10.1063/1.1905789"));
-    }
-
-    @Test
-    public void testCleanDoi_diactric() throws Exception {
-        String doi = "10.1063/1.1905789͔";
-
-        String cleanDoi = Consolidation.cleanDoi(doi);
-
-        assertThat(cleanDoi, is("10.1063/1.1905789"));
-    }
 
 }


### PR DESCRIPTION
As mentioned in https://github.com/kermitt2/biblio-glutton/issues/55 

When I wrote the test I realised that the result of `substring()`, aiming at removing the prefix, was not used. 

This should: 
 - remove diactric (not sure is needed)
 - remove characther that combined with others 
 - fix substring(4) using the 

About diactricts: https://memorynotfound.com/remove-accents-diacritics-from-string/ 