### PR TITLE
Automatic reduction of nb of threads if they are above the max connections

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/factory/GrobidPoolingFactory.java
+++ b/grobid-core/src/main/java/org/grobid/core/factory/GrobidPoolingFactory.java
@@ -11,12 +11,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GrobidPoolingFactory extends AbstractEngineFactory implements
-		PoolableObjectFactory {
+		PoolableObjectFactory<Engine> {
 
 	/**
 	 * A pool which contains objects of type Engine for the conversion.
 	 */
-	private static volatile GenericObjectPool grobidEnginePool = null;
+	private static volatile GenericObjectPool<Engine> grobidEnginePool = null;
 	private static volatile Boolean grobidEnginePoolControl = false;
 	private static final Logger LOGGER = LoggerFactory
 			.getLogger(GrobidPoolingFactory.class);
@@ -37,13 +37,13 @@ public class GrobidPoolingFactory extends AbstractEngineFactory implements
 	 * 
 	 * @return GenericObjectPool
 	 */
-	protected static GenericObjectPool newPoolInstance() {
+	protected static GenericObjectPool<Engine> newPoolInstance() {
 		if (grobidEnginePool == null) {
 			// initialize grobidEnginePool
 			LOGGER.debug("synchronized newPoolInstance");
 			synchronized (grobidEnginePoolControl) {
 				if (grobidEnginePool == null) {
-					grobidEnginePool = new GenericObjectPool(GrobidPoolingFactory.newInstance());
+					grobidEnginePool = new GenericObjectPool<>(GrobidPoolingFactory.newInstance());
 					//grobidEnginePool.setFactory(GrobidPoolingFactory.newInstance());
 					grobidEnginePool
 							.setWhenExhaustedAction(GenericObjectPool.WHEN_EXHAUSTED_BLOCK);
@@ -72,7 +72,7 @@ public class GrobidPoolingFactory extends AbstractEngineFactory implements
 		}
 		Engine engine = null;
 		try {
-			engine = (Engine) grobidEnginePool.borrowObject();
+			engine = grobidEnginePool.borrowObject();
 		} catch (NoSuchElementException nseExp) {
 			throw new NoSuchElementException();
 		} catch (Exception exp) {
@@ -92,7 +92,7 @@ public class GrobidPoolingFactory extends AbstractEngineFactory implements
 		try {
 			//engine.close();
 			if (grobidEnginePool == null) 
-				System.out.println("grobidEnginePool is null !");
+				LOGGER.error("grobidEnginePool is null !");
 			grobidEnginePool.returnObject(engine);
 		} catch (Exception exp) {
 			throw new GrobidException(
@@ -109,41 +109,28 @@ public class GrobidPoolingFactory extends AbstractEngineFactory implements
 	protected static GrobidPoolingFactory newInstance() {
 		return new GrobidPoolingFactory();
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
+	
 	@Override
-	public void activateObject(Object arg0) throws Exception {
+	public void activateObject(Engine arg0) throws Exception {
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	@Override
-	public void destroyObject(Object arg0) throws Exception {
+	public void destroyObject(Engine engine) throws Exception {
+        engine.close();
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
+
 	@Override
-	public Object makeObject() throws Exception {
+	public Engine makeObject() throws Exception {
 		return (createEngine(this.preload));
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
+	
 	@Override
-	public void passivateObject(Object arg0) throws Exception {
+	public void passivateObject(Engine arg0) throws Exception {
 	}
-
-	/**
-	 * {@inheritDoc}
-	 */
+	
 	@Override
-	public boolean validateObject(Object arg0) {
+	public boolean validateObject(Engine arg0) {
 		return false;
 	}
 

--- a/grobid-core/src/main/java/org/grobid/core/factory/GrobidPoolingFactory.java
+++ b/grobid-core/src/main/java/org/grobid/core/factory/GrobidPoolingFactory.java
@@ -116,7 +116,6 @@ public class GrobidPoolingFactory extends AbstractEngineFactory implements
 
 	@Override
 	public void destroyObject(Engine engine) throws Exception {
-        engine.close();
 	}
 
 

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -185,7 +185,7 @@ public class EndToEndEvaluation {
 
             int maxNumThreads = GrobidProperties.getInstance().getNBThreads();
 
-            if (maxNumThreads > GrobidProperties.getInstance().getMaxPoolConnections()) {
+            if (maxNumThreads >= GrobidProperties.getInstance().getMaxPoolConnections()) {
                 int newNumThreads = GrobidProperties.getInstance().getMaxPoolConnections() -1;
                 System.out.println("Grobid nbThreads > maxPoolConnections. Lowering to " + newNumThreads);
                 maxNumThreads = GrobidProperties.getInstance().getMaxPoolConnections() -1;

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -184,11 +184,12 @@ public class EndToEndEvaluation {
 			int fails = 0;
 
             int maxNumThreads = GrobidProperties.getInstance().getNBThreads();
-
-            if (maxNumThreads >= GrobidProperties.getInstance().getMaxPoolConnections()) {
-                int newNumThreads = GrobidProperties.getInstance().getMaxPoolConnections() -1;
-                System.out.println("Grobid nbThreads > maxPoolConnections. Lowering to " + newNumThreads);
-                maxNumThreads = GrobidProperties.getInstance().getMaxPoolConnections() -1;
+            int maxPoolConnections = GrobidProperties.getInstance().getMaxPoolConnections();
+            
+            if (maxNumThreads >= maxPoolConnections) {
+                int newNumThreads = maxPoolConnections - 1;
+                System.out.println("Grobid nbThreads ("+maxNumThreads+") >= maxPoolConnections ("+maxPoolConnections+"). Lowering to " + newNumThreads);
+                maxNumThreads = maxPoolConnections - 1;
             }
 
 			ExecutorService executor = Executors.newFixedThreadPool(maxNumThreads);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -189,7 +189,7 @@ public class EndToEndEvaluation {
             if (maxNumThreads >= maxPoolConnections) {
                 int newNumThreads = maxPoolConnections - 1;
                 System.out.println("Grobid nbThreads ("+maxNumThreads+") >= maxPoolConnections ("+maxPoolConnections+"). Lowering to " + newNumThreads);
-                maxNumThreads = maxPoolConnections - 1;
+                maxNumThreads = newNumThreads;
             }
 
 			ExecutorService executor = Executors.newFixedThreadPool(maxNumThreads);


### PR DESCRIPTION
The number of connections (`maxConnections`) represents the number of engines that are available, and the number of threads (`maxNbThreads`) is used to size the number of concurrent pdfs that are processed when running the end2end evaluation. 

If `maxNbThreds  > maxConnections` many PDFs will fail because no enough engines will be available to cover all the parallel pdfs. 

Example: 
```
(base) [Luca@falcon grobid]$ ./gradlew jatsEval -Pp2t=/data/workspace/Luca/PMC_sample_1943 -Prun=1
<-------------> 0% INITIALIZING [232ms]
> Evaluating settings
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass (file:/home/Luca/.gradle/wrapper/dists/gradle-6.5.1-all/cdund22i8guosqylfo49op4dv/gradle-6.5.1/lib/groovy-all-1.3-2.5.11.jar) to method java.lang.Object.finalize()
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.reflection.CachedClass
Configuration(s) specified but the install task does not exist in project :grobid-core.
Configuration(s) specified but the install task does not exist in project :grobid-home.
Configuration(s) specified but the install task does not exist in project :grobid-service.
Configuration(s) specified but the install task does not exist in project :grobid-trainer.

> Task :grobid-trainer:jatsEval
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
>>>>>>>> GROBID_HOME=/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/affiliation-address/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/affiliation-address/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/name/header/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/name/header/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/name/citation/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/name/citation/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/header/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/header/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/date/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/date/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/citation/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/citation/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/fulltext/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/fulltext/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/segmentation/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/segmentation/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/reference-segmenter/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/reference-segmenter/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/figure/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/figure/model.wapiti
[Wapiti] Loading model: "/data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/table/model.wapiti"
Model path: /data/workspace/Luca/github/grobid/grobid-trainer/../grobid-home/models/table/model.wapiti


PDF processing   0% │                      │    0/1943 (0:00:00 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Lett_Appl_Microbiol_2009_Aug_49(2)_191-195/lam0049-0191.pdf
PDF processing   0% │                      │    0/1943 (0:00:01 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/J_Insect_Physiol_2010_May_56(5)_447-454/main.pdf
PDF processing   0% │                      │    0/1943 (0:00:02 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Neuropharmacology_2011_Feb_60(2-3)_488-495/main.pdf
PDF processing   0% │                      │    0/1943 (0:00:03 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Thorax_2011_May_25_66(5)_375-382/thoraxjnl153825.pdf
PDF processing   0% │                      │    0/1943 (0:00:04 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Curr_Atheroscler_Rep_2011_Jun_5_13(3)_277-284/11883_2011_Article_176.pdf
PDF processing   0% │                      │    0/1943 (0:00:05 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Public_Health_Nutr_2008_Feb_11(2)_203-213/S1368980007000304a.pdf
PDF processing   0% │                      │    0/1943 (0:00:06 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Protein_J_2010_Oct_25_29(7)_524-529/10930_2010_Article_9283.pdf
PDF processing   0% │                      │    0/1943 (0:00:07 / ?)           Could not get an engine from the pool within configured time.
Could not process: /data/workspace/Luca/PMC_sample_1943/Cell_Metab_2011_Jan_5_13(1)_92-104/main.pdf
```

This PR automatically reduces maxNBThreads to maxConnection -1 if maxNbThreds  > maxConnections. 

Additionally, I've modified the GrobidPooledFactory to be strongly-typed as it's dealing only with Engine objects. 

Note: As of today, this PR is `compatible` with the PR #706. 