### PR TITLE
Fix changelog (links + date)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.7.0] – 2020-07-17
+## [0.7.0] – 2021-07-17
 
 ### Added
 
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 + Add missing pdfalto Graphics information when `-noImage` is used, fix graphics data path in TEI
 + Fix the tendency to merge tables when they are in close proximity
 
-## [0.6.2] – 2020-03-20
+## [0.6.2] – 2021-03-20
 
 ### Added
 
@@ -278,7 +278,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 + More robust synchronization of CRF sequence with PDF areas, resulting in improved bounding box calculations for locating annotations in the PDF documents.
 + Improved general robustness thanks to better token alignments.
 
-[Unreleased]: https://github.com/kermitt2/grobid/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/kermitt2/grobid/compare/0.7.0...HEAD
+[0.7.0]: https://github.com/kermitt2/grobid/compare/0.6.2...0.7.0
+[0.6.2]: https://github.com/kermitt2/grobid/compare/0.6.1...0.6.2
+[0.6.1]: https://github.com/kermitt2/grobid/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/kermitt2/grobid/compare/0.5.6...0.6.0
 [0.5.6]: https://github.com/kermitt2/grobid/compare/0.5.5...0.5.6
 [0.5.5]: https://github.com/kermitt2/grobid/compare/0.5.4...0.5.5


### PR DESCRIPTION
This PR fixes the links in the headers - and the release date of 0.6.2 and 0.7.0.

## Before

![grafik](https://user-images.githubusercontent.com/1366654/126549588-fa06cc23-f634-4acd-8818-a1d5c12eb03a.png)

## After

![grafik](https://user-images.githubusercontent.com/1366654/126549634-4406ea1a-d637-401d-bffe-d5bb0c0d72bc.png)

