### PR TITLE
Revise BibTeX date output

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -1990,9 +1990,17 @@ public class BiblioItem {
                 if (isoDate != null) {
                     bibtex.add("  date = {" + isoDate + "}");
                 }
-            }
-            if (publication_date != null) {
-                bibtex.add("  year = {" + publication_date + "}");
+                if (normalized_publication_date.getYear() >= 0) {
+                    bibtex.add("  year = {" + normalized_publication_date.getYear() + "}");
+                }
+                if (normalized_publication_date.getMonth() >= 0) {
+                    bibtex.add("  month = {" + normalized_publication_date.getMonth() + "}");
+                }
+                if (normalized_publication_date.getMonth() >= 0) {
+                    bibtex.add("  day = {" + normalized_publication_date.getDay() + "}");
+                }
+            } else if (publication_date != null) {
+                bibtex.add("  date = {" + publication_date + "}");
             }
 
             // address

--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -2000,7 +2000,7 @@ public class BiblioItem {
                     bibtex.add("  day = {" + normalized_publication_date.getDay() + "}");
                 }
             } else if (publication_date != null) {
-                bibtex.add("  date = {" + publication_date + "}");
+                bibtex.add("  year = {" + publication_date + "}");
             }
 
             // address


### PR DESCRIPTION
Follow up to #761 and #807.

Date is now given as:

- If date is normalizable:
  - ISO string in date field
  - year integer in year field
  - month integer in month field
  - day integer in day field
- If date is not normalizable:
  - raw date-string in year field