### PR TITLE
fix deserialised consolidation day

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/crossref/WorkDeserializer.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/crossref/WorkDeserializer.java
@@ -212,7 +212,7 @@ public class WorkDeserializer extends CrossrefDeserializer<BiblioItem> {
 						}
 						
 						if (day != null) {
-							date.setDayString(month);
+							date.setDayString(day);
 							int dayInt = -1;
 							try {
 								dayInt = Integer.parseInt(day);


### PR DESCRIPTION
Minor bugfix. The day (String only) in the consolidated date was not correctly assigned from the response. 