### PR TITLE
training: small fixes to name (citation) data

### DIFF
--- a/grobid-trainer/resources/dataset/name/citation/corpus/author.tei.xml
+++ b/grobid-trainer/resources/dataset/name/citation/corpus/author.tei.xml
@@ -36,7 +36,7 @@ Durfee</lastname>, <forename>E</forename>. <middlename>H</middlename>., &amp; <l
 		<author><lastname>Johnson</lastname>, et al.,</author>
 		<author><lastname>Calci</lastname>.</author>
 		<author><lastname>Holler</lastname>, et al.,</author>
-		<author><lastname>Smith</lastname>, B. et al.,</author>
+		<author><lastname>Smith</lastname>, <forename>B</forename>. et al.,</author>
 		<author><lastname>Elliot</lastname>, et al.,</author>
 		<author><lastname>von Dullemen</lastname>, et al.,</author>
 		<author><lastname>Grau</lastname>, et al.,</author>
@@ -63,7 +63,7 @@ Durfee</lastname>, <forename>E</forename>. <middlename>H</middlename>., &amp; <l
 		<author><lastname>Bar-Haim</lastname>, <forename>R</forename>., <lastname>Dagan</lastname>, <forename>I</forename>., <lastname>Dolan</lastname>, <forename>B</forename>., <lastname>Ferro</lastname>, <forename>L</forename>., <lastname>Giampiccolo</lastname>, <forename>D</forename>., <lastname>Magnini</lastname>, <forename>B</forename>. and <lastname>Szpektor</lastname>.</author>
 		<author><forename>Jenny</forename> <middlename>Rose</middlename> <lastname>Finkel</lastname>, <forename>Trond</forename> <lastname>Grenager</lastname>, and <forename>Christopher</forename> <lastname>Manning</lastname>. </author>
 		<author><forename>C.-Y.</forename> <lastname>Lu</lastname> et al.</author>
-		<author><forename>K</forename>. <middlename>C</middlename>. <lastname>Je</lastname>, In-Chul <lastname>Shin</lastname>, <forename>J</forename>. <lastname>Kim</lastname>, and <forename>K</forename>. <lastname>Kyhm</lastname>,</author>
+		<author><forename>K</forename>. <middlename>C</middlename>. <lastname>Je</lastname>, <forename>In-Chul</forename> <lastname>Shin</lastname>, <forename>J</forename>. <lastname>Kim</lastname>, and <forename>K</forename>. <lastname>Kyhm</lastname>,</author>
 		<author><lastname>Gupta</lastname>, <forename>J</forename>.<middlename>A</middlename>., <lastname>Knobel</lastname>, <forename>R</forename>., <lastname>Samarth</lastname>, <forename>N</forename>. &amp; <lastname>Awschalom</lastname>, <forename>D</forename>.<middlename>D</middlename>.</author>
 		<author><lastname>Hanson</lastname>, <forename>R</forename>. &amp; <lastname>Awschalom</lastname>, <forename>D</forename>.<middlename>D</middlename>.,</author>
 		<author><lastname>Michetti</lastname>, <forename>P</forename>. &amp; <lastname>La Rocca</lastname>, <forename>G</forename>. <middlename>C</middlename>..</author>


### PR DESCRIPTION
When skimming over TEI training data (to see how diverse the source data is), I noticed what seem to be two small labeling errors.

I checked over the rest of this file (author.tei.xml), but didn't inspect the rest of the citation corpus carefully.