### PR TITLE
TEI: multiple editors each get <editor> around <persName>

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -2380,22 +2380,22 @@ public class BiblioItem {
                 }
 
                 if (fullEditors != null && fullEditors.size()>0) {
-                    for (int i = 0; i < indent + 2; i++) {
-                        tei.append("\t");
-                    }
-                    tei.append("<editor>\n");
                     for(Person editor : fullEditors) {
+                        for (int i = 0; i < indent + 2; i++) {
+                            tei.append("\t");
+                        }
+                        tei.append("<editor>\n");
                         for (int i = 0; i < indent + 3; i++) {
                             tei.append("\t");
                         }
                         String localString = editor.toTEI(false);
                         localString = localString.replace(" xmlns=\"http://www.tei-c.org/ns/1.0\"", "");
                         tei.append(localString).append("\n");
+                        for (int i = 0; i < indent + 2; i++) {
+                            tei.append("\t");
+                        }
+                        tei.append("</editor>\n");
                     }
-                    for (int i = 0; i < indent + 2; i++) {
-                        tei.append("\t");
-                    }
-                    tei.append("</editor>\n");
                 } else if (!StringUtils.isEmpty(editors)) {
                     //postProcessingEditors();
 


### PR DESCRIPTION
Closes: https://github.com/kermitt2/grobid/issues/845

Tested with the string mentioned in the issue, but didn't add any unit test coverage.