### PR TITLE
Fix regex, #867

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/citations/CalloutAnalyzer.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/citations/CalloutAnalyzer.java
@@ -24,10 +24,12 @@ public class CalloutAnalyzer {
 
     // simple patterns just to capture the majority callout style
     private final static Pattern BRACKET_TEXT_PATTERN = Pattern.compile("\\[(.)+\\]");
-    private final static Pattern BRACKET_NUMBER_PATTERN = Pattern.compile("\\[((\\d+[a-f]?)|[,-;•])+\\]");
+    //private final static Pattern BRACKET_NUMBER_PATTERN = Pattern.compile("\\[((\\d{0,4}[a-f]?)|[,-;•])+\\]");
+    private final static Pattern BRACKET_NUMBER_PATTERN = Pattern.compile("\\[(?>[0-9]{1,4}[a-f]?[\\-;•,]?((and)|&|(et))?)+\\]");
     private final static Pattern PARENTHESIS_TEXT_PATTERN = Pattern.compile("\\((.)+\\)");
-    private final static Pattern PARENTHESIS_NUMBER_PATTERN = Pattern.compile("\\(((\\d+[a-f]?)|[,-;•])+\\)");
-    private final static Pattern NUMBER_PATTERN = Pattern.compile("(\\d+)[a-f]?");
+    //private final static Pattern PARENTHESIS_NUMBER_PATTERN = Pattern.compile("\\(((\\d+[a-f]?)|[,-;•])+\\)");
+    private final static Pattern PARENTHESIS_NUMBER_PATTERN = Pattern.compile("\\((?>[0-9]{1,4}[a-f]?[\\-;•,]?((and)|&|(et))?)+\\)");
+    private final static Pattern NUMBER_PATTERN = Pattern.compile("(?>\\d+)[a-f]?");
     private final static Pattern ROMAN_PATTERN = Pattern.compile("(IX|IV|V?I{0,3})");
 
     public static MarkerType getCalloutType(List<LayoutToken> callout) {

--- a/grobid-core/src/test/java/org/grobid/core/engines/citations/CalloutAnalyzerTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/citations/CalloutAnalyzerTest.java
@@ -1,0 +1,71 @@
+package org.grobid.core.engines.citations;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+
+import org.grobid.core.engines.citations.CalloutAnalyzer.MarkerType;
+import org.grobid.core.analyzers.GrobidDefaultAnalyzer;
+import org.grobid.core.layout.LayoutToken;
+
+import java.util.List;
+
+public class CalloutAnalyzerTest {
+
+    @Test
+    public void testGetCalloutTypeText() throws Exception {
+        String input = "(Dé&amps, C & Bidule, D., 2010)";
+        List<LayoutToken> inputCallout = GrobidDefaultAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        MarkerType result = MarkerType.PARENTHESIS_TEXT;
+        assertThat(CalloutAnalyzer.getCalloutType(inputCallout), is(result));
+    }
+
+    @Test
+    public void testGetCalloutTypeTextFail() throws Exception {
+        String input = "(1,3)";
+        List<LayoutToken> inputCallout = GrobidDefaultAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        MarkerType result = MarkerType.PARENTHESIS_TEXT;
+        assertThat(CalloutAnalyzer.getCalloutType(inputCallout), not(result));
+    }
+
+    @Test
+    public void testGetCalloutTypeNumber() throws Exception {
+        String input = "[1-5]";
+        List<LayoutToken> inputCallout = GrobidDefaultAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        MarkerType result = MarkerType.BRACKET_NUMBER;
+        assertThat(CalloutAnalyzer.getCalloutType(inputCallout), is(result));
+    }
+
+    @Test
+    public void testGetCalloutTypeNumberFail() throws Exception {
+        String input = "[Foppiano et. al, 2004]";
+        List<LayoutToken> inputCallout = GrobidDefaultAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        MarkerType result = MarkerType.BRACKET_NUMBER;
+        assertThat(CalloutAnalyzer.getCalloutType(inputCallout), not(result));
+    }
+
+    @Test
+    public void testGetCalloutCatastrophicBacktracking() throws Exception {
+        String input = "(1915-1919, 1920-1924, 1925-1929, 1930-1934, and 1935-1939)";
+        List<LayoutToken> inputCallout = GrobidDefaultAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        MarkerType result = MarkerType.PARENTHESIS_NUMBER;
+        assertThat(CalloutAnalyzer.getCalloutType(inputCallout), is(result));
+    }
+
+    @Test
+    public void testGetCalloutCatastrophicBacktrackingFail() throws Exception {
+        String input = "(1915-1919, 1920-1924, 1925-1929, 1930-1934, and 1935-1939)";
+        List<LayoutToken> inputCallout = GrobidDefaultAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        MarkerType result = MarkerType.BRACKET_NUMBER;
+        assertThat(CalloutAnalyzer.getCalloutType(inputCallout), not(result));
+    }
+}


### PR DESCRIPTION
Try to fix issue #867 with atomic grouping, avoiding normally possible catastrophic backtracking.

Add some pretty useless tests, giving false confidence that nothing bad could happen. 
