### PR TITLE
Add dynamic timeout on pdfalto_server

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
@@ -148,7 +148,7 @@ public class DocumentSource {
                 cmd.add(String.valueOf(GrobidProperties.getPdfaltoTimeoutMs()));
                 tmpPathXML = processPdfaltoServerMode(pdfPath, tmpPathXML, cmd);
             } else {
-                if (!SystemUtils.IS_OS_WINDOWS) {
+                if (!SystemUtils.IS_OS_WINDOWS && !SystemUtils.IS_OS_MAC) {
                     cmd = Arrays.asList("bash", "-c", "ulimit -Sv " +
                             GrobidProperties.getPdfaltoMemoryLimitMb() * 1024 + " && " + pdftoxml0 + " '" + pdfPath + "' " + tmpPathXML);
                 }

--- a/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
@@ -145,7 +145,7 @@ public class DocumentSource {
             cmd.add(tmpPathXML.getAbsolutePath());
             if (GrobidProperties.isContextExecutionServer()) {
                 cmd.add("--timeout");
-                cmd.add(String.valueOf(GrobidProperties.getPdfaltoTimeoutMs()));
+                cmd.add(String.valueOf(GrobidProperties.getPdfaltoTimeoutS()));
                 tmpPathXML = processPdfaltoServerMode(pdfPath, tmpPathXML, cmd);
             } else {
                 if (!SystemUtils.IS_OS_WINDOWS && !SystemUtils.IS_OS_MAC) {

--- a/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
@@ -144,6 +144,8 @@ public class DocumentSource {
             cmd.add(pdfPath.getAbsolutePath());
             cmd.add(tmpPathXML.getAbsolutePath());
             if (GrobidProperties.isContextExecutionServer()) {
+                cmd.add("--timeout");
+                cmd.add(String.valueOf(GrobidProperties.getPdfaltoTimeoutMs()));
                 tmpPathXML = processPdfaltoServerMode(pdfPath, tmpPathXML, cmd);
             } else {
                 if (!SystemUtils.IS_OS_WINDOWS) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -480,6 +480,10 @@ public class GrobidProperties {
         return grobidConfig.grobid.pdf.pdfalto.memoryLimitMb;
     }
 
+    public static Integer getPdfaltoTimeoutS() {
+        return grobidConfig.grobid.pdf.pdfalto.timeoutSec;
+    }
+
     public static Integer getPdfaltoTimeoutMs() {
         return grobidConfig.grobid.pdf.pdfalto.timeoutSec * 1000;
     }

--- a/grobid-home/pdfalto/lin-64/pdfalto_server
+++ b/grobid-home/pdfalto/lin-64/pdfalto_server
@@ -8,6 +8,26 @@ interval=1
 delay=0
 
 command=${0:0:${#0}-7}
+args=("$@")
+pdfalto_params=()
+
+for ((n=0; n<="$#";n++)); do
+   echo ${args[n]}
+   case ${args[n]} in
+         --timeout) 
+	      timeout=${args[n+1]}
+              ((n++))
+              ;;
+         *)
+              pdfalto_params+=" ${args[n+1]}"
+              ;;
+   esac
+
+#  [[ ${args[n]} == '--timeout' ]] && echo "${args[n+1]}"
+done
+
+echo timeout $timeout
+echo pdfalto commands: $command $pdfalto_params
 
 # kill -0 pid   Exit code indicates if a signal may be sent to $pid process.
 (
@@ -26,4 +46,4 @@ command=${0:0:${#0}-7}
     kill -s SIGKILL $$
 ) 2> /dev/null &
 
-exec $command $@
+exec $command $pdfalto_params

--- a/grobid-home/pdfalto/lin-64/pdfalto_server
+++ b/grobid-home/pdfalto/lin-64/pdfalto_server
@@ -12,18 +12,15 @@ args=("$@")
 pdfalto_params=()
 
 for ((n=0; n<="$#";n++)); do
-   echo ${args[n]}
    case ${args[n]} in
          --timeout) 
 	      timeout=${args[n+1]}
               ((n++))
               ;;
          *)
-              pdfalto_params+=" ${args[n+1]}"
+              pdfalto_params+=" ${args[n]}"
               ;;
    esac
-
-#  [[ ${args[n]} == '--timeout' ]] && echo "${args[n+1]}"
 done
 
 echo timeout $timeout

--- a/grobid-home/pdfalto/lin-64/pdfalto_server
+++ b/grobid-home/pdfalto/lin-64/pdfalto_server
@@ -23,8 +23,8 @@ for ((n=0; n<="$#";n++)); do
    esac
 done
 
-echo timeout $timeout
-echo pdfalto commands: $command $pdfalto_params
+#echo timeout $timeout
+#echo pdfalto commands: $command $pdfalto_params
 
 # kill -0 pid   Exit code indicates if a signal may be sent to $pid process.
 (

--- a/grobid-home/pdfalto/mac-64/pdfalto_server
+++ b/grobid-home/pdfalto/mac-64/pdfalto_server
@@ -12,18 +12,15 @@ args=("$@")
 pdfalto_params=()
 
 for ((n=0; n<="$#";n++)); do
-   echo ${args[n]}
    case ${args[n]} in
          --timeout)
 	      timeout=${args[n+1]}
               ((n++))
               ;;
          *)
-              pdfalto_params+=" ${args[n+1]}"
+              pdfalto_params+=" ${args[n]}"
               ;;
    esac
-
-#  [[ ${args[n]} == '--timeout' ]] && echo "${args[n+1]}"
 done
 
 # kill -0 pid   Exit code indicates if a signal may be sent to $pid process.

--- a/grobid-home/pdfalto/mac-64/pdfalto_server
+++ b/grobid-home/pdfalto/mac-64/pdfalto_server
@@ -8,6 +8,24 @@ interval=1
 delay=0
 command=${0:0:${#0}-7}
 
+args=("$@")
+pdfalto_params=()
+
+for ((n=0; n<="$#";n++)); do
+   echo ${args[n]}
+   case ${args[n]} in
+         --timeout)
+	      timeout=${args[n+1]}
+              ((n++))
+              ;;
+         *)
+              pdfalto_params+=" ${args[n+1]}"
+              ;;
+   esac
+
+#  [[ ${args[n]} == '--timeout' ]] && echo "${args[n+1]}"
+done
+
 # kill -0 pid   Exit code indicates if a signal may be sent to $pid process.
 (
     ((t = timeout))

--- a/grobid-home/pdfalto/mac-64/pdfalto_server
+++ b/grobid-home/pdfalto/mac-64/pdfalto_server
@@ -14,12 +14,12 @@ pdfalto_params=()
 for ((n=0; n<="$#";n++)); do
    case ${args[n]} in
          --timeout)
-	      timeout=${args[n+1]}
-              ((n++))
-              ;;
+	        timeout=${args[n+1]}
+            ((n++))
+            ;;
          *)
-              pdfalto_params+=" ${args[n]}"
-              ;;
+            pdfalto_params+=" ${args[n]}"
+            ;;
    esac
 done
 
@@ -40,4 +40,4 @@ done
     kill -s SIGKILL $$
 ) 2> /dev/null &
 
-exec $command $@
+exec $command $pdfalto_params


### PR DESCRIPTION
This PR should add a dynamic timeout on the pdfalto_server script using the argument `--timeout XY`. #923 

It also avoid changing the virtual memory on mac Os. #894 