### PR TITLE
Allow absolute paths in temporary directory configuration 

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -337,8 +337,13 @@ public class GrobidProperties {
     public static File getTempPath() {
         if (grobidConfig.grobid.temp == null)
             return new File(System.getProperty("java.io.tmpdir"));
-        else 
-            return new File(grobidHome.getPath(), grobidConfig.grobid.temp);
+        else {
+            if (!new File(grobidConfig.grobid.temp).isAbsolute()) {
+                return new File(grobidHome.getPath(), grobidConfig.grobid.temp);
+            } else {
+                return new File(grobidConfig.grobid.temp);
+            }
+        }
     }
 
     public static void setNativeLibraryPath(final String nativeLibPath) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/IOUtilities.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/IOUtilities.java
@@ -209,16 +209,18 @@ public class IOUtilities {
         long threasholdMillisec =  currentDateMillisec - (maxLifeInSeconds*1000);
         if (dir.isDirectory() && (StringUtils.isEmpty(prefix) || dir.getName().startsWith(prefix))) {
             File[] children = dir.listFiles();
-            for (int i = 0; i < children.length; i++) {
-                if ((StringUtils.isEmpty(prefix) || children[i].getName().startsWith(prefix))) {
-                    long millisec = children[i].lastModified();
-                    if (millisec < threasholdMillisec) {
-                        success = deleteOldies(children[i], maxLifeInSeconds, prefix, false);
-                        if (!success) 
-                            return false;
+            if (children != null) {
+                for (int i = 0; i < children.length; i++) {
+                    if ((StringUtils.isEmpty(prefix) || children[i].getName().startsWith(prefix))) {
+                        long millisec = children[i].lastModified();
+                        if (millisec < threasholdMillisec) {
+                            success = deleteOldies(children[i], maxLifeInSeconds, prefix, false);
+                            if (!success) 
+                                return false;
+                        }
+                        else
+                            empty = false;
                     }
-                    else
-                        empty = false;
                 }
             }
         }

--- a/grobid-core/src/main/java/org/grobid/core/utilities/TextUtilities.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/TextUtilities.java
@@ -25,7 +25,7 @@ public class TextUtilities {
     public static final String punctuations = " •*,:;?.!)-−–\"“”‘’'`$]*\u2666\u2665\u2663\u2660\u00A0。、，・";
     public static final String fullPunctuations = "(（[ •*,:;?.!/)）-−–‐«»„\"“”‘’'`$#@]*\u2666\u2665\u2663\u2660\u00A0。、，・";
     public static final String restrictedPunctuations = ",:;?.!/-–«»„\"“”‘’'`*\u2666\u2665\u2663\u2660。、，・";
-    public static String delimiters = "\n\r\t\f\u00A0" + fullPunctuations;
+    public static String delimiters = "\n\r\t\f\u00A0\u200C" + fullPunctuations;
 
     public static final String OR = "|";
     public static final String NEW_LINE = "\n";

--- a/grobid-core/src/main/java/org/grobid/core/utilities/TextUtilities.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/TextUtilities.java
@@ -25,7 +25,7 @@ public class TextUtilities {
     public static final String punctuations = " •*,:;?.!)-−–\"“”‘’'`$]*\u2666\u2665\u2663\u2660\u00A0。、，・";
     public static final String fullPunctuations = "(（[ •*,:;?.!/)）-−–‐«»„\"“”‘’'`$#@]*\u2666\u2665\u2663\u2660\u00A0。、，・";
     public static final String restrictedPunctuations = ",:;?.!/-–«»„\"“”‘’'`*\u2666\u2665\u2663\u2660。、，・";
-    public static String delimiters = "\n\r\t\f\u00A0\u200C" + fullPunctuations;
+    public static String delimiters = "\n\r\t\f\u00A0" + fullPunctuations;
 
     public static final String OR = "|";
     public static final String NEW_LINE = "\n";

--- a/grobid-home/config/grobid.yaml
+++ b/grobid-home/config/grobid.yaml
@@ -4,8 +4,8 @@ grobid:
   # where all the Grobid resources are stored (models, lexicon, native libraries, etc.), normally no need to change
   grobidHome: "grobid-home"
 
-  # path relative to the grobid-home path (e.g. grobid-home/tmp)
-  temp: "tmp"
+  # path relative to the grobid-home path (e.g. tmp for grobid-home/tmp) or absolute path (/tmp)
+  temp: "/tmp"
   
   # normally nothing to change here, path relative to the grobid-home path (e.g. grobid-home/lib)
   nativelibrary: "lib"

--- a/grobid-home/config/grobid.yaml
+++ b/grobid-home/config/grobid.yaml
@@ -5,7 +5,7 @@ grobid:
   grobidHome: "grobid-home"
 
   # path relative to the grobid-home path (e.g. tmp for grobid-home/tmp) or absolute path (/tmp)
-  temp: "/tmp"
+  temp: "tmp"
   
   # normally nothing to change here, path relative to the grobid-home path (e.g. grobid-home/lib)
   nativelibrary: "lib"

--- a/grobid-home/config/resources-registry.json
+++ b/grobid-home/config/resources-registry.json
@@ -78,8 +78,8 @@
     "embeddings-contextualized": [
         {
             "name": "elmo-en",
-            "path-config": "/media/lopez/T51/embeddings/elmo_2x4096_512_2048cnn_2xhighway_5.5B/elmo_2x4096_512_2048cnn_2xhighway_5.5B_options.json",
-            "path_weights": "/media/lopez/T51/embeddings/elmo_2x4096_512_2048cnn_2xhighway_5.5B/elmo_2x4096_512_2048cnn_2xhighway_5.5B_weights.hdf5",
+            "path-config": "/opt/elmo/elmo_2x4096_512_2048cnn_2xhighway_5.5B_options.json",
+            "path_weights": "/opt/elmo/elmo_2x4096_512_2048cnn_2xhighway_5.5B_weights.hdf5",
             "path-vocab": "data/models/ELMo/en/vocab.txt",
             "path-cache": "data/models/ELMo/en/",
             "cache-training": true,
@@ -89,8 +89,8 @@
         },
         {
             "name": "elmo-pubmed",
-            "path-config": "/media/lopez/T51/embeddings/elmo-pubmed/elmo_2x4096_512_2048cnn_2xhighway_options_pubmed.json",
-            "path_weights": "/media/lopez/T51/embeddings/elmo-pubmed/elmo_2x4096_512_2048cnn_2xhighway_weights_PubMed_only.hdf5",
+            "path-config": "",
+            "path_weights": "",
             "path-vocab": "data/models/ELMo/en/vocab.txt",
             "path-cache": "data/models/ELMo/en/",
             "cache-training": true,
@@ -100,8 +100,8 @@
         },
         {
             "name": "elmo-fr",
-            "path-config": "/media/lopez/T51/embeddings/elmo_fr_020/elmo_fr_020_options.json",
-            "path_weights": "/media/lopez/T51/embeddings/elmo_fr_020/elmo_fr_020_weights.hdf5",
+            "path-config": "/opt/elmo_fr/elmo_fr_020_options.json",
+            "path_weights": "/opt/elmo_fr/elmo_fr_020/elmo_fr_020_weights.hdf5",
             "path-vocab": "data/models/ELMo/fr/vocab.txt",
             "path-cache": "data/models/ELMo/fr/",
             "cache-training": true,


### PR DESCRIPTION
This PR allows to use the temporary directory as it is (without concatenation to the grobid-home) when the specified directory is an absolute path. 