### PR TITLE
Improve JEP initialisation and DL model loading error logging

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTClassifierModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTClassifierModel.java
@@ -33,7 +33,7 @@ public class DeLFTClassifierModel {
         try {
             LOGGER.info("Loading DeLFT classification model for " + this.modelName + " in " + GrobidProperties.getInstance().getModelPath());
             JEPThreadPoolClassifier.getInstance().run(new InitModel(this.modelName, GrobidProperties.getInstance().getModelPath(), this.architecture));
-        } catch(InterruptedException e) {
+        } catch(InterruptedException | RuntimeException e) {
             LOGGER.error("DeLFT model " + this.modelName + " initialization failed", e);
         }
     }
@@ -68,6 +68,7 @@ public class DeLFTClassifierModel {
                         GrobidProperties.getInstance().getDelftRuntimeBatchSize(this.modelName));
 
             } catch(JepException e) {
+                LOGGER.error("DeLFT classifier model initialization failed. ", e);
                 throw new GrobidException("DeLFT classifier model initialization failed. ", e);
             }
         } 

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -32,7 +32,7 @@ public class DeLFTModel {
         try {
             LOGGER.info("Loading DeLFT model for " + model.getModelName() + " with architecture " + architecture + "...");            
             JEPThreadPool.getInstance().run(new InitModel(this.modelName, GrobidProperties.getInstance().getModelPath(), architecture));
-        } catch(InterruptedException e) {
+        } catch(InterruptedException | RuntimeException e) {
             LOGGER.error("DeLFT model " + this.modelName + " initialization failed", e);
         }
     }

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -75,6 +75,7 @@ public class DeLFTModel {
                 }
 
             } catch(JepException e) {
+                LOGGER.error("DeLFT model initialization failed. ", e);
                 throw new GrobidException("DeLFT model initialization failed. ", e);
             }
         } 

--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
@@ -162,7 +162,7 @@ public class JEPThreadPool {
     }
 
     public void run(Runnable task) throws InterruptedException {
-        System.out.println("running thread: " + Thread.currentThread().getId());
+        LOGGER.info("running thread: " + Thread.currentThread().getId());
         Future future = executor.submit(task);
         // wait until done (in ms)
         while (!future.isDone()) {

--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
@@ -119,6 +119,9 @@ public class JEPThreadPool {
         } catch(GrobidResourceException e) {
             LOGGER.error("DeLFT installation path invalid, JEP initialization failed", e);
             throw new RuntimeException("DeLFT installation path invalid, JEP initialization failed", e);
+        } catch (UnsatisfiedLinkError e) {
+            LOGGER.error("The JEP or DeLFT environment is not correctly installed. ", e);
+            throw new RuntimeException("Python/DeLFT/Jep environment not correctly installed. ", e);
         } finally {
             if (!success && (jep != null)) {
                 try {

--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
@@ -123,11 +123,16 @@ public class JEPThreadPool {
             LOGGER.error("The JEP or DeLFT environment is not correctly installed. ", e);
             throw new RuntimeException("Python/DeLFT/Jep environment not correctly installed. ", e);
         } finally {
-            if (!success && (jep != null)) {
-                try {
-                    jep.close();
-                } catch (JepException e) {
-                    LOGGER.error("failed to close JEP instance", e);
+            if (!success) {
+                if (jep != null) {
+                    try {
+                        jep.close();
+                    } catch (JepException e) {
+                        LOGGER.error("failed to close JEP instance", e);
+                    }
+                } else {
+                    LOGGER.error("JEP initialisation failed somewhere.");
+                    throw new RuntimeException("General failure in JEP. ");
                 }
             }
         }

--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPoolClassifier.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPoolClassifier.java
@@ -121,12 +121,20 @@ public class JEPThreadPoolClassifier {
         } catch(GrobidResourceException e) {
             LOGGER.error("DeLFT installation path invalid, JEP initialization failed", e);
             throw new RuntimeException("DeLFT installation path invalid, JEP initialization failed", e);
+        } catch (UnsatisfiedLinkError e) {
+            LOGGER.error("The JEP or DeLFT environment is not correctly installed. ", e);
+            throw new RuntimeException("Python/DeLFT/JEP environment not correctly installed. ", e);
         } finally {
-            if (!success && (jep != null)) {
-                try {
-                    jep.close();
-                } catch (JepException e) {
-                    LOGGER.error("failed to close JEP instance", e);
+            if (!success) {
+                if (jep != null) {
+                    try {
+                        jep.close();
+                    } catch (JepException e) {
+                        LOGGER.error("Failed to close JEP instance", e);
+                    }
+                } else {
+                    LOGGER.error("JEP initialisation failed somewhere.");
+                    throw new RuntimeException("General failure in JEP. ");
                 }
             }
         }
@@ -156,6 +164,7 @@ public class JEPThreadPoolClassifier {
     }
 
     public void run(Runnable task) throws InterruptedException {
+        LOGGER.info("running thread: " + Thread.currentThread().getId());
         Future future = executor.submit(task);
         // wait until done (in ms)
         while (!future.isDone()) {

--- a/grobid-core/src/main/java/org/grobid/core/main/LibraryLoader.java
+++ b/grobid-core/src/main/java/org/grobid/core/main/LibraryLoader.java
@@ -165,7 +165,7 @@ public class LibraryLoader {
 
                         if (SystemUtils.IS_OS_MAC) {
 //                            System.setProperty("java.library.path", System.getProperty("java.library.path") + ":" + libraryFolder.getAbsolutePath());
-                            System.loadLibrary("python" + pythonEnvironmentConfig.getPythonVersion() + "m");
+                            System.loadLibrary("python" + pythonEnvironmentConfig.getPythonVersion());
                             System.loadLibrary(DELFT_NATIVE_LIB_NAME);
                         } else if (SystemUtils.IS_OS_LINUX) {
                             System.loadLibrary(DELFT_NATIVE_LIB_NAME);


### PR DESCRIPTION
This PR tries to show an error at startup when JEP is not correctly initialised: 

For example: 
```
INFO  [2022-08-09 14:23:57,617] org.grobid.core.jni.DeLFTModel: Loading DeLFT model for quantities with architecture BidLSTM_CRF...
running thread: 1
INFO  [2022-08-09 14:23:57,623] org.grobid.core.jni.JEPThreadPool: Creating JEP instance for thread 16
ERROR [2022-08-09 14:23:57,633] org.grobid.core.jni.JEPThreadPool: JEP initialisation failed somewhere.
```

The startup will continue, however at least there is a trace in the log file. 