### PR TITLE
Link footnotes in the text 

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/Footnote.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/Footnote.java
@@ -1,0 +1,90 @@
+package org.grobid.core.data;
+
+import org.grobid.core.layout.LayoutToken;
+import org.grobid.core.layout.Page;
+
+import java.util.List;
+
+import static com.google.common.collect.Iterables.getLast;
+
+public class Footnote {
+
+    private int number;
+
+    private List<LayoutToken> tokens;
+
+    private String text;
+
+    private int offsetStartInPage;
+
+    private boolean ignored = false;
+
+    public Footnote() {
+    }
+
+    public Footnote(int number, List<LayoutToken> tokens, String text) {
+        this.number = number;
+        this.tokens = tokens;
+        this.text = text;
+    }
+
+    public Footnote(int number, List<LayoutToken> tokens, String text, int offsetStartInPage) {
+        this.number = number;
+        this.tokens = tokens;
+        this.text = text;
+        this.offsetStartInPage = offsetStartInPage;
+    }
+
+    public Footnote(int number, List<LayoutToken> tokens) {
+        this.number = number;
+        this.tokens = tokens;
+    }
+
+    public int getOffsetStartInPage() {
+        return offsetStartInPage;
+    }
+
+    public void setOffsetStartInPage(int offsetStartInPage) {
+        this.offsetStartInPage = offsetStartInPage;
+    }
+
+    public int getPageNumber() {
+        return tokens.get(0).getPage();
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public List<LayoutToken> getTokens() {
+        return tokens;
+    }
+
+    public void setTokens(List<LayoutToken> tokens) {
+        this.tokens = tokens;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public void setNumber(int number) {
+        this.number = number;
+    }
+
+    public int getOffsetEndInPage() {
+        return getLast(tokens).getOffset();
+    }
+
+    public boolean isIgnored() {
+        return ignored;
+    }
+
+    public void setIgnored(boolean ignored) {
+        this.ignored = ignored;
+    }
+}


### PR DESCRIPTION
This PR aims to link footnotes (already extracted from the segmentation model) to the text. 
This current implementation uses an heuristic that uses the footnote number and search for the marker in the paragraph text from the same page as the footnote. 

As an example: 
<img width="722" alt="image" src="https://user-images.githubusercontent.com/15426/187045074-f89a830c-e2b8-4249-b10b-15a198a06fbb.png">

The result is injected in the output XML as (using the same strategy as the references): 

```xml
The building blocks for these theories are phrasal or clausal units, and the targets of the analyses are usually very short texts, typically one to three paragraphs in length.
                    <ref type="foot" target="#b5">5</ref> Many problems in discourse analysis, such as dialogue generation and turntaking 
                    <ref type="bibr" target="#b47">(Moore and Pollack 1992;</ref>
```

What still to verify: 
 - when we look up in the text, we might incorrectly link to the wrong place. When we have a list usually is when we get false positives. Example: 

<img width="724" alt="Untitled" src="https://user-images.githubusercontent.com/15426/187045220-f518122f-721c-4fe3-a269-3b817d0ae6d6.png">

and the output is linked to the list item: 

 ```xml
    <p>the relative length of the document,
                    <ref type="foot" target="#b2">2</ref>. the frequency of the term sets in the document, and 3. the distribution of the term sets with respect to the document and to each other.
                </p>
    ```

 - the subscript/superscript are not reliable and I did not find a consistent alternative way to know when a marker in the text is not a footnote marker. 
 
