### PR TITLE
Incremental training for Deep Learning and Wapiti models

### DIFF
--- a/doc/Grobid-service.md
+++ b/doc/Grobid-service.md
@@ -751,6 +751,7 @@ Launch a training for a given model. The service return back a training token (a
 |           |                     |                      | type | optional | type of training, `full`, `holdout`, `split`, `nfold`, default is `split` |
 |           |                     |                      | ratio | optional | only considered for `split` training mode, give the ratio (number bewteen 0 and 1) of training and evaluation data when splitting the annotated data, default is `0.9` |
 |           |                     |                      | n | optional | only considered for `nfold` training mode, give the number of folds to be used, default is `10` |
+|           |                     |                      | `incremental` | optional | boolean indicating if the training should be incremental (`1`) starting from the existing model, or not (default, `0`) |
 
 The `type` of training indicates which training and evaluation mode should be used:
 - `full`: the whole available training data is used for training a model

--- a/doc/Training-the-models-of-Grobid.md
+++ b/doc/Training-the-models-of-Grobid.md
@@ -28,7 +28,7 @@ Grobid uses different sequence labelling models depending on the labeling task t
 
 * table
 
-The models are located under `grobid/grobid-home/models`. Each of these models can be retrained using amended or additional training data. For production, a model is trained with all the available training data to maximize the performance. For development purposes, it is also possible to evaluate a model with part of the training data. 
+The models are located under `grobid/grobid-home/models`. Each of these models can be retrained using amended or additional training data. For production, a model is trained with all the available training data to maximize the performance. For development purposes, it is also possible to evaluate a model with part of the training data as frozen set (e.g. holdout set), automatic random split or apply 10-fold cross-evaluation. 
 
 ## Train and evaluate
 
@@ -43,56 +43,88 @@ When generating a new model, a segmentation of data can be done (e.g. 80%-20%) b
 
 There are different ways to generate the new model and run the evaluation, whether running the training and the evaluation of the new model separately or not, and whether to split automatically the training data or not. For any methods, the newly generated models are saved directly under grobid-home/models and replace the previous one. A rollback can be made by replacing the newly generated model by the backup record (`<model name>.wapiti.old`).
 
-### Train and evaluation in one command
-Under the main project directory `grobid/`, run the following command to execute both training and evaluation: 
-```bash
-> ./gradlew <training goal. I.E: train_name-header>
-```
-Example of goal names: `train_header`, `train_date`, `train_name_header`, `train_name_citation`, `train_citation`, `train_affiliation_address`, `train_fulltext`, `train_patent_citation`, ...
+### Train and evaluation in one command (simple mode)
 
-The files used for the training are located under `grobid/grobid-trainer/resources/dataset/*MODEL*/corpus`, and the evaluation files under `grobid/grobid-trainer/resources/dataset/*MODEL*/evaluation`. 
+For simple training without particular parameters, a single command can be used as follow. All the available annotated files under `grobid/grobid-trainer/resources/dataset/*MODEL*/corpus` will be used for trainng and all available annotated files under `grobid/grobid-trainer/resources/dataset/*MODEL*/evaluation/` will be used for evaluation.
+
+Under the main project directory `grobid/`, run the following command to execute both training and evaluation: 
+
+```bash
+> ./gradlew train_<name_of_model>
+```
+
+Example: `train_header`, `train_date`, `train_name_header`, `train_name_citation`, `train_citation`, `train_affiliation_address`, `train_fulltext`, `train_patent_citation`, ...
 
 Examples for training the header model: 
+
 ```bash
 > ./gradlew train_header
 ```
+
 Examples for training the model for names in header: 
+
 ```bash
 > ./gradlew train_name_header 
 ```
 
-### Train and evaluation separately
-Under the main project directory `grobid/`, execute the following command (be sure to have built the project as indicated in [Install GROBID](Install-Grobid.md)):
+### Train and evaluation separately and using more parameters (full mode)
 
-Train (generate a new model):
+To have more flexibility and options for training and evaluating the models, use the following commands. 
+
+First be sure to have the full project libraries locally built (see [Install GROBID](Install-Grobid.md) for nore details): 
+
+```bash
+> ./gradlew clean install
+```
+
+Under the main project directory `grobid/`:
+
+**Train** (generate a new model):
+
 ```bash
 > java -Xmx1024m -jar grobid-trainer/build/libs/grobid-trainer-<current version>-onejar.jar 0 <name of the model> -gH grobid-home
 ```
+
 The training files considered are located under `grobid/grobid-trainer/resources/dataset/*MODEL*/corpus`
 
 The training of the models can be controlled using different parameters. The `nbThreads` parameter in the configuration file `grobid-home/config/grobid.yaml` can be increased to speed up the training. Similarly, modifying the stopping criteria can help speed up the training. Please refer [this comment](https://github.com/kermitt2/grobid/issues/336#issuecomment-412516422) to know more.
 
-Evaluate:
+**Evaluate**:
+
 ```bash
 > java -Xmx1024m -jar grobid-trainer/build/libs/grobid-trainer-<current version>-onejar.jar 1 <name of the model> -gH grobid-home
 ```
 
 The considered evaluation files are located under `grobid/grobid-trainer/resources/dataset/*MODEL*/evaluation`
 
-Automatically split data, train and evaluate:
+**Automatically split data, train and evaluate**:
+
 ```bash
 > java -Xmx1024m -jar grobid-trainer/build/libs/grobid-trainer-<current version>-onejar.jar 2 <name of the model> -gH grobid-home -s <segmentation ratio as a number between 0 and 1, e.g. 0.8 for 80%>
 ```
 
 For instance, training the date model with a ratio of 75% for training and 25% for evaluation:
+
 ```bash
 > java -Xmx1024m -jar grobid-trainer/build/libs/grobid-trainer-<current version>-onejar.jar 2 date -gH grobid-home -s 0.75
 ```
 
-A ratio of 1.0 means that all the data available under `grobid/grobid-trainer/resources/dataset/*MODEL*/corpus/` will be used for training the model, and the evaluation will be empty. *Automatic split data, train and evaluate* is for the moment only available for the following models: header, citation, date, name-citation, name-header and affiliation-address.
+A ratio of 1.0 means that all the data available under `grobid/grobid-trainer/resources/dataset/*MODEL*/corpus/` will be used for training the model, and the evaluation will be empty. 
 
-Several runs with different files to evaluate can be made to have a more reliable evaluation (e.g. 10 fold cross-validation). For the time being, such segmentation and iterative evaluation is not yet implemented. 
+**Incremental training**: 
 
+The previous commands were starting a training from scratch, using all available training data in one training task. 
+Incremental training will start from an existing already train model and apply a further training task using the available training data under `grobid/grobid-trainer/resources/dataset/*MODEL*/corpus`. 
+
+Launching an incremental training is similar as the previous commands, but adding the parameter `-i`. An existing model under `grobid/grobid-home/models/*MODEL*` must be available. For example:
+
+```bash
+> java -Xmx1024m -jar grobid-trainer/build/libs/grobid-trainer-<current version>-onejar.jar 0 <name of the model> -gH grobid-home -i
+```
+
+Note that a full training from scratch with all training data should normally provide better accuracy for a model than several iterative training with a partition of the training data. Using incremental training makes sense for exemple when the model has been trained with a lot of data during days/weeks, and an update is required, or for the development of training data when the update of a model must be quick to generate new trainng data. 
+
+In incremental training phases, the training parameters might require some update to stop the training earlier than in normal full training. 
 
 ### N-folds cross-evaluation
 

--- a/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/DeLFTModel.java
@@ -271,7 +271,7 @@ public class DeLFTModel {
                 else
                     jep.eval("model = Sequence('"+this.modelName+
                         "', max_epoch=100, recurrent_dropout=0.50, embeddings_name='glove-840B', use_ELMo="+useELMo+localArgs+ 
-                        ", model_type='"+architecture+"')");
+                        ", architecture='"+architecture+"')");
 
                 // actual training
                 //start_time = time.time()
@@ -280,6 +280,7 @@ public class DeLFTModel {
                     if (this.modelPath != null && 
                         this.modelPath.exists() &&
                         !this.modelPath.isDirectory()) {
+                        jep.eval("model.load('" + this.modelPath.getAbsolutePath() + "')");
                         jep.eval("model.train(x_train, y_train, x_valid, y_valid, incremental=True)");
                     } else {
                         throw new GrobidException("the path to the model to be used for starting incremental training is invalid: " +

--- a/grobid-core/src/test/java/org/grobid/core/test/TestHeaderParser.java
+++ b/grobid-core/src/test/java/org/grobid/core/test/TestHeaderParser.java
@@ -35,9 +35,10 @@ public class TestHeaderParser extends EngineTest {
         getTestResourcePath();
 
         String pdfPath = testPath + File.separator + "Wang-paperAVE2008.pdf";
+        File pdfFile = new File(pdfPath);
         BiblioItem resHeader = new BiblioItem();
 
-        String tei = engine.processHeader(pdfPath, 0, resHeader);
+        String tei = engine.processHeader(pdfFile.getAbsolutePath(), 0, resHeader);
 
         assertNotNull(resHeader);
         assertThat(resHeader.getTitle(), is("Information Synthesis for Answer Validation"));

--- a/grobid-service/src/main/java/org/grobid/service/GrobidRestService.java
+++ b/grobid-service/src/main/java/org/grobid/service/GrobidRestService.java
@@ -286,14 +286,14 @@ public class GrobidRestService implements GrobidPaths {
 
     private boolean validateGenerateIdParam(String generateIDs) {
         boolean generate = false;
-        if ((generateIDs != null) && (generateIDs.equals("1"))) {
+        if ((generateIDs != null) && (generateIDs.equals("1") || generateIDs.equals("true"))) {
             generate = true;
         }
         return generate;
     }
 
     private boolean validateIncludeRawParam(String includeRaw) {
-        return ((includeRaw != null) && (includeRaw.equals("1")));
+        return ((includeRaw != null) && (includeRaw.equals("1") || includeRaw.equals("true")));
     }
 
     private int validateConsolidationParam(String consolidate) {
@@ -791,8 +791,10 @@ public class GrobidRestService implements GrobidPaths {
                                @DefaultValue("crf") @FormParam("architecture") String architecture,
                                @DefaultValue("split") @FormParam("type") String type, 
                                @DefaultValue("0.9") @FormParam("ratio") double ratio, 
-                               @DefaultValue("10") @FormParam("n") int n) {
-        return restProcessTraining.trainModel(model, architecture, type, ratio, n);
+                               @DefaultValue("10") @FormParam("n") int n,
+                               @DefaultValue("0") @FormParam("incremental") String incremental) {
+        boolean incrementalVal = validateIncludeRawParam(incremental);
+        return restProcessTraining.trainModel(model, architecture, type, ratio, n, incrementalVal);
     }
 
     @Path(PATH_TRAINING_RESULT)

--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessTraining.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessTraining.java
@@ -128,7 +128,8 @@ public class GrobidRestProcessTraining {
                         for (final File currFile : files) {
                             if (currFile.getName().toLowerCase().endsWith(".hdf5")
                                 || currFile.getName().toLowerCase().endsWith(".json") 
-                                || currFile.getName().toLowerCase().endsWith(".pkl")) {
+                                || currFile.getName().toLowerCase().endsWith(".pkl")
+                                || currFile.getName().toLowerCase().endsWith(".txt")) {
                                 try {
                                     ZipEntry ze = new ZipEntry(currFile.getName());
                                     out.putNextEntry(ze);
@@ -309,14 +310,14 @@ public class GrobidRestProcessTraining {
                 switch (this.type.toLowerCase()) {
                     // possible values are `full`, `holdout`, `split`, `nfold`
                     case "full":
-                        AbstractTrainer.runTraining(this.trainer);
+                        AbstractTrainer.runTraining(this.trainer, false);
                         break;
                     case "holdout":
                         AbstractTrainer.runTraining(this.trainer);
                         results = AbstractTrainer.runEvaluation(this.trainer);
                         break;
                     case "split":
-                        results = AbstractTrainer.runSplitTrainingEvaluation(this.trainer, this.ratio);
+                        results = AbstractTrainer.runSplitTrainingEvaluation(this.trainer, this.ratio, false);
                         break;
                     case "nfold":
                         if (n == 0) {

--- a/grobid-trainer/src/main/java/org/grobid/trainer/AbstractTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/AbstractTrainer.java
@@ -79,6 +79,11 @@ public abstract class AbstractTrainer implements Trainer {
     }
 
     @Override
+    public void train() {
+        train(false);
+    }
+
+    @Override
     public void train(boolean incremental) {
         final File dataPath = trainDataPath;
         createCRFPPData(getCorpusPath(), dataPath);
@@ -131,6 +136,11 @@ public abstract class AbstractTrainer implements Trainer {
     public String evaluate(GenericTagger tagger, boolean includeRawResults) {
         createCRFPPData(getEvalCorpusPath(), evalDataPath);
         return EvaluationUtilities.evaluateStandard(evalDataPath.getAbsolutePath(), tagger).toString(includeRawResults);
+    }
+
+    @Override
+    public String splitTrainEvaluate(Double split) {
+        return splitTrainEvaluate(split, false);
     }
 
     @Override
@@ -579,6 +589,10 @@ public abstract class AbstractTrainer implements Trainer {
 
     public static String runEvaluation(final Trainer trainer) {
         return trainer.evaluate(false);
+    }
+
+    public static String runSplitTrainingEvaluation(final Trainer trainer, Double split) {
+        return runSplitTrainingEvaluation(trainer, split, false);
     }
 
     public static String runSplitTrainingEvaluation(final Trainer trainer, Double split, boolean incremental) {

--- a/grobid-trainer/src/main/java/org/grobid/trainer/CRFPPGenericTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/CRFPPGenericTrainer.java
@@ -29,6 +29,11 @@ public class CRFPPGenericTrainer implements GenericTrainer {
     }
 
     @Override
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+        train(template, trainingData, outputModel, numThreads, model, false);
+    }
+
+    @Override
     public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
         crfppTrainer.train(template.getAbsolutePath(), trainingData.getAbsolutePath(), outputModel.getAbsolutePath(), numThreads);
         if (!crfppTrainer.what().isEmpty()) {

--- a/grobid-trainer/src/main/java/org/grobid/trainer/CRFPPGenericTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/CRFPPGenericTrainer.java
@@ -29,7 +29,7 @@ public class CRFPPGenericTrainer implements GenericTrainer {
     }
 
     @Override
-    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
         crfppTrainer.train(template.getAbsolutePath(), trainingData.getAbsolutePath(), outputModel.getAbsolutePath(), numThreads);
         if (!crfppTrainer.what().isEmpty()) {
             LOGGER.warn("CRF++ Trainer warnings:\n" + crfppTrainer.what());

--- a/grobid-trainer/src/main/java/org/grobid/trainer/DeLFTTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/DeLFTTrainer.java
@@ -14,8 +14,8 @@ public class DeLFTTrainer implements GenericTrainer {
     public static final String DELFT = "delft";
 
     @Override
-    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
-        DeLFTModel.train(model.getModelName(), trainingData, outputModel, GrobidProperties.getDelftArchitecture(model));
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
+        DeLFTModel.train(model.getModelName(), trainingData, outputModel, GrobidProperties.getDelftArchitecture(model), incremental);
     }
 
     @Override

--- a/grobid-trainer/src/main/java/org/grobid/trainer/DeLFTTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/DeLFTTrainer.java
@@ -14,6 +14,11 @@ public class DeLFTTrainer implements GenericTrainer {
     public static final String DELFT = "delft";
 
     @Override
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+        train(template, trainingData, outputModel, numThreads, model, false);
+    }
+
+    @Override
     public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
         DeLFTModel.train(model.getModelName(), trainingData, outputModel, GrobidProperties.getDelftArchitecture(model), incremental);
     }

--- a/grobid-trainer/src/main/java/org/grobid/trainer/DummyTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/DummyTrainer.java
@@ -9,6 +9,11 @@ import java.io.File;
  */
 public class DummyTrainer implements GenericTrainer {
     @Override
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+
+    }
+
+    @Override
     public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
 
     }

--- a/grobid-trainer/src/main/java/org/grobid/trainer/DummyTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/DummyTrainer.java
@@ -9,7 +9,7 @@ import java.io.File;
  */
 public class DummyTrainer implements GenericTrainer {
     @Override
-    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
 
     }
 

--- a/grobid-trainer/src/main/java/org/grobid/trainer/GenericTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/GenericTrainer.java
@@ -5,6 +5,7 @@ import org.grobid.core.GrobidModels;
 import java.io.File;
 
 public interface GenericTrainer {
+    void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model);
     void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental);
     String getName();
 	public void setEpsilon(double epsilon);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/GenericTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/GenericTrainer.java
@@ -5,7 +5,7 @@ import org.grobid.core.GrobidModels;
 import java.io.File;
 
 public interface GenericTrainer {
-    void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model);
+    void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental);
     String getName();
 	public void setEpsilon(double epsilon);
 	public void setWindow(int window);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/Trainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/Trainer.java
@@ -12,7 +12,7 @@ public interface Trainer {
 
 	int createCRFPPData(File corpusPath, File outputTrainingFile, File outputEvalFile, double splitRatio);
 
-    void train();
+    void train(boolean incremental);
 
     String evaluate();
 
@@ -20,7 +20,7 @@ public interface Trainer {
 
     String evaluate(GenericTagger tagger, boolean includeRawResults);
 
-	String splitTrainEvaluate(Double split);
+	String splitTrainEvaluate(Double split, boolean incremental);
 
 	String nFoldEvaluate(int folds);
 

--- a/grobid-trainer/src/main/java/org/grobid/trainer/Trainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/Trainer.java
@@ -12,6 +12,8 @@ public interface Trainer {
 
 	int createCRFPPData(File corpusPath, File outputTrainingFile, File outputEvalFile, double splitRatio);
 
+    void train();
+
     void train(boolean incremental);
 
     String evaluate();
@@ -19,6 +21,8 @@ public interface Trainer {
     String evaluate(boolean includeRawResults);
 
     String evaluate(GenericTagger tagger, boolean includeRawResults);
+
+    String splitTrainEvaluate(Double split);
 
 	String splitTrainEvaluate(Double split, boolean incremental);
 

--- a/grobid-trainer/src/main/java/org/grobid/trainer/TrainerRunner.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/TrainerRunner.java
@@ -53,6 +53,7 @@ public class TrainerRunner {
         double split = 0.0;
         int numFolds = 0;
         String outputFilePath = null;
+        boolean incremental = false;
         for (int i = 0; i < args.length; i++) {
             if (args[i].equals("-gH")) {
                 if (i + 1 == args.length) {
@@ -84,6 +85,9 @@ public class TrainerRunner {
                     throw new IllegalStateException("Missing output file. ");
                 }
                 outputFilePath = args[i + 1];
+
+            } else if (args[i].equals("-i")) {
+                incremental = true;
 
             }
         }
@@ -136,13 +140,13 @@ public class TrainerRunner {
 
         switch (mode) {
             case TRAIN:
-                AbstractTrainer.runTraining(trainer);
+                AbstractTrainer.runTraining(trainer, incremental);
                 break;
             case EVAL:
                 System.out.println(AbstractTrainer.runEvaluation(trainer));
                 break;
             case SPLIT:
-                System.out.println(AbstractTrainer.runSplitTrainingEvaluation(trainer, split));
+                System.out.println(AbstractTrainer.runSplitTrainingEvaluation(trainer, split, incremental));
                 break;
             case EVAL_N_FOLD:
                 if(numFolds == 0) {
@@ -154,7 +158,7 @@ public class TrainerRunner {
                         System.err.println("Output file exists. ");
                     }
                 } else {
-                    String results = AbstractTrainer.runNFoldEvaluation(trainer, numFolds);
+                    String results = AbstractTrainer.runNFoldEvaluation(trainer, numFolds, incremental);
                     System.out.println(results);
                 }
                 break;

--- a/grobid-trainer/src/main/java/org/grobid/trainer/WapitiTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/WapitiTrainer.java
@@ -18,7 +18,7 @@ public class WapitiTrainer implements GenericTrainer {
     protected int nbMaxIterations = 2000; // by default maximum of training iterations
 
     @Override
-    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
 		System.out.println("\tepsilon: " + epsilon);
 		System.out.println("\twindow: " + window);
         System.out.println("\tnb max iterations: " + nbMaxIterations);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/WapitiTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/WapitiTrainer.java
@@ -18,6 +18,11 @@ public class WapitiTrainer implements GenericTrainer {
     protected int nbMaxIterations = 2000; // by default maximum of training iterations
 
     @Override
+    public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model) {
+        train(template, trainingData, outputModel, numThreads, model, false);
+    }
+
+    @Override
     public void train(File template, File trainingData, File outputModel, int numThreads, GrobidModel model, boolean incremental) {
 		System.out.println("\tepsilon: " + epsilon);
 		System.out.println("\twindow: " + window);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/WapitiTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/WapitiTrainer.java
@@ -23,11 +23,21 @@ public class WapitiTrainer implements GenericTrainer {
 		System.out.println("\twindow: " + window);
         System.out.println("\tnb max iterations: " + nbMaxIterations);
 		System.out.println("\tnb threads: " + numThreads);
+
+        String incrementalBlock = "";
+        if (incremental) {
+            String inputModelPath = outputModel.getAbsolutePath();
+            if (inputModelPath.endsWith(".new"))
+                inputModelPath = inputModelPath.substring(0, inputModelPath.length()-4);
+            System.out.println("\tincremental training from: " + inputModelPath);
+            incrementalBlock += " -m " + inputModelPath;
+        }
+
         WapitiModel.train(template, trainingData, outputModel, "--nthread " + numThreads +
 //       		" --algo sgd-l1" +
 			" -e " + BigDecimal.valueOf(epsilon).toPlainString() +
 			" -w " + window +
-			" -i " + nbMaxIterations
+			" -i " + nbMaxIterations + incrementalBlock
         );
     }
 


### PR DESCRIPTION
Support incremental training for Deep Learning models. 

We simply add `-i` to the training command, and the training will resume from the existing model instead of starting from scratch with a new model.

```bash
> java -Xmx1024m -jar grobid-trainer/build/libs/grobid-trainer-<current version>-onejar.jar 0 <name of the model> -gH grobid-home -i
``` 

See https://github.com/kermitt2/delft/pull/147 

It does work for CRF Wapiti too. 

