### PR TITLE
Temporary fix to Windows pdfalto issue #862

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/DocumentSource.java
@@ -83,7 +83,11 @@ public class DocumentSource {
         pdfToXml.append(
                 GrobidProperties.isContextExecutionServer() ? File.separator + "pdfalto_server" : File.separator + "pdfalto");
 
-        pdfToXml.append(" -fullFontName -noLineNumbers");
+        pdfToXml.append(" -fullFontName");
+
+        if (!SystemUtils.IS_OS_WINDOWS) {
+            pdfToXml.append(" -noLineNumbers");
+        }
 
         if (!withImage) {
             pdfToXml.append(" -noImage ");
@@ -144,7 +148,10 @@ public class DocumentSource {
             cmd.add(pdfPath.getAbsolutePath());
             cmd.add(tmpPathXML.getAbsolutePath());
             if (GrobidProperties.isContextExecutionServer()) {
-                cmd.add("--timeout");
+                if (!SystemUtils.IS_OS_WINDOWS) {
+                    cmd.add("--timeout");
+                    cmd.add(String.valueOf(GrobidProperties.getPdfaltoTimeoutS()));
+                }
                 cmd.add(String.valueOf(GrobidProperties.getPdfaltoTimeoutS()));
                 tmpPathXML = processPdfaltoServerMode(pdfPath, tmpPathXML, cmd);
             } else {


### PR DESCRIPTION
Have modified the generated command on Windows to work without the `-noLineNumbers` and the `--timeout XXX` options.

NOTE: This does not fix all issues on Grobid on Windows !