### PR TITLE
Minor update to the docker images

### DIFF
--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -39,6 +39,7 @@ COPY grobid-trainer/ ./grobid-trainer/
 RUN rm -rf grobid-home/pdf2xml
 RUN rm -rf grobid-home/pdfalto/lin-32
 RUN rm -rf grobid-home/pdfalto/mac-64
+RUN rm -rf grobid-home/pdfalto/mac_arm-64
 RUN rm -rf grobid-home/pdfalto/win-*
 RUN rm -rf grobid-home/lib/lin-32
 RUN rm -rf grobid-home/lib/win-*

--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -41,6 +41,7 @@ COPY grobid-trainer/ ./grobid-trainer/
 RUN rm -rf grobid-home/pdf2xml
 RUN rm -rf grobid-home/pdfalto/lin-32
 RUN rm -rf grobid-home/pdfalto/mac-64
+RUN rm -rf grobid-home/pdfalto/mac_arm-64
 RUN rm -rf grobid-home/pdfalto/win-*
 RUN rm -rf grobid-home/lib/lin-32
 RUN rm -rf grobid-home/lib/win-*


### PR DESCRIPTION
Remove the mac arm libraries from the linux-based docker images. 
Until we build a multi-arch image we don't need these libraries to be there. 