### PR TITLE
correct <title> coordinates attribute name

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -2263,7 +2263,7 @@ public class BiblioItem {
                         if (titleTokens != null && titleTokens.size()>0) {
                             String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                             if (coords != null && coords.length()>0) {
-                                tei.append(" coord=\"" + coords + "\"");
+                                tei.append(" coords=\"" + coords + "\"");
                             }
                         } 
                     }
@@ -2276,7 +2276,7 @@ public class BiblioItem {
                         if (titleTokens != null && titleTokens.size()>0) {
                             String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                             if (coords != null && coords.length()>0) {
-                                tei.append(" coord=\"" + coords + "\"");
+                                tei.append(" coords=\"" + coords + "\"");
                             }
                         } 
                     }
@@ -2426,7 +2426,7 @@ public class BiblioItem {
                     if (titleTokens != null && titleTokens.size()>0) {
                         String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                         if (coords != null && coords.length()>0) {
-                            tei.append(" coord=\"" + coords + "\"");
+                            tei.append(" coords=\"" + coords + "\"");
                         }
                     } 
                 }
@@ -2450,7 +2450,7 @@ public class BiblioItem {
                         if (titleTokens != null && titleTokens.size()>0) {
                             String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                             if (coords != null && coords.length()>0) {
-                                tei.append(" coord=\"" + coords + "\"");
+                                tei.append(" coords=\"" + coords + "\"");
                             }
                         } 
                     }
@@ -2682,7 +2682,7 @@ public class BiblioItem {
                         if (titleTokens != null && titleTokens.size()>0) {
                             String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                             if (coords != null && coords.length()>0) {
-                                tei.append(" coord=\"" + coords + "\"");
+                                tei.append(" coords=\"" + coords + "\"");
                             }
                         } 
                     }
@@ -2709,7 +2709,7 @@ public class BiblioItem {
                         if (titleTokens != null && titleTokens.size()>0) {
                             String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                             if (coords != null && coords.length()>0) {
-                                tei.append(" coord=\"" + coords + "\"");
+                                tei.append(" coords=\"" + coords + "\"");
                             }
                         } 
                     }
@@ -3791,7 +3791,7 @@ public class BiblioItem {
             List<LayoutToken> affTokens = aff.getLayoutTokens();
             String coords = LayoutTokensUtil.getCoordsString(affTokens);
             if (coords != null && coords.length()>0) {
-                tei.append(" coord=\"" + coords + "\"");
+                tei.append(" coords=\"" + coords + "\"");
             }
         }
         tei.append(">\n");

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -154,7 +154,7 @@ public class TEIFormatter {
             if (titleTokens != null && titleTokens.size()>0) {
                 String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                 if (coords != null) {
-                    tei.append(" coord=\"" + coords + "\"");
+                    tei.append(" coords=\"" + coords + "\"");
                 }
             }
         }
@@ -394,7 +394,7 @@ public class TEIFormatter {
                 if (titleTokens != null && titleTokens.size()>0) {
                     String coords = LayoutTokensUtil.getCoordsString(titleTokens);
                     if (coords != null) {
-                        tei.append(" coord=\"" + coords + "\"");
+                        tei.append(" coords=\"" + coords + "\"");
                     }
                 }
             }

--- a/grobid-core/src/main/java/org/grobid/core/engines/ProcessEngine.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/ProcessEngine.java
@@ -137,7 +137,7 @@ public class ProcessEngine implements Closeable {
         } else {
             List<String> elementCoordinates = null;
             if (pGbdArgs.getTeiCoordinates()) {
-                elementCoordinates = Arrays.asList("figure", "persName", "ref", "biblStruct", "formula", "s", "note");
+                elementCoordinates = Arrays.asList("figure", "persName", "ref", "biblStruct", "formula", "s", "note", "title", "head");
             }
             processFullTextDirectory(files, pGbdArgs, pGbdArgs.getPath2Output(), pGbdArgs.getSaveAssets(), 
                 elementCoordinates, pGbdArgs.getSegmentSentences(), pGbdArgs.getAddElementId());

--- a/grobid-service/src/main/resources/web/grobid/grobid.js
+++ b/grobid-service/src/main/resources/web/grobid/grobid.js
@@ -13,7 +13,7 @@ var grobid = (function($) {
 
 	var block = 0;
 
-    var elementCoords = ['s', 'biblStruct', 'persName', 'figure', 'formula', 'head', 'note'];
+    var elementCoords = ['p', 's', 'biblStruct', 'persName', 'figure', 'formula', 'head', 'note', 'title'];
 
 	function defineBaseURL(ext) {
 		var baseUrl = null;

--- a/grobid-service/src/main/resources/web/grobid/grobid.js
+++ b/grobid-service/src/main/resources/web/grobid/grobid.js
@@ -13,7 +13,7 @@ var grobid = (function($) {
 
 	var block = 0;
 
-    var elementCoords = ['p', 's', 'biblStruct', 'persName', 'figure', 'formula', 'head', 'note', 'title'];
+    var elementCoords = ['s', 'biblStruct', 'persName', 'figure', 'formula', 'head', 'note', 'title'];
 
 	function defineBaseURL(ext) {
 		var baseUrl = null;


### PR DESCRIPTION
The attribute for the coordinates in titles is 'coord' instead of 'coords'. 

I assume it was a typo, and it should be consistent with the rest of the TEI output, anyway it was easier to submit a PR than to ask first :smile: