### PR TITLE
Fix missing coordinates in paragraphs continuation 

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1488,6 +1488,13 @@ public class TEIFormatter {
                         
                         curDiv.appendChild(curParagraph);
                         curParagraphTokens = new ArrayList<>();
+                    } else {
+                        if (config.isGenerateTeiCoordinates("p")) {
+                            String coords = LayoutTokensUtil.getCoordsString(clusterTokens);
+                            if (curParagraph.getAttribute("coords") != null && !curParagraph.getAttributeValue("coords").contains(coords)) {
+                                curParagraph.addAttribute(new Attribute("coords", curParagraph.getAttributeValue("coords") + ";" + coords));
+                            }
+                        }
                     }
                     curParagraph.appendChild(clusterContent);
                     curParagraphTokens.addAll(clusterTokens);

--- a/grobid-service/src/main/resources/web/grobid/grobid.js
+++ b/grobid-service/src/main/resources/web/grobid/grobid.js
@@ -13,7 +13,7 @@ var grobid = (function($) {
 
 	var block = 0;
 
-    var elementCoords = ['s', 'biblStruct', 'persName', 'figure', 'formula', 'head', 'note', 'title', 'affiliation'];
+    var elementCoords = ['p', 's', 'biblStruct', 'persName', 'figure', 'formula', 'head', 'note', 'title', 'affiliation'];
 
 	function defineBaseURL(ext) {
 		var baseUrl = null;
@@ -239,10 +239,15 @@ var grobid = (function($) {
 
 	function ShowRequest1(formData, jqForm, options) {
         var addCoordinates = false;
+        var segmentSentences = false;
         for(var formd in formData) {
             if (formData[formd].name == 'teiCoordinates') {
                 addCoordinates = true;
             }
+            if (formData[formd].name == 'segmentSentences') {
+                segmentSentences = true;
+            }
+            
         }
         if (addCoordinates) {
             for (var i in elementCoords) {
@@ -251,6 +256,15 @@ var grobid = (function($) {
                     "value": "ref",
                     "type": "checkbox",
                     "required": false
+                }
+                if (segmentSentences === false) {
+                    if (elementCoords[i] === "s") {
+                        continue;
+                    }
+                } else {
+                    if (elementCoords[i] === "p") {
+                        continue;
+                    }
                 }
                 additionalFormData["value"] = elementCoords[i]
                 formData.push(additionalFormData)


### PR DESCRIPTION
When the paragraph continues after interruption (e.g., reference callout), the coordinates are lost: 

![image](https://github.com/kermitt2/grobid/assets/15426/7b4ba131-349e-434c-9cc1-f9ffed9c1d37)

This PR solves this issue. 
![image](https://github.com/kermitt2/grobid/assets/15426/5f013fe9-69ab-4638-b39c-92ab94f85a18)


This PR also adds a small modification in the frontend so that the paragraph coordinates are extracted if "add coordinates" is selected and "segment sentence" is not selected. 