### PR TITLE
Add additional github actions

### DIFF
--- a/.github/workflows/ci-build-manual.yml
+++ b/.github/workflows/ci-build-manual.yml
@@ -1,37 +1,25 @@
-name: Build unstable
+name: Build and push a development version on docker 
 
-on: [ push ]
-
-concurrency:
-  group: gradle
-  cancel-in-progress: true
-
+on: 
+  workflow_dispatch: 
+    
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 17
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.17
-      - name: Build with Gradle
-        run: ./gradlew clean assemble --info --stacktrace --no-daemon
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17.0.10+7'
+        distribution: 'temurin'
+        cache: 'gradle'
+    - name: Build with Gradle
+      run: ./gradlew build -x test
 
-      - name: Test with Gradle Jacoco and Coveralls
-        run: ./gradlew test jacocoTestReport coveralls --no-daemon
-
-      - name: Coveralls GitHub Action
-        uses: coverallsapp/github-action@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          format: jacoco
-          file: build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
-          debug: true
-  
-  docker-build-crf:
+  docker-build:
     needs: [ build ]
     runs-on: ubuntu-latest
 
@@ -41,15 +29,15 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build and push
         id: docker_build
-        uses: mr-smithers-excellent/docker-build-push@v5
+        uses: mr-smithers-excellent/docker-build-push@v6
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
-          password: ${{ secrets.DOCKERHUB_TOKEN_LFOPPIANO }}
+          dockerfile: Dockerfile
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           image: lfoppiano/grobid
           registry: docker.io
-          pushImage: ${{ github.event_name != 'pull_request' }}
-          tags: latest-develop-crf
-          dockerfile: Dockerfile.crf
+          pushImage: true
+          tags: latest-develop
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -69,7 +57,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN_LFOPPIANO }}
           image: lfoppiano/grobid
           registry: docker.io
-          pushImage: ${{ github.event_name != 'pull_request' }}
+          pushImage: true
           tags: latest-develop
           dockerfile: Dockerfile.delft
       - name: Image digest

--- a/.github/workflows/ci-build-manual.yml
+++ b/.github/workflows/ci-build-manual.yml
@@ -37,7 +37,7 @@ jobs:
           image: lfoppiano/grobid
           registry: docker.io
           pushImage: true
-          tags: latest-develop
+          tags: latest-develop, latest-develop-crf
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -58,7 +58,7 @@ jobs:
           image: lfoppiano/grobid
           registry: docker.io
           pushImage: true
-          tags: latest-develop
+          tags: latest-develop-full
           dockerfile: Dockerfile.delft
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci-build-manual.yml
+++ b/.github/workflows/ci-build-manual.yml
@@ -37,7 +37,7 @@ jobs:
           image: lfoppiano/grobid
           registry: docker.io
           pushImage: true
-          tags: latest-develop, latest-develop-crf
+          tags: latest-develop, latest-crf
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
@@ -58,7 +58,7 @@ jobs:
           image: lfoppiano/grobid
           registry: docker.io
           pushImage: true
-          tags: latest-develop-full
+          tags: latest-full
           dockerfile: Dockerfile.delft
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -50,29 +50,29 @@ jobs:
           image: lfoppiano/grobid
           registry: docker.io
           pushImage: ${{ github.event_name != 'pull_request' }}
-          tags: latest-develop-crf
+          tags: latest-develop, latest-develop-crf
           dockerfile: Dockerfile.crf
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
 
-  docker-build-full:
-    needs: [ build ]
-    runs-on: ubuntu-latest
+  # docker-build-full:
+  #   needs: [ build ]
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Create more disk space
-        run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      - uses: actions/checkout@v2
-      - name: Build and push
-        id: docker_build
-        uses: mr-smithers-excellent/docker-build-push@v5
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
-          password: ${{ secrets.DOCKERHUB_TOKEN_LFOPPIANO }}
-          image: lfoppiano/grobid
-          registry: docker.io
-          pushImage: ${{ github.event_name != 'pull_request' }}
-          tags: latest-develop
-          dockerfile: Dockerfile.delft
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+  #   steps:
+  #     - name: Create more disk space
+  #       run: sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+  #     - uses: actions/checkout@v2
+  #     - name: Build and push
+  #       id: docker_build
+  #       uses: mr-smithers-excellent/docker-build-push@v5
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
+  #         password: ${{ secrets.DOCKERHUB_TOKEN_LFOPPIANO }}
+  #         image: lfoppiano/grobid
+  #         registry: docker.io
+  #         pushImage: ${{ github.event_name != 'pull_request' }}
+  #         tags: latest-develop
+  #         dockerfile: Dockerfile.delft
+  #     - name: Image digest
+  #       run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -12,11 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.17
+          java-version: '17.0.10+7'
+          distribution: 'temurin'
+          cache: 'gradle'
       - name: Build with Gradle
         run: ./gradlew clean assemble --info --stacktrace --no-daemon
 
@@ -41,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build and push
         id: docker_build
-        uses: mr-smithers-excellent/docker-build-push@v5
+        uses: mr-smithers-excellent/docker-build-push@v6
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
           password: ${{ secrets.DOCKERHUB_TOKEN_LFOPPIANO }}

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -50,7 +50,7 @@ jobs:
           image: lfoppiano/grobid
           registry: docker.io
           pushImage: ${{ github.event_name != 'pull_request' }}
-          tags: latest-develop, latest-develop-crf
+          tags: latest-develop, latest-crf
           dockerfile: Dockerfile.crf
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
This PR will extend the current github actions: 
- The automatic build only produce the CRF-only image (`latest-develop`)
- We added a manual build that will push both CRF-only (tags `latest-develop`, `latest-crf`) and the delft full image (tag `latest-full`) . The user can select any branch, this is useful for testing specific features. 