### PR TITLE
fix notes identification

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1274,6 +1274,11 @@ public class TEIFormatter {
 
             org.apache.commons.lang3.tuple.Pair<String, List<LayoutToken>> noteProcess = 
                 fullTextParser.processShort(noteTokens, doc);
+
+            if (noteProcess == null) {
+                continue;
+            }
+
             String labeledNote = noteProcess.getLeft();
             List<LayoutToken> noteLayoutTokens = noteProcess.getRight();
 


### PR DESCRIPTION
More details are in #1113. 

TLDR: 
 - avoid collecting the same position in the text when the note label is the same. So for example if we have `This note1, and this note2, but back to the first note1`, we would collect twice the offset of the first 1 label.
  - update the labels2notes so that we use the identifier instead.
  - fix a NPE when the note tokenization are empty, the processShort return a null, so we skip such note
