### PR TITLE
Adjust circuit-breaker for #1113

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1630,7 +1630,7 @@ public class TEIFormatter {
                         String type = referenceInformation.getMiddle();
                         OffsetPosition matchingPosition = referenceInformation.getRight();
 
-                        if (pos >= matchingPosition.start)
+                        if (pos > matchingPosition.start)
                             break;
 
                         List<LayoutToken> before = clusterTokens.subList(pos, matchingPosition.start);


### PR DESCRIPTION
In the fix for #1113:

https://github.com/kermitt2/grobid/blob/83f2c81a3580c052697ffb46949dfec3deb67f32/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java#L1614

if the URL is at beginning of the sentence/paragraph, it does not cause any trouble (the string `before` will be empty). 

This PR updates the `>=` with `>`. 😅 