### PR TITLE
Avoid replacing DOIs with shorter ones

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -635,7 +635,7 @@ public class Document implements Serializable {
     }
 
     /*
-     * Try to match a DOI in the first page, independently from any preliminar
+     * Try to match a DOI in the first page, independently of any preliminary
      * segmentation. This can be useful for improving the chance to find a DOI
      * in headers or footnotes.
      */

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -268,7 +268,9 @@ public class HeaderParser extends AbstractParser {
                 // DOI pass
                 List<String> dois = doc.getDOIMatches();
                 if (isNotEmpty(dois) && dois.size() == 1) {
-                    resHeader.setDOI(dois.get(0));
+                    if (dois.get(0).length() > resHeader.getDOI().length()) {
+                        resHeader.setDOI(dois.get(0));
+                    }
                 }
 
                 // normalization of dates


### PR DESCRIPTION
When we search for a DOI in the page, the regex may truncate DOIs that are split by a breakline, so this PR proposes a simple fix that is to substitute the DOI only when the one found in the page is larger than the one extracted by the header parser 