### PR TITLE
adding apt-get upgrade in  the builder image

### DIFF
--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -18,6 +18,7 @@ FROM openjdk:17-jdk-slim as builder
 USER root
 
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get -y --no-install-recommends install unzip
 
 WORKDIR /opt/grobid-source


### PR DESCRIPTION
There are still 46 high- and 11 critical-level vulnerabilities in the "latest:crf" tag. this should apply the patches for these vulnerabilities.