### PR TITLE
Update docker runtime with the latest openjdk:24-slim image tag

### DIFF
--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -63,7 +63,7 @@ RUN rm -rf grobid-source
 # -------------------
 # build runtime image
 # -------------------
-FROM openjdk:17-slim
+FROM openjdk:24-slim
 
 RUN apt-get update && \
     apt-get -y upgrade && \


### PR DESCRIPTION
the openjdk:17-slim image is outdated with high- and critical-level vulnerabilities. Updating it with the latest image should fix the issue. 