### PR TITLE
hold cuda11.2 from upgrading to cuda12.2

### DIFF
--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -20,6 +20,7 @@ FROM openjdk:17-jdk-slim as builder
 USER root
 
 RUN apt-get update && \
+    apt-get -y upgrade && \
     apt-get -y --no-install-recommends install unzip
 
 WORKDIR /opt/grobid-source
@@ -86,6 +87,8 @@ ENTRYPOINT ["/tini", "-s", "--"]
 
 # install JRE, python and other dependencies
 RUN apt-get update && \
+    apt-mark hold libcudnn8 && \
+    apt-get -y upgrade && \
     apt-get -y --no-install-recommends install apt-utils build-essential gcc libxml2 libfontconfig unzip curl \
     openjdk-17-jre-headless ca-certificates-java \
     musl gfortran \


### PR DESCRIPTION
This PR fixes an issue where apt-get upgrade was upgrading CUDA from 11.2 to 12.2, causing mismatches between libcublas 11.2, libcudnn8, and other GPU libraries. This led to GPU-related errors in production.

Changes:
Held back library _libcudnn8_ to prevent it from upgrading to CUDA 12.2.