### PR TITLE
move TEI idno identifiers under <analytics>

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -482,6 +482,42 @@ public class TEIFormatter {
             // if it's not something in English, we will write it anyway as note without type at the end
         }
 
+        if (!StringUtils.isEmpty(biblio.getDOI())) {
+            String theDOI = TextUtilities.HTMLEncode(biblio.getDOI());
+            if (theDOI.endsWith(".xml")) {
+                theDOI = theDOI.replace(".xml", "");
+            }
+            tei.append("\t\t\t\t\t<idno type=\"DOI\">" + TextUtilities.HTMLEncode(theDOI) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getHalId())) {
+            tei.append("\t\t\t\t\t<idno type=\"halId\">" + TextUtilities.HTMLEncode(biblio.getHalId()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getArXivId())) {
+            tei.append("\t\t\t\t\t<idno type=\"arXiv\">" + TextUtilities.HTMLEncode(biblio.getArXivId()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getPMID())) {
+            tei.append("\t\t\t\t\t<idno type=\"PMID\">" + TextUtilities.HTMLEncode(biblio.getPMID()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getPMCID())) {
+            tei.append("\t\t\t\t\t<idno type=\"PMCID\">" + TextUtilities.HTMLEncode(biblio.getPMCID()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getPII())) {
+            tei.append("\t\t\t\t\t<idno type=\"PII\">" + TextUtilities.HTMLEncode(biblio.getPII()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getArk())) {
+            tei.append("\t\t\t\t\t<idno type=\"ark\">" + TextUtilities.HTMLEncode(biblio.getArk()) + "</idno>\n");
+        }
+
+        if (!StringUtils.isEmpty(biblio.getIstexId())) {
+            tei.append("\t\t\t\t\t<idno type=\"istexId\">" + TextUtilities.HTMLEncode(biblio.getIstexId()) + "</idno>\n");
+        }
+
         tei.append("\t\t\t\t\t</analytic>\n");
 
         if ((biblio.getJournal() != null) ||
@@ -744,35 +780,35 @@ public class TEIFormatter {
             if (theDOI.endsWith(".xml")) {
                 theDOI = theDOI.replace(".xml", "");
             }
-            tei.append("\t\t\t\t\t<idno type=\"DOI\">" + TextUtilities.HTMLEncode(theDOI) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"DOI\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(theDOI) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getHalId())) {
-            tei.append("\t\t\t\t\t<idno type=\"halId\">" + TextUtilities.HTMLEncode(biblio.getHalId()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"halId\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getHalId()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getArXivId())) {
-            tei.append("\t\t\t\t\t<idno type=\"arXiv\">" + TextUtilities.HTMLEncode(biblio.getArXivId()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"arXiv\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getArXivId()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getPMID())) {
-            tei.append("\t\t\t\t\t<idno type=\"PMID\">" + TextUtilities.HTMLEncode(biblio.getPMID()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"PMID\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getPMID()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getPMCID())) {
-            tei.append("\t\t\t\t\t<idno type=\"PMCID\">" + TextUtilities.HTMLEncode(biblio.getPMCID()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"PMCID\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getPMCID()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getPII())) {
-            tei.append("\t\t\t\t\t<idno type=\"PII\">" + TextUtilities.HTMLEncode(biblio.getPII()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"PII\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getPII()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getArk())) {
-            tei.append("\t\t\t\t\t<idno type=\"ark\">" + TextUtilities.HTMLEncode(biblio.getArk()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"ark\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getArk()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getIstexId())) {
-            tei.append("\t\t\t\t\t<idno type=\"istexId\">" + TextUtilities.HTMLEncode(biblio.getIstexId()) + "</idno>\n");
+            tei.append("\t\t\t\t\t<idno type=\"istexId\" status=\"deprecatedLocation\">" + TextUtilities.HTMLEncode(biblio.getIstexId()) + "</idno>\n");
         }
 
         if (!StringUtils.isEmpty(biblio.getOAURL())) {


### PR DESCRIPTION
See #1192 . The same treatment is applied to any identifier: PMCID, PMID, halID, etc

See example: 

```
                                </address>
                            </affiliation>
                        </author>
                        <title level="a" type="main">Transgressive phenotypes from outbreeding between the Trichoderma reesei hyper producer RutC30 and a natural isolate</title>
                        <idno type="DOI">10.1128/spectrum.00441-24</idno>
                    </analytic>
                    <monogr>
                        <imprint>
                            <date type="published" when="2024-08-20">20 August 2024</date>
                        </imprint>
                    </monogr>
                    <idno type="MD5">9E9A05DAEBD10C49EB098AF73FA55CD1</idno>
                    <idno type="DOI" status="deprecatedLocation">10.1128/spectrum.00441-24</idno>
                    <note type="submission">Received 22 February 2024 Accepted 3 July 2024</note>
                </biblStruct>
```