### PR TITLE
Fix code scanning alert no. 61: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/grobid-service/src/main/java/org/grobid/service/util/ZipUtils.java
+++ b/grobid-service/src/main/java/org/grobid/service/util/ZipUtils.java
@@ -80,8 +80,11 @@ public class ZipUtils {
 							+ entry.getName());
 					// This is not robust, just for demonstration purposes.
 
-					(new File(tempDir.getAbsolutePath() + File.separator
-							+ entry.getName())).mkdir();
+					File dir = new File(tempDir.getAbsolutePath() + File.separator + entry.getName()).getCanonicalFile();
+					if (!dir.toPath().startsWith(tempDir.toPath())) {
+						throw new IOException("Bad zip entry: " + entry.getName());
+					}
+					dir.mkdir();
 					continue;
 				}
 
@@ -89,10 +92,15 @@ public class ZipUtils {
 
 				copyInputStream(
 						zipFile.getInputStream(entry),
-						new BufferedOutputStream(new FileOutputStream(tempDir
+						new BufferedOutputStream(new FileOutputStream(new File(tempDir
 								.getAbsolutePath()
 								+ File.separator
-								+ entry.getName())));
+								+ entry.getName()).getCanonicalFile())));
+						File outFile = new File(tempDir.getAbsolutePath() + File.separator + entry.getName()).getCanonicalFile();
+						if (!outFile.toPath().startsWith(tempDir.toPath())) {
+							throw new IOException("Bad zip entry: " + entry.getName());
+						}
+						copyInputStream(zipFile.getInputStream(entry), new BufferedOutputStream(new FileOutputStream(outFile)));
 			}
 
 			zipFile.close();


### PR DESCRIPTION
Fixes [https://github.com/kermitt2/grobid/security/code-scanning/61](https://github.com/kermitt2/grobid/security/code-scanning/61)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be done by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. We will use `java.nio.file.Path` for path normalization and prefix checking.

1. Normalize the path of the file to be created.
2. Check if the normalized path starts with the destination directory path.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
