### PR TITLE
Fix code scanning alert no. 39: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/main/GrobidHomeFinder.java
+++ b/grobid-core/src/main/java/org/grobid/core/main/GrobidHomeFinder.java
@@ -173,7 +173,10 @@ public class GrobidHomeFinder {
         ZipInputStream zipIn = new ZipInputStream(is);
         ZipEntry entry = zipIn.getNextEntry();
         while (entry != null) {
-            File filePath = new File(destinationDir, entry.getName());
+            File filePath = new File(destinationDir, entry.getName()).toPath().normalize().toFile();
+            if (!filePath.toPath().startsWith(destinationDir.toPath())) {
+                throw new IOException("Bad zip entry: " + entry.getName());
+            }
             try {
                 if (!entry.isDirectory()) {
                     String absolutePath = filePath.getAbsolutePath();


### PR DESCRIPTION
Fixes [https://github.com/kermitt2/grobid/security/code-scanning/39](https://github.com/kermitt2/grobid/security/code-scanning/39)

To fix the problem, we need to ensure that the file paths constructed from zip entries are validated to prevent writing files to unexpected locations. This can be achieved by normalizing the file paths and ensuring they start with the intended destination directory.

1. Normalize the file path using `toPath().normalize()`.
2. Check if the normalized path starts with the destination directory path using `startsWith()`.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
