### PR TITLE
Avoid empty figures/tables reference markers

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1731,7 +1731,7 @@ public class TEIFormatter {
                 } else {
                     throw new IllegalStateException("Unsupported marker type: " + clusterLabel);
                 }
-                
+
                 if (refNodes != null) {
                     boolean footNoteCallout = false;
 
@@ -2293,9 +2293,9 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                     // second pass with relaxed figure marker matching
                     for(int i=figures.size()-1; i>=0; i--) {
                         Figure figure = figures.get(i);
-                        if ((figure.getLabel() != null) && (figure.getLabel().length() > 0)) {
+                        if (StringUtils.isNotBlank(figure.getLabel())) {
                             String label = TextUtilities.cleanField(figure.getLabel(), false);
-                            if (label != null && (label.length() > 0) &&
+                            if (StringUtils.isNotBlank(label) &&
                                     (textLow.contains(label.toLowerCase()))) {
                                 bestFigure = figure.getId();
                                 break;
@@ -2313,13 +2313,17 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
 
             String andWordString = null;
             if (text.endsWith("and") || text.endsWith("&")) {
-                // the AND_WORD_PATTERN case, we want to exclude the AND word from the tagged chunk                
-                if (text.endsWith("and")) {
+                if (text.equals("and") || text.equals("&")) {
+                    nodes.add(new Text(text));
+                    if (spaceEnd)
+                        nodes.add(new Text(" "));
+                    continue;
+                } else if (text.endsWith("and")) {
+                    // the AND_WORD_PATTERN case, we want to exclude the AND word from the tagged chunk
                     text = text.substring(0, text.length()-3);
                     andWordString = "and";
                     refTokens = refTokens.subList(0,refTokens.size()-1);
-                }
-                else if (text.endsWith("&")) {
+                } else if (text.endsWith("&")) {
                     text = text.substring(0, text.length()-1);
                     andWordString = "&";
                     refTokens = refTokens.subList(0,refTokens.size()-1);

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -2306,24 +2306,37 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
             }
 
             boolean spaceEnd = false;
+            boolean spaceStart = false;
             text = text.replace("\n", " ");
-            if (text.endsWith(" "))
+            if (text.endsWith(" ")) {
                 spaceEnd = true;
+            }
+            if (!text.equals(" ") & text.startsWith(" ")) {
+                spaceStart = true;
+            }
             text = text.trim();
 
             if (StringUtils.isBlank(text)) {
-                nodes.add(new Text(text));
-                if (spaceEnd)
+                if (spaceStart) {
                     nodes.add(new Text(" "));
+                }
+                nodes.add(new Text(text));
+                if (spaceEnd) {
+                    nodes.add(new Text(" "));
+                }
                 continue;
             }
 
             String andWordString = null;
             if (text.endsWith("and") || text.endsWith("&")) {
                 if (text.equals("and") || text.equals("&")) {
-                    nodes.add(new Text(text));
-                    if (spaceEnd)
+                    if (spaceStart) {
                         nodes.add(new Text(" "));
+                    }
+                    nodes.add(new Text(text));
+                    if (spaceEnd) {
+                        nodes.add(new Text(" "));
+                    }
                     continue;
                 } else if (text.endsWith("and")) {
                     // the AND_WORD_PATTERN case, we want to exclude the AND word from the tagged chunk
@@ -2358,14 +2371,18 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
             if (bestFigure != null) {
                 ref.addAttribute(new Attribute("target", "#fig_" + bestFigure));
             }
+            if (spaceStart) {
+                nodes.add(new Text(" "));
+            }
             nodes.add(ref);
 
             if (andWordString != null) {
                 nodes.add(new Text(andWordString));
             }
 
-            if (spaceEnd)
+            if (spaceEnd) {
                 nodes.add(new Text(" "));
+            }
         }
         return nodes;
     }

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -2311,6 +2311,13 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                 spaceEnd = true;
             text = text.trim();
 
+            if (StringUtils.isBlank(text)) {
+                nodes.add(new Text(text));
+                if (spaceEnd)
+                    nodes.add(new Text(" "));
+                continue;
+            }
+
             String andWordString = null;
             if (text.endsWith("and") || text.endsWith("&")) {
                 if (text.equals("and") || text.equals("&")) {

--- a/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
@@ -5,6 +5,7 @@ import nu.xom.Node;
 import org.grobid.core.analyzers.GrobidAnalyzer;
 import org.grobid.core.data.Figure;
 import org.grobid.core.data.Note;
+import org.grobid.core.data.Table;
 import org.grobid.core.layout.LayoutToken;
 import org.grobid.core.utilities.GrobidProperties;
 import org.grobid.core.utilities.LayoutTokensUtil;
@@ -90,9 +91,9 @@ public class TEIFormatterTest {
         Figure f1 = new Figure();
         f1.setLabel(new StringBuilder("1"));
         Figure f2 = new Figure();
-        f1.setLabel(new StringBuilder("2"));
+        f2.setLabel(new StringBuilder("2"));
         Figure f3 = new Figure();
-        f1.setLabel(new StringBuilder(""));
+        f3.setLabel(new StringBuilder(""));
 
         List<Figure> figures = List.of(f1, f2, f3);
 
@@ -101,10 +102,10 @@ public class TEIFormatterTest {
             .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
 
         assertThat(nodes, hasSize(4));
-        assertThat(((Element)nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3C</ref>"));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3C</ref>"));
         assertThat(nodes.get(1).toXML(), is(" and"));
         assertThat(nodes.get(2).toXML(), is(" "));
-        assertThat(((Element)nodes.get(3)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+        assertThat(((Element) nodes.get(3)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
     }
 
     @Test
@@ -120,9 +121,9 @@ public class TEIFormatterTest {
         Figure f1 = new Figure();
         f1.setLabel(new StringBuilder("1"));
         Figure f2 = new Figure();
-        f1.setLabel(new StringBuilder("2"));
+        f2.setLabel(new StringBuilder("2"));
         Figure f3 = new Figure();
-        f1.setLabel(new StringBuilder(""));
+        f3.setLabel(new StringBuilder(""));
 
         List<Figure> figures = List.of(f1, f2, f3);
 
@@ -133,7 +134,7 @@ public class TEIFormatterTest {
         assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is("and"));
         assertThat(nodes.get(1).toXML(), is(" "));
-        assertThat(((Element)nodes.get(2)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+        assertThat(((Element) nodes.get(2)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
     }
 
     @Test
@@ -149,9 +150,9 @@ public class TEIFormatterTest {
         Figure f1 = new Figure();
         f1.setLabel(new StringBuilder("1"));
         Figure f2 = new Figure();
-        f1.setLabel(new StringBuilder("2"));
+        f2.setLabel(new StringBuilder("2"));
         Figure f3 = new Figure();
-        f1.setLabel(new StringBuilder(""));
+        f3.setLabel(new StringBuilder(""));
 
         List<Figure> figures = List.of(f1, f2, f3);
 
@@ -160,7 +161,89 @@ public class TEIFormatterTest {
             .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
 
         assertThat(nodes, hasSize(4));
-        assertThat(((Element)nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5,</ref>"));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5,</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" &amp;"));
+        assertThat(nodes.get(2).toXML(), is(""));
+        assertThat(nodes.get(3).toXML(), is(" "));
+    }
+
+    @Test
+    public void testMarkReferencesTableTEI() throws Exception {
+        String input = "3C and 3D";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Table t1 = new Table();
+        t1.setLabel(new StringBuilder("1"));
+        Table t2 = new Table();
+        t2.setLabel(new StringBuilder("2"));
+        Table t3 = new Table();
+        t3.setLabel(new StringBuilder(""));
+
+        List<Table> tables = List.of(t1, t2, t3);
+
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
+        assertThat(nodes, hasSize(4));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">3C</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" and"));
+        assertThat(nodes.get(2).toXML(), is(" "));
+        assertThat(((Element) nodes.get(3)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">3D</ref>"));
+    }
+
+    @Test
+    public void testMarkReferencesTableTEI_truncatedRef_referenceAtTheEnd() throws Exception {
+        String input = "and 3D";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Table t1 = new Table();
+        t1.setLabel(new StringBuilder("1"));
+        Table t2 = new Table();
+        t2.setLabel(new StringBuilder("2"));
+        Table t3 = new Table();
+        t3.setLabel(new StringBuilder(""));
+
+        List<Table> tables = List.of(t1, t2, t3);
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
+        assertThat(nodes, hasSize(3));
+        assertThat(nodes.get(0).toXML(), is("and"));
+        assertThat(nodes.get(1).toXML(), is(" "));
+        assertThat(((Element) nodes.get(2)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">3D</ref>"));
+    }
+
+    @Test
+    public void testMarkReferencesTableTEI_truncatedRef_referenceAtBeginning() throws Exception {
+        String input = "5, & ";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Table t1 = new Table();
+        t1.setLabel(new StringBuilder("1"));
+        Table t2 = new Table();
+        t2.setLabel(new StringBuilder("2"));
+        Table t3 = new Table();
+        t3.setLabel(new StringBuilder(""));
+
+        List<Table> tables = List.of(t1, t2, t3);
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
+
+        assertThat(nodes, hasSize(4));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">5,</ref>"));
         assertThat(nodes.get(1).toXML(), is(" &amp;"));
         assertThat(nodes.get(2).toXML(), is(""));
         assertThat(nodes.get(3).toXML(), is(" "));

--- a/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
@@ -79,6 +79,36 @@ public class TEIFormatterTest {
 
     @Test
     public void testMarkReferencesFigureTEI() throws Exception {
+        String input = "3C and 3D";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Figure f1 = new Figure();
+        f1.setLabel(new StringBuilder("1"));
+        Figure f2 = new Figure();
+        f1.setLabel(new StringBuilder("2"));
+        Figure f3 = new Figure();
+        f1.setLabel(new StringBuilder(""));
+
+        List<Figure> figures = List.of(f1, f2, f3);
+
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
+
+        assertThat(nodes, hasSize(4));
+        assertThat(((Element)nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3C</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" and"));
+        assertThat(nodes.get(2).toXML(), is(" "));
+        assertThat(((Element)nodes.get(3)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+    }
+
+    @Test
+    public void testMarkReferencesFigureTEI_truncatedRef_referenceAtTheEnd() throws Exception {
         String input = "and 3D";
         List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
 
@@ -100,13 +130,14 @@ public class TEIFormatterTest {
         List<Node> nodes = new TEIFormatter(null, null)
             .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
 
-        assertThat(nodes, hasSize(2));
+        assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is("and"));
-        assertThat(((Element)nodes.get(1)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" "));
+        assertThat(((Element)nodes.get(2)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
     }
 
     @Test
-    public void testMarkReferencesFigureTEI_() throws Exception {
+    public void testMarkReferencesFigureTEI_truncatedRef_referenceAtBeginning() throws Exception {
         String input = "5, & ";
         List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
 

--- a/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
@@ -105,5 +105,35 @@ public class TEIFormatterTest {
         assertThat(((Element)nodes.get(1)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
     }
 
+    @Test
+    public void testMarkReferencesFigureTEI_() throws Exception {
+        String input = "5, & ";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Figure f1 = new Figure();
+        f1.setLabel(new StringBuilder("1"));
+        Figure f2 = new Figure();
+        f1.setLabel(new StringBuilder("2"));
+        Figure f3 = new Figure();
+        f1.setLabel(new StringBuilder(""));
+
+        List<Figure> figures = List.of(f1, f2, f3);
+
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
+
+        assertThat(nodes, hasSize(4));
+        assertThat(((Element)nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5,</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" &amp;"));
+        assertThat(nodes.get(2).toXML(), is(""));
+        assertThat(nodes.get(3).toXML(), is(" "));
+    }
+
 
 }


### PR DESCRIPTION
This PR fixes issues #1233 (the part related to the reference construction), #1244, and #1175. 

The issue happens when the reference markers labels are partially correct, for example the reference is `and 3C` with the first reference which is wrongly classified. 