### PR TITLE
Fix missing sentence segmentation for table notes

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/Table.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/Table.java
@@ -227,17 +227,25 @@ public class Table extends Figure {
                         }
                         p.appendChild(textNode(clusterContent));
                     }
-
-                    if (config.isWithSentenceSegmentation()) {
-                        // we need a sentence segmentation of the figure caption
-                        formatter.segmentIntoSentences(noteNode, this.noteLayoutTokens, config, doc.getLanguage(), doc.getPDFAnnotations());
-                    }
                 }
                 if (p.getChildCount() > 0) {
                     noteNode.appendChild(p);
                 }
+                if (config.isWithSentenceSegmentation()) {
+                    // we need a sentence segmentation of the figure caption
+                    formatter.segmentIntoSentences(p, this.noteLayoutTokens, config, doc.getLanguage(), doc.getPDFAnnotations());
+                }
             } else {
-                noteNode = XmlBuilderUtils.teiElement("note", LayoutTokensUtil.normalizeText(note.toString()).trim());
+                Element p = teiElement("p");
+                p.appendChild(LayoutTokensUtil.normalizeText(note.toString()).trim());
+
+                if (config.isWithSentenceSegmentation()) {
+                    // we need a sentence segmentation of the figure caption
+                    formatter.segmentIntoSentences(p, this.noteLayoutTokens, config, doc.getLanguage(), doc.getPDFAnnotations());
+                }
+
+                noteNode = XmlBuilderUtils.teiElement("note");
+                noteNode.appendChild(p);
             }
 
             String coords = null;


### PR DESCRIPTION
Table notes seems to have missing sentence when requested. Probably a regression from #1232 