### PR TITLE
Add ARCH ARG for '--build-arg ARCH=<ARCH>', defaulting to 'amd64'.

### DIFF
--- a/.github/ISSUE_TEMPLATE/general-report.yml
+++ b/.github/ISSUE_TEMPLATE/general-report.yml
@@ -6,6 +6,13 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report! Before creating a new issue, make sure you had a look at the [official documentation](https://grobid.readthedocs.com) or with the **experimental** [Mendable Q/A chat](https://www.mendable.ai/demo/723cfc12-fdd6-4631-9a9e-21b80241131b). **NOTE**: the suggested method of running grobid is through Docker (https://grobid.readthedocs.io/en/latest/Grobid-docker/).
   - type: input
+    id: grobid_version
+    attributes:
+      label: Grobid version
+      description: Which grobid version are you using? Is it via Docker or natively? With Deep Learning models or only the lightweight CRF models? 
+    validations:
+      required: true
+  - type: input
     id: os
     attributes:
       label: Operating System and architecture (arm64, amd64, x86, etc.)

--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -13,7 +13,7 @@
 # -------------------
 # build builder image
 # -------------------
-FROM openjdk:17-jdk-slim as builder
+FROM openjdk:17-jdk-slim AS builder
 
 USER root
 

--- a/Dockerfile.crf
+++ b/Dockerfile.crf
@@ -72,7 +72,8 @@ RUN apt-get update && \
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ARG ARCH=amd64
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "-s", "--"]
 

--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -15,7 +15,7 @@
 # build builder image
 # -------------------
 
-FROM openjdk:17-jdk-slim as builder
+FROM openjdk:17-jdk-slim AS builder
 
 USER root
 

--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -81,7 +81,8 @@ RUN apt-get install -y wget && \
 
 # Add Tini
 ENV TINI_VERSION v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+ARG ARCH=amd64
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${ARCH} /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "-s", "--"]
 

--- a/Dockerfile.evaluation
+++ b/Dockerfile.evaluation
@@ -8,7 +8,7 @@
 # Please notice that the evaluation is run through a python script that runs all the needed commands
 # TODO: upload the evaluation in Markdown somewhere
 
-FROM lfoppiano/grobid:latest-evaluation-full as runtime
+FROM lfoppiano/grobid:latest-evaluation-full AS runtime
 
 # setting locale is likely useless but to be sure
 ENV LANG C.UTF-8


### PR DESCRIPTION
Added ARCH ARG argument to allow overriding of the architecture using '--build-arg ARCH=<ARCH>', defaulting to 'amd64'.
 
For CRF amd64 :-
```
docker build -t grobid/grobid:0.8.2-SNAPSHOT --build-arg GROBID_VERSION=0.8.2-SNAPSHOT --file Dockerfile.crf .
```
For CRF arm64 :-
```
docker build -t grobid/grobid:0.8.2-SNAPSHOT --build-arg GROBID_VERSION=0.8.2-SNAPSHOT --build-arg ARCH=arm64 --file Dockerfile.crf .
```
For DELFT amd64 :-
```
docker build -t grobid/grobid:0.8.2-SNAPSHOT --build-arg GROBID_VERSION=0.8.2-SNAPSHOT --file Dockerfile.delft .
```
For DELFT arm64 :-
```
docker build -t grobid/grobid:0.8.2-SNAPSHOT --build-arg GROBID_VERSION=0.8.2-SNAPSHOT --build-arg ARCH=arm64 --file Dockerfile.delft .
```
