### PR TITLE
return configuration processing parameters in response header

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -874,6 +874,7 @@ public class TEIFormatter {
         tei.append("\t\t\t\t<application version=\"" + GrobidProperties.getVersion() +
                 "\" ident=\"GROBID\" when=\"" + dateISOString + "\">\n");
         tei.append("\t\t\t\t\t<desc>GROBID - A machine learning software for extracting information from scholarly documents</desc>\n");
+        tei.append("\t\t\t\t\t<desc type=\"parameters\">" + config.toStringTEI() + "</desc>\n");
         tei.append("\t\t\t\t\t<ref target=\"https://github.com/kermitt2/grobid\"/>\n");
         tei.append("\t\t\t\t</application>\n");
         tei.append("\t\t\t</appInfo>\n");

--- a/grobid-core/src/main/java/org/grobid/core/engines/config/GrobidAnalysisConfig.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/config/GrobidAnalysisConfig.java
@@ -3,6 +3,7 @@ package org.grobid.core.engines.config;
 import java.io.File;
 import java.util.List;
 
+import org.grobid.core.GrobidModels;
 import org.grobid.core.analyzers.Analyzer;
 
 /**
@@ -100,6 +101,8 @@ public class GrobidAnalysisConfig {
     public void setIncludeDiscardedText(boolean includeDiscardedText) {
         this.includeDiscardedText = includeDiscardedText;
     }
+
+    private String flavor = null;
 
     // BUILDER
 
@@ -205,6 +208,12 @@ public class GrobidAnalysisConfig {
             return this;
         }
 
+        public GrobidAnalysisConfigBuilder flavor(GrobidModels.Flavor a) {
+            config.flavor = a.getLabel();
+            return this;
+        }
+
+
         public GrobidAnalysisConfig build() {
             postProcessAndValidate();
             return config;
@@ -232,6 +241,24 @@ public class GrobidAnalysisConfig {
 
     public static GrobidAnalysisConfig defaultInstance() {
         return new GrobidAnalysisConfig();
+    }
+
+    public String toStringTEI() {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("startPage=").append(startPage);
+        sb.append(", endPage=").append(endPage);
+        sb.append(", consolidateCitations=").append(consolidateCitations);
+        sb.append(", consolidateHeader=").append(consolidateHeader);
+        sb.append(", consolidateFunders=").append(consolidateFunders);
+        sb.append(", includeRawAffiliations=").append(includeRawAffiliations);
+        sb.append(", includeRawCitations=").append(includeRawCitations);
+        sb.append(", includeRawCopyrights=").append(includeRawCopyrights);
+        sb.append(", generateTeiIds=").append(generateTeiIds);
+        sb.append(", generateTeiCoordinates=").append(generateTeiCoordinates);
+        sb.append(", flavor=").append(flavor);
+
+        return sb.toString();
     }
 
     public int getStartPage() {
@@ -308,5 +335,9 @@ public class GrobidAnalysisConfig {
 
     public boolean isWithSentenceSegmentation() {
         return withSentenceSegmentation;
+    }
+
+    public String getFlavor() {
+        return flavor;
     }
 }

--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessFiles.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessFiles.java
@@ -345,6 +345,7 @@ public class GrobidRestProcessFiles {
                     .generateTeiIds(generateIDs)
                     .generateTeiCoordinates(teiCoordinates)
                     .withSentenceSegmentation(segmentSentences)
+                    .flavor(flavor)
                     .build();
 
             retVal = engine.fullTextToTEI(originFile, flavor, md5Str, config);
@@ -525,6 +526,7 @@ public class GrobidRestProcessFiles {
                     .generateTeiCoordinates(teiCoordinates)
                     .pdfAssetPath(new File(assetPath))
                     .withSentenceSegmentation(segmentSentences)
+                    .flavor(flavor)
                     .build();
 
             retVal = engine.fullTextToTEI(originFile, flavor, md5Str, config);

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -100,6 +100,7 @@ public class EndToEndEvaluation {
                         .consolidateFunders(0)
                         .withPreprocessImages(true)
                         .withSentenceSegmentation(false)
+                        .flavor(flavor)
                         .build();
 
                 String tei = engine.fullTextToTEI(this.pdfFile, flavor, config);


### PR DESCRIPTION
This PR proposes to add part of the configuration parameters that have been sent to the server for processing, in the response header, information such as `sentenceSegmentation`? True/False, model flavor, coordinates, etc.. 

The proposal for the header would be 

```xml
<appInfo>
   <application version="project.version" ident="GROBID" when="2025-04-03T05:30+0000">
      <desc>GROBID - A machine learning software for extracting information from scholarly documents</desc>
      <desc type="parameters">startPage=-1, endPage=-1, consolidateCitations=0, consolidateHeader=1, consolidateFunders=0, includeRawAffiliations=false, includeRawCitations=true, includeRawCopyrights=false, generateTeiIds=false, generateTeiCoordinates=[], flavor=null</desc>
      <ref target="https://github.com/kermitt2/grobid"/>
   </application>
</appInfo>
```
