### PR TITLE
Avoid NPE when the authors names are empty or null

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/Person.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/Person.java
@@ -1,10 +1,9 @@
 package org.grobid.core.data;
 
-import org.apache.commons.lang3.StringUtils;
-
 import nu.xom.Attribute;
 import nu.xom.Element;
-
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.grobid.core.document.xml.XmlBuilderUtils;
 import org.grobid.core.layout.LayoutToken;
 import org.grobid.core.utilities.LayoutTokensUtil;
@@ -756,18 +755,20 @@ public class Person {
      *  Remove invalid/impossible person names (no last names, noise, etc.)
      */
     public static List<Person> sanityCheck(List<Person> persons) {
-        if (persons == null)
+        if (persons == null) {
             return null;
-        if (persons.size() == 0)
+        }
+
+        if (CollectionUtils.isEmpty(persons)) {
             return persons;
+        }
         
-        List<Person> result = new ArrayList<Person>();
+        List<Person> result = new ArrayList<>();
 
         for(Person person : persons) {
-            if (person.getLastName() == null || person.getLastName().trim().length() == 0) 
-                continue;
-            else
+            if (StringUtils.isNotBlank(person.getLastName())) {
                 result.add(person);
+            }
         }
 
         return result;

--- a/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
@@ -129,14 +129,17 @@ public class AuthorParser {
                                 } else {
                                     double pixPerChar = authorsToken.getWidth() / authorsToken.getText().length();
                                     int charsCovered = (int) ((intersectBox.getWidth() / pixPerChar) + 0.5);
-                                    if (pdfAnnotation.getDestination() != null && pdfAnnotation.getDestination().length() > 0) {
+                                    if (StringUtils.isNotBlank(pdfAnnotation.getDestination())) {
                                         Matcher orcidMatcher = TextUtilities.ORCIDPattern.matcher(pdfAnnotation.getDestination());
                                         if (orcidMatcher.find()) {
                                             // !! here we consider the annot is at the tail or end of the names
-                                            String newToken = authorsToken.getText().substring(0, authorsToken.getText().length() - charsCovered);        
+                                            //LF: sometimes there is no token at the end of the name, and the annotation covers all the name.
+                                            String newToken = authorsToken.getText().substring(0, authorsToken.getText().length() - charsCovered);
+                                            if (StringUtils.isNotBlank(newToken)) {
+                                                authorsToken.setText(newToken);
+                                            }
                                             aut.setORCID(orcidMatcher.group(1) + "-"
                                                 + orcidMatcher.group(2) + "-" + orcidMatcher.group(3)+ "-" + orcidMatcher.group(4));
-                                            authorsToken.setText(newToken);
                                         }
                                     }
                                 }
@@ -149,8 +152,10 @@ public class AuthorParser {
                 Engine.getCntManager().i(clusterLabel);
                 //String clusterContent = LayoutTokensUtil.normalizeText(LayoutTokensUtil.toText(cluster.concatTokens()));
                 String clusterContent = StringUtils.normalizeSpace(LayoutTokensUtil.toText(cluster.concatTokens()));
-                if (clusterContent.trim().length() == 0)
+                if (StringUtils.isBlank(clusterContent)) {
                     continue;
+                }
+
                 if (clusterLabel.equals(TaggingLabels.NAMES_HEADER_MARKER)) {
                     // a marker introduces a new author, and the marker could be attached to the previous (usual) 
                     // or following author (rare)

--- a/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/HeaderParser.java
@@ -242,10 +242,10 @@ public class HeaderParser extends AbstractParser {
                 resHeader.attachEmails();
                 boolean attached = false;
                 if (fragmentedAuthors && !hasMarker) {
-                    if (resHeader.getFullAffiliations() != null) {
-                        if (resHeader.getFullAffiliations().size() == authorSegments.size()) {
-                            int k = 0;
-                            List<Person> persons = resHeader.getFullAuthors();
+                    if (resHeader.getFullAffiliations() != null && resHeader.getFullAffiliations().size() == authorSegments.size()) {
+                        int k = 0;
+                        List<Person> persons = resHeader.getFullAuthors();
+                        if (CollectionUtils.isNotEmpty(persons)) {
                             for (Person pers : persons) {
                                 if (k < authorsBlocks.size()) {
                                     int indd = authorsBlocks.get(k);
@@ -255,10 +255,10 @@ public class HeaderParser extends AbstractParser {
                                 }
                                 k++;
                             }
-                            attached = true;
-                            resHeader.setFullAffiliations(null);
-                            resHeader.setAffiliation(null);
                         }
+                        attached = true;
+                        resHeader.setFullAffiliations(null);
+                        resHeader.setAffiliation(null);
                     }
 
                 }


### PR DESCRIPTION
Causes: 
 - in the case of the ORCID PDF Annotation is placed on top of the author names the authors names are lost (Example [hal-03664928_v1_main.pdf](https://github.com/user-attachments/files/19795155/hal-03664928_v1_main.pdf))
 - in the case whether the authors are not extracted correctly from the PDF (Example:  [hal-01859106_v1_main_Gimello_Georges_Delerue_une_vie_texte1.pdf](https://github.com/user-attachments/files/19795175/hal-01859106_v1_main_Gimello_Georges_Delerue_une_vie_texte1.pdf)
