### PR TITLE
Fix invalid figure reference when punctuation comma are left inside

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/FigureTableType.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/FigureTableType.java
@@ -1,0 +1,16 @@
+package org.grobid.core.data;
+
+public enum FigureTableType {
+    FIGURE("figure"),
+    TABLE("table");
+
+    private final String value;
+
+    FigureTableType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -1832,14 +1832,11 @@ public class TEIFormatter {
                             keepUnsolvedCallout, citationMarkerType);
 
                 } else if (clusterLabel.equals(TaggingLabels.FIGURE_MARKER)) {
-                    refNodes = markReferencesFigureOrTableTEI(chunkRefString,
-                        refTokens, figures,
-                        FigureTableType.FIGURE, config.isGenerateTeiCoordinates("ref"));
+                    refNodes = markReferencesFigureTEI(chunkRefString,
+                        refTokens, figures, config.isGenerateTeiCoordinates("ref"));
                 } else if (clusterLabel.equals(TaggingLabels.TABLE_MARKER)) {
-                    refNodes = markReferencesFigureOrTableTEI(chunkRefString,
-                        refTokens, tables,
-                        FigureTableType.TABLE,
-                        config.isGenerateTeiCoordinates("ref"));
+                    refNodes = markReferencesTableTEI(chunkRefString,
+                        refTokens, tables, config.isGenerateTeiCoordinates("ref"));
                 } else if (clusterLabel.equals(TaggingLabels.EQUATION_MARKER)) {
                     refNodes = markReferencesEquationTEI(chunkRefString, refTokens, equations,
                             config.isGenerateTeiCoordinates("ref"));
@@ -2355,8 +2352,25 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
         return nodes;
     }
 
+    public List<Node> markReferencesFigureTEI(
+        String refText,
+        List<LayoutToken> allRefTokens,
+        List<Figure> figures,
+        boolean generateCoordinates
+    ) {
+        return markReferencesFigureOrTableTEI(refText, allRefTokens, figures, FigureTableType.FIGURE, generateCoordinates);
+    }
 
-    public List<Node> markReferencesFigureOrTableTEI(
+    public List<Node> markReferencesTableTEI(
+        String refText,
+        List<LayoutToken> allRefTokens,
+        List<Table> tables,
+        boolean generateCoordinates
+    ) {
+        return markReferencesFigureOrTableTEI(refText, allRefTokens, tables, FigureTableType.TABLE, generateCoordinates);
+    }
+
+    private List<Node> markReferencesFigureOrTableTEI(
         String refText,
         List<LayoutToken> allRefTokens,
         List<? extends Figure> figuresOrTables,

--- a/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/TEIFormatter.java
@@ -142,7 +142,7 @@ public class TEIFormatter {
             // standard RelaxNG
             tei.append("<?xml-model href=\"" + SCHEMA_RNG_LOCATION +
                     "\" schematypens=\"http://relaxng.org/ns/structure/1.0\"?>\n");
-        } 
+        }
 
         // by default there is no schema association
         if (schemaDeclaration != SchemaDeclaration.XSD) {
@@ -198,17 +198,17 @@ public class TEIFormatter {
             for(Funding funding : fundings) {
                 if (funding.getFunder() == null) {
                     List<Funding> localfundings = fundingRelation.get(Funder.EMPTY);
-                    if (localfundings == null) 
+                    if (localfundings == null)
                         localfundings = new ArrayList<>();
                     localfundings.add(funding);
                     fundingRelation.put(Funder.EMPTY, localfundings);
                 } else {
                     List<Funding> localfundings = fundingRelation.get(funding.getFunder());
-                    if (localfundings == null) 
+                    if (localfundings == null)
                         localfundings = new ArrayList<>();
                     localfundings.add(funding);
                     fundingRelation.put(funding.getFunder(), localfundings);
-                }    
+                }
             }
 
             List<Funder> localFunders = new ArrayList<>();
@@ -315,7 +315,7 @@ public class TEIFormatter {
 
                 tei.append(" status=\"unknown\">\n");
                 tei.append("\t\t\t\t\t<licence/>\n");
-                
+
                 if (defaultPublicationStatement != null) {
                     tei.append("\t\t\t\t\t<p>" +
                             TextUtilities.HTMLEncode(defaultPublicationStatement) + "</p>\n");
@@ -340,7 +340,7 @@ public class TEIFormatter {
                 } else {
                     tei.append("\t\t\t\t<date>");
                 }
-                
+
                 if (biblio.getPublicationDate() != null) {
                     tei.append(TextUtilities.HTMLEncode(biblio.getPublicationDate()));
                 } else {
@@ -1229,7 +1229,7 @@ public class TEIFormatter {
             if (localNotes != null)
                 notes.addAll(localNotes);
         }
-        
+
         notes.stream()
             .forEach(n -> n.setText(TextUtilities.dehyphenize(n.getText())));
 
@@ -1285,7 +1285,7 @@ public class TEIFormatter {
         Note localNote = null;
         if (currentNumber == -1)
             localNote = new Note(null, noteTokens, footText, noteType);
-        else 
+        else
             localNote = new Note(""+currentNumber, noteTokens, footText, noteType);
 
         notes.add(localNote);
@@ -1345,7 +1345,7 @@ public class TEIFormatter {
         // pattern is <note n="1" place="foot" xml:id="foot_1">
         // or 
         // pattern is <note n="1" place="margin" xml:id="margin_1">
-        
+
         // if no note label is found, no @n attribute but we generate a random xml:id (not be used currently)
 
         for (Note note : notes) {
@@ -1364,12 +1364,12 @@ public class TEIFormatter {
                 String pID = KeyGen.getKey().substring(0, 7);
                 addXmlId(pNote, "_" + pID);
             }
-            
+
             if (config.isGenerateTeiCoordinates("p")) {
                 String coords = LayoutTokensUtil.getCoordsString(note.getTokens());
                 desc.addAttribute(new Attribute("coords", coords));
             }
-            
+
             // for labelling bibliographical references in notes 
             List<LayoutToken> noteTokens = note.getTokens();
 
@@ -1382,7 +1382,7 @@ public class TEIFormatter {
                 desc.addAttribute(new Attribute("coords", coords));
             }
 
-            org.apache.commons.lang3.tuple.Pair<String, List<LayoutToken>> noteProcess = 
+            org.apache.commons.lang3.tuple.Pair<String, List<LayoutToken>> noteProcess =
                 fullTextParser.processShort(noteTokens, doc);
 
             if (noteProcess == null) {
@@ -1395,7 +1395,7 @@ public class TEIFormatter {
             if ( (labeledNote != null) && (labeledNote.length() > 0) ) {
                 TaggingTokenClusteror clusteror = new TaggingTokenClusteror(GrobidModels.FULLTEXT, labeledNote, noteLayoutTokens);
                 List<TaggingTokenCluster> clusters = clusteror.cluster();
-                
+
                 for (TaggingTokenCluster cluster : clusters) {
                     if (cluster == null) {
                         continue;
@@ -1408,7 +1408,7 @@ public class TEIFormatter {
                             List<Node> refNodes = this.markReferencesTEILuceneBased(
                                     cluster.concatTokens(),
                                     doc.getReferenceMarkerMatcher(),
-                                    config.isGenerateTeiCoordinates("ref"), 
+                                    config.isGenerateTeiCoordinates("ref"),
                                     false);
                             if (refNodes != null) {
                                 for (Node n : refNodes) {
@@ -1464,7 +1464,7 @@ public class TEIFormatter {
         StringBuilder contentBuffer = new StringBuilder();
 
         contentBuffer = toTEITextPiece(contentBuffer, text, null, biblioData, false,
-                new LayoutTokenization(tokens), null, null, null, 
+                new LayoutTokenization(tokens), null, null, null,
             null, null, doc, config);
         String result = contentBuffer.toString();
         String[] resultAsArray = result.split("\n");
@@ -1575,7 +1575,7 @@ public class TEIFormatter {
 
                 curDiv.appendChild(head);
                 divResults.add(curDiv);
-            } else if (clusterLabel.equals(TaggingLabels.EQUATION) || 
+            } else if (clusterLabel.equals(TaggingLabels.EQUATION) ||
                     clusterLabel.equals(TaggingLabels.EQUATION_LABEL)) {
                 // get starting position of the cluster
                 int start = -1;
@@ -1587,7 +1587,7 @@ public class TEIFormatter {
                     Equation theEquation = null;
                     if (equations != null) {
                         for(int i=0; i<equations.size(); i++) {
-                            if (i < equationIndex) 
+                            if (i < equationIndex)
                                 continue;
                             Equation equation = equations.get(i);
                             if (equation.getStart() == start) {
@@ -1828,18 +1828,21 @@ public class TEIFormatter {
                 if (clusterLabel.equals(TaggingLabels.CITATION_MARKER)) {
                     refNodes = markReferencesTEILuceneBased(refTokens,
                             doc.getReferenceMarkerMatcher(),
-                            config.isGenerateTeiCoordinates("ref"), 
+                            config.isGenerateTeiCoordinates("ref"),
                             keepUnsolvedCallout, citationMarkerType);
 
                 } else if (clusterLabel.equals(TaggingLabels.FIGURE_MARKER)) {
-                    refNodes = markReferencesFigureTEI(chunkRefString, refTokens, figures,
-                            config.isGenerateTeiCoordinates("ref"));
+                    refNodes = markReferencesFigureOrTableTEI(chunkRefString,
+                        refTokens, figures,
+                        FigureTableType.FIGURE, config.isGenerateTeiCoordinates("ref"));
                 } else if (clusterLabel.equals(TaggingLabels.TABLE_MARKER)) {
-                    refNodes = markReferencesTableTEI(chunkRefString, refTokens, tables,
-                            config.isGenerateTeiCoordinates("ref"));
+                    refNodes = markReferencesFigureOrTableTEI(chunkRefString,
+                        refTokens, tables,
+                        FigureTableType.TABLE,
+                        config.isGenerateTeiCoordinates("ref"));
                 } else if (clusterLabel.equals(TaggingLabels.EQUATION_MARKER)) {
                     refNodes = markReferencesEquationTEI(chunkRefString, refTokens, equations,
-                            config.isGenerateTeiCoordinates("ref"));                    
+                            config.isGenerateTeiCoordinates("ref"));
                 } else {
                     throw new IllegalStateException("Unsupported marker type: " + clusterLabel);
                 }
@@ -1880,16 +1883,16 @@ public class TEIFormatter {
                                     }
                                 }
                             }
-                        } 
+                        }
                     }
 
                     if (!footNoteCallout) {
                         for (Node n : refNodes) {
                             parent.appendChild(n);
                         }
-                    } 
+                    }
                 }
-                
+
                 if (curParagraph != null)
                     curParagraphTokens.addAll(cluster.concatTokens());
             } else if (clusterLabel.equals(TaggingLabels.FIGURE) || clusterLabel.equals(TaggingLabels.TABLE)) {
@@ -1913,10 +1916,10 @@ public class TEIFormatter {
                 if ( (theDiv.getChildElements() == null) || (theDiv.getChildElements().size() == 0) ) {
                     divResults.remove(i);
                 }
-            } 
+            }
         }
 
-        if (divResults.size() != 0) 
+        if (divResults.size() != 0)
             buffer.append(XmlBuilderUtils.toXml(divResults));
         else
             buffer.append(XmlBuilderUtils.toXml(curDiv));
@@ -2021,7 +2024,7 @@ public class TEIFormatter {
 
                     String chunk = theNode.getValue();
                     forbiddenPositions.add(new OffsetPosition(pos, pos+chunk.length()));
-                    pos += chunk.length();                    
+                    pos += chunk.length();
                 }
             }
         }
@@ -2052,9 +2055,9 @@ public class TEIFormatter {
         List<List<LayoutToken>> segmentedParagraphTokens = new ArrayList<>();
         List<LayoutToken> currentSentenceTokens = new ArrayList<>();
         pos = 0;
-        
+
         if (config.isGenerateTeiCoordinates("s")) {
-            
+
             int currentSentenceIndex = 0;
             String sentenceChunk = text.substring(theSentences.get(currentSentenceIndex).start, theSentences.get(currentSentenceIndex).end);
 
@@ -2083,7 +2086,7 @@ public class TEIFormatter {
                     currentSentenceTokens.add(token);
                     pos = 0;
                 }
-                
+
                 if (currentSentenceIndex >= theSentences.size())
                     break;
             }
@@ -2132,12 +2135,12 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                     }
                 }
             }
-            
+
             int sentenceLength = theSentences.get(i).end - pos;
             // check if we have a ref between pos and pos+sentenceLength
             for(int j=refIndex; j<refPositions.size(); j++) {
                 int refPos = refPositions.get(j).intValue();
-                if (refPos < pos+posInSentence) 
+                if (refPos < pos+posInSentence)
                     continue;
 
                 if (refPos >= pos+posInSentence && refPos <= pos+sentenceLength) {
@@ -2178,7 +2181,7 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
             }
         }
 
-    }   
+    }
 
     /**
      * Return the graphic objects in a given interval position in the document.
@@ -2266,19 +2269,19 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
      * Mark using TEI annotations the identified references in the text body build with the machine learning model.
      */
     public List<Node> markReferencesTEILuceneBased(List<LayoutToken> refTokens,
-                                                   ReferenceMarkerMatcher markerMatcher, 
+                                                   ReferenceMarkerMatcher markerMatcher,
                                                    boolean generateCoordinates,
                                                    boolean keepUnsolvedCallout) throws EntityMatcherException {
         return markReferencesTEILuceneBased(refTokens, markerMatcher, generateCoordinates, keepUnsolvedCallout, null);
     }
 
     public List<Node> markReferencesTEILuceneBased(List<LayoutToken> refTokens,
-                                                   ReferenceMarkerMatcher markerMatcher, 
+                                                   ReferenceMarkerMatcher markerMatcher,
                                                    boolean generateCoordinates,
                                                    boolean keepUnsolvedCallout,
                                                    MarkerType citationMarkerType) throws EntityMatcherException {
         // safety tests
-        if ( (refTokens == null) || (refTokens.size() == 0) ) 
+        if ( (refTokens == null) || (refTokens.size() == 0) )
             return null;
         String text = LayoutTokensUtil.toText(refTokens);
         if (text == null || text.trim().length() == 0 || text.endsWith("</ref>") || text.startsWith("<ref") || markerMatcher == null)
@@ -2298,7 +2301,7 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                 if (refToken.isSuperscript()) {
                     hasSuperScriptNumber = true;
                     break;
-                }                    
+                }
             }
 
             if (citationMarkerType == MarkerType.SUPERSCRIPT_NUMBER) {
@@ -2343,7 +2346,7 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                 }
                 if ( solved || (!solved && keepUnsolvedCallout) )
                     nodes.add(ref);
-                else 
+                else
                     nodes.add(textNode(matchResult.getText()));
             }
         }
@@ -2353,11 +2356,14 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
     }
 
 
-    public List<Node> markReferencesFigureTEI(String refText, 
-                                            List<LayoutToken> allRefTokens,
-                                            List<Figure> figures,
-                                            boolean generateCoordinates) {
-        if (refText == null || 
+    public List<Node> markReferencesFigureOrTableTEI(
+        String refText,
+        List<LayoutToken> allRefTokens,
+        List<? extends Figure> figuresOrTables,
+        FigureTableType type,
+        boolean generateCoordinates
+    ) {
+        if (refText == null ||
             refText.trim().isEmpty()) {
             return null;
         }
@@ -2365,27 +2371,27 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
         List<Node> nodes = new ArrayList<>();
 
         if (refText.trim().length() == 1 && TextUtilities.fullPunctuations.contains(refText.trim())) {
-            // the reference text marker is a punctuation
+            // the reference text marker is punctuation
             nodes.add(new Text(refText));
             return nodes;
         }
 
         List<org.grobid.core.utilities.Pair<String, List<LayoutToken>>> labels = null;
 
-        List<List<LayoutToken>> allYs = LayoutTokensUtil.split(allRefTokens, ReferenceMarkerMatcher.AND_WORD_PATTERN, true);
+        List<List<LayoutToken>> allYs = LayoutTokensUtil.split(allRefTokens, ReferenceMarkerMatcher.FIGURE_TABLES_REF_SEPARATORS, true);
         if (allYs.size() > 1) {
             labels = new ArrayList<>();
             for (List<LayoutToken> ys : allYs) {
                 labels.add(new org.grobid.core.utilities.Pair<>(LayoutTokensUtil.toText(LayoutTokensUtil.dehyphenize(ys)), ys));
             }
         } else {
-            // possibly expand range of reference numbers (like for numeriacval bibliographical markers)
+            // possibly expand the range of reference numbers (like for numerical bibliographical markers)
             labels = ReferenceMarkerMatcher.getNumberedLabels(allRefTokens, false);
         }
 
         if (labels == null || labels.size() <= 1) {
-            org.grobid.core.utilities.Pair<String, List<LayoutToken>> localLabel = 
-                new org.grobid.core.utilities.Pair(refText, allRefTokens);
+            org.grobid.core.utilities.Pair<String, List<LayoutToken>> localLabel =
+                new org.grobid.core.utilities.Pair<>(refText, allRefTokens);
             labels = new ArrayList<>();
             labels.add(localLabel);
         }
@@ -2395,28 +2401,27 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
             List<LayoutToken> refTokens = theLabel.b;
 
             String textLow = text.toLowerCase().trim();
-            String bestFigure = null;
+            String bestFigureOrTable = null;
 
-            if (figures != null) {
-                for (Figure figure : figures) {
-                    if ((figure.getLabel() != null) && (figure.getLabel().length() > 0)) {
-                        String label = TextUtilities.cleanField(figure.getLabel(), false);
-                        if (label != null && (label.length() > 0) &&
-                                (textLow.equals(label.toLowerCase()))) {
-                            bestFigure = figure.getId();
+            if (figuresOrTables != null) {
+                for (Figure figureOrTable : figuresOrTables) {
+                    if (StringUtils.isNotBlank(figureOrTable.getLabel())) {
+                        String label = TextUtilities.cleanField(figureOrTable.getLabel(), false);
+                        if (StringUtils.isNotBlank(label) && textLow.equals(label.toLowerCase())) {
+                            bestFigureOrTable = figureOrTable.getId();
                             break;
                         }
                     }
                 }
-                if (bestFigure == null) {
+                if (bestFigureOrTable == null) {
                     // second pass with relaxed figure marker matching
-                    for(int i=figures.size()-1; i>=0; i--) {
-                        Figure figure = figures.get(i);
-                        if (StringUtils.isNotBlank(figure.getLabel())) {
-                            String label = TextUtilities.cleanField(figure.getLabel(), false);
+                    for(int i=figuresOrTables.size()-1; i>=0; i--) {
+                        Figure figureOrTable = figuresOrTables.get(i);
+                        if (StringUtils.isNotBlank(figureOrTable.getLabel())) {
+                            String label = TextUtilities.cleanField(figureOrTable.getLabel(), false);
                             if (StringUtils.isNotBlank(label) &&
                                     (textLow.contains(label.toLowerCase()))) {
-                                bestFigure = figure.getId();
+                                bestFigureOrTable = figureOrTable.getId();
                                 break;
                             }
                         }
@@ -2447,8 +2452,8 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
             }
 
             String andWordString = null;
-            if (text.endsWith("and") || text.endsWith("&")) {
-                if (text.equals("and") || text.equals("&")) {
+            if (text.endsWith("and") || text.endsWith("&") || text.endsWith(",")) {
+                if (text.equals("and") || text.equals("&") || text.equals(",")) {
                     if (spaceStart) {
                         nodes.add(new Text(" "));
                     }
@@ -2466,158 +2471,12 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                     text = text.substring(0, text.length()-1);
                     andWordString = "&";
                     refTokens = refTokens.subList(0,refTokens.size()-1);
-                }
-                if (text.endsWith(" ")) {
-                    andWordString = " " + andWordString;
-                    refTokens = refTokens.subList(0,refTokens.size()-1);
-                }
-                text = text.trim();
-            }
-
-            String coords = null;
-            if (generateCoordinates && refTokens != null) {
-                coords = LayoutTokensUtil.getCoordsString(refTokens);
-            }
-
-            Element ref = teiElement("ref");
-            ref.addAttribute(new Attribute("type", "figure"));
-
-            if (coords != null) {
-                ref.addAttribute(new Attribute("coords", coords));
-            }
-            ref.appendChild(text);
-
-            if (bestFigure != null) {
-                ref.addAttribute(new Attribute("target", "#fig_" + bestFigure));
-            }
-            if (spaceStart) {
-                nodes.add(new Text(" "));
-            }
-            nodes.add(ref);
-
-            if (andWordString != null) {
-                nodes.add(new Text(andWordString));
-            }
-
-            if (spaceEnd) {
-                nodes.add(new Text(" "));
-            }
-        }
-        return nodes;
-    }
-
-    public List<Node> markReferencesTableTEI(String refText, List<LayoutToken> allRefTokens,
-                                             List<Table> tables,
-                                             boolean generateCoordinates) {
-        if (refText == null || 
-            refText.trim().isEmpty()) {
-            return null;
-        }
-
-        List<Node> nodes = new ArrayList<>();
-
-        if (refText.trim().length() == 1 && TextUtilities.fullPunctuations.contains(refText.trim())) {
-            // the reference text marker is a punctuation
-            nodes.add(new Text(refText));
-            return nodes;
-        }
-
-        List<org.grobid.core.utilities.Pair<String, List<LayoutToken>>> labels = null;
-
-        List<List<LayoutToken>> allYs = LayoutTokensUtil.split(allRefTokens, ReferenceMarkerMatcher.AND_WORD_PATTERN, true);
-        if (allYs.size() > 1) {
-            labels = new ArrayList<>();
-            for (List<LayoutToken> ys : allYs) {
-                labels.add(new org.grobid.core.utilities.Pair<>(LayoutTokensUtil.toText(LayoutTokensUtil.dehyphenize(ys)), ys));
-            }
-        } else {
-            // possibly expand range of reference numbers (like for numeriacval bibliographical markers)
-            labels = ReferenceMarkerMatcher.getNumberedLabels(allRefTokens, false);
-        }
-
-        if (labels == null || labels.size() <= 1) {
-            org.grobid.core.utilities.Pair<String, List<LayoutToken>> localLabel = 
-                new org.grobid.core.utilities.Pair(refText, allRefTokens);
-            labels = new ArrayList<>();
-            labels.add(localLabel);
-        }
-
-        for (org.grobid.core.utilities.Pair<String, List<LayoutToken>> theLabel : labels) {
-            String text = theLabel.a;
-            List<LayoutToken> refTokens = theLabel.b;
-
-            String textLow = text.toLowerCase().trim();
-            String bestTable = null;
-            if (tables != null) {
-                for (Table table : tables) {
-                    if ((table.getLabel() != null) && (table.getLabel().length() > 0)) {
-                        String label = TextUtilities.cleanField(table.getLabel(), false);
-                        if (label != null && (label.length() > 0) &&
-                                (textLow.equals(label.toLowerCase()))) {
-                            bestTable = table.getId();
-                            break;
-                        }
-                    }
-                }
-
-                if (bestTable == null) {
-                    // second pass with relaxed table marker matching
-                    for(int i=tables.size()-1; i>=0; i--) {
-                        Table table = tables.get(i);
-                        if (StringUtils.isNotBlank(table.getLabel())) {
-                            String label = TextUtilities.cleanField(table.getLabel(), false);
-                            if (StringUtils.isNotBlank(label) && (textLow.contains(label.toLowerCase()))) {
-                                bestTable = table.getId();
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            boolean spaceEnd = false;
-            boolean spaceStart = false;
-            text = text.replace("\n", " ");
-            if (text.endsWith(" ")) {
-                spaceEnd = true;
-            }
-            if (!text.equals(" ") & text.startsWith(" ")) {
-                spaceStart = true;
-            }
-            text = text.trim();
-
-            if (StringUtils.isBlank(text)) {
-                if (spaceStart) {
-                    nodes.add(new Text(" "));
-                }
-                nodes.add(new Text(text));
-                if (spaceEnd) {
-                    nodes.add(new Text(" "));
-                }
-                continue;
-            }
-
-            String andWordString = null;
-            if (text.endsWith("and") || text.endsWith("&")) {
-               if (text.equals("and") || text.equals("&")) {
-                    if (spaceStart) {
-                        nodes.add(new Text(" "));
-                    }
-                    nodes.add(new Text(text));
-                    if (spaceEnd) {
-                        nodes.add(new Text(" "));
-                    }
-                    continue;
-                } else if (text.endsWith("and")) {
-                    // the AND_WORD_PATTERN case, we want to exclude the AND word from the tagged chunk
-                    text = text.substring(0, text.length()-3);
-                    andWordString = "and";
-                    refTokens = refTokens.subList(0,refTokens.size()-1);
-                } else if (text.endsWith("&")) {
+                } else if (text.endsWith(",")) {
                     text = text.substring(0, text.length()-1);
-                    andWordString = "&";
+                    andWordString = ",";
                     refTokens = refTokens.subList(0,refTokens.size()-1);
                 }
+
                 if (text.endsWith(" ")) {
                     andWordString = " " + andWordString;
                     refTokens = refTokens.subList(0,refTokens.size()-1);
@@ -2631,15 +2490,20 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
             }
 
             Element ref = teiElement("ref");
-            ref.addAttribute(new Attribute("type", "table"));
+
+            ref.addAttribute(new Attribute("type", type.getValue()));
 
             if (coords != null) {
                 ref.addAttribute(new Attribute("coords", coords));
             }
             ref.appendChild(text);
 
-            if (bestTable != null) {
-                ref.addAttribute(new Attribute("target", "#tab_" + bestTable));
+            if (bestFigureOrTable != null) {
+                if (type == FigureTableType.TABLE) {
+                    ref.addAttribute(new Attribute("target", "#tab_" + bestFigureOrTable));
+                } else if (type == FigureTableType.FIGURE) {
+                    ref.addAttribute(new Attribute("target", "#fig_" + bestFigureOrTable));
+                }
             }
             if (spaceStart) {
                 nodes.add(new Text(" "));
@@ -2659,7 +2523,7 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
 
     private static Pattern patternNumber = Pattern.compile("\\d+");
 
-    public List<Node> markReferencesEquationTEI(String text, 
+    public List<Node> markReferencesEquationTEI(String text,
                                             List<LayoutToken> refTokens,
                                             List<Equation> equations,
                                             boolean generateCoordinates) {
@@ -2690,15 +2554,15 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
                     //if ((label.length() > 0) &&
                     //        (textLow.contains(label.toLowerCase()))) {
                     if ( (labelNumber != null && textNumber != null && labelNumber.length()>0 &&
-                        labelNumber.equals(textNumber)) || 
+                        labelNumber.equals(textNumber)) ||
                         ((label.length() > 0) && (textLow.equals(label.toLowerCase()))) ) {
                         bestFormula = equation.getId();
                         break;
-                    } 
+                    }
                 }
             }
         }
-        
+
         boolean spaceEnd = false;
         text = text.replace("\n", " ");
         if (text.endsWith(" "))
@@ -2765,9 +2629,9 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
 
     /**
      * In case, the coordinates of structural elements are provided in the TEI
-     * representation, we need the page sizes in order to scale the coordinates 
-     * appropriately. These size information are provided via the TEI facsimile 
-     * element, with a surface element for each page carrying the page size info.  
+     * representation, we need the page sizes in order to scale the coordinates
+     * appropriately. These size information are provided via the TEI facsimile
+     * element, with a surface element for each page carrying the page size info.
      */
     public StringBuilder toTEIPages(StringBuilder buffer,
                                    Document doc,
@@ -2783,7 +2647,7 @@ for (List<LayoutToken> segmentedParagraphToken : segmentedParagraphTokens) {
         buffer.append("\t<facsimile>\n");
         for(Page page : pages) {
             buffer.append("\t\t<surface ");
-            buffer.append("n=\"" + pageNumber + "\" "); 
+            buffer.append("n=\"" + pageNumber + "\" ");
             buffer.append("ulx=\"0.0\" uly=\"0.0\" ");
             buffer.append("lrx=\"" + page.getWidth() + "\" lry=\"" + page.getHeight() + "\"");
             buffer.append("/>\n");

--- a/grobid-core/src/main/java/org/grobid/core/utilities/matching/ReferenceMarkerMatcher.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/matching/ReferenceMarkerMatcher.java
@@ -11,7 +11,6 @@ import org.grobid.core.data.BiblioItem;
 import org.grobid.core.layout.LayoutToken;
 import org.grobid.core.utilities.LayoutTokensUtil;
 import org.grobid.core.utilities.Pair;
-import org.grobid.core.utilities.TextUtilities;
 import org.grobid.core.utilities.counters.CntManager;
 import org.grobid.core.engines.counters.ReferenceMarkerMatcherCounters;
 import org.slf4j.Logger;
@@ -42,6 +41,7 @@ public class ReferenceMarkerMatcher {
     public static final int MAX_RANGE = 20;
     public static final Pattern NUMBERED_CITATIONS_SPLIT_PATTERN = Pattern.compile("[,;]");
     public static final Pattern AND_WORD_PATTERN = Pattern.compile("(and)|&");
+    public static final Pattern FIGURE_TABLES_REF_SEPARATORS = Pattern.compile("(and)|(&)|(,)");
     public static final Pattern DASH_PATTERN = Pattern.compile("[–−-]");
 
     public class MatchResult {  

--- a/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
@@ -101,8 +101,8 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
-                figures, FigureTableType.FIGURE, false);
+            .markReferencesFigureTEI(input, tokensWithOffset,
+                figures, false);
 
         assertThat(nodes, hasSize(4));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3C</ref>"));
@@ -132,8 +132,8 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
-                figures, FigureTableType.FIGURE, false);
+            .markReferencesFigureTEI(input, tokensWithOffset,
+                figures, false);
 
         assertThat(nodes, hasSize(2));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
@@ -161,8 +161,8 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
-                figures, FigureTableType.FIGURE, false);
+            .markReferencesFigureTEI(input, tokensWithOffset,
+                figures, false);
 
         assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is("and"));
@@ -190,7 +190,7 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset, figures, FigureTableType.FIGURE,  false);
+            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
 
         assertThat(nodes, hasSize(6));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5</ref>"));
@@ -222,7 +222,7 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset, figures, FigureTableType.FIGURE, false);
+            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
 
         assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is(","));
@@ -251,7 +251,7 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset, figures, FigureTableType.FIGURE, false);
+            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
 
         assertThat(nodes, hasSize(4));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5</ref>"));
@@ -280,8 +280,8 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
-                tables, TABLE, false);
+            .markReferencesTableTEI(input, tokensWithOffset,
+                tables, false);
         assertThat(nodes, hasSize(4));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">3C</ref>"));
         assertThat(nodes.get(1).toXML(), is(" and"));
@@ -308,8 +308,8 @@ public class TEIFormatterTest {
         List<Table> tables = List.of(t1, t2, t3);
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset, tables,
-                FigureTableType.TABLE, false);
+            .markReferencesTableTEI(input, tokensWithOffset, tables,
+                false);
         assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is("and"));
         assertThat(nodes.get(1).toXML(), is(" "));
@@ -335,8 +335,8 @@ public class TEIFormatterTest {
         List<Table> tables = List.of(t1, t2, t3);
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset, tables,
-                FigureTableType.TABLE, false);
+            .markReferencesTableTEI(input, tokensWithOffset, tables,
+                false);
 
         assertThat(nodes, hasSize(6));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">5</ref>"));
@@ -366,8 +366,7 @@ public class TEIFormatterTest {
         List<Table> tables = List.of(t1, t2, t3);
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureOrTableTEI(input, tokensWithOffset, tables,
-                FigureTableType.TABLE, false);
+            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
 
         assertThat(nodes, hasSize(6));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">5</ref>"));

--- a/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/document/TEIFormatterTest.java
@@ -4,6 +4,7 @@ import nu.xom.Element;
 import nu.xom.Node;
 import org.grobid.core.analyzers.GrobidAnalyzer;
 import org.grobid.core.data.Figure;
+import org.grobid.core.data.FigureTableType;
 import org.grobid.core.data.Note;
 import org.grobid.core.data.Table;
 import org.grobid.core.layout.LayoutToken;
@@ -15,6 +16,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.grobid.core.data.FigureTableType.TABLE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -99,13 +101,43 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
+                figures, FigureTableType.FIGURE, false);
 
         assertThat(nodes, hasSize(4));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3C</ref>"));
         assertThat(nodes.get(1).toXML(), is(" and"));
         assertThat(nodes.get(2).toXML(), is(" "));
         assertThat(((Element) nodes.get(3)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+    }
+
+    @Test
+    public void testMarkReferencesFigureTEI_truncatedRef_andSeparator_referenceAtBeginning() throws Exception {
+        String input = "3D and";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Figure f1 = new Figure();
+        f1.setLabel(new StringBuilder("1"));
+        Figure f2 = new Figure();
+        f2.setLabel(new StringBuilder("2"));
+        Figure f3 = new Figure();
+        f3.setLabel(new StringBuilder(""));
+
+        List<Figure> figures = List.of(f1, f2, f3);
+
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
+                figures, FigureTableType.FIGURE, false);
+
+        assertThat(nodes, hasSize(2));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" and"));
     }
 
     @Test
@@ -129,7 +161,8 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
+                figures, FigureTableType.FIGURE, false);
 
         assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is("and"));
@@ -140,6 +173,37 @@ public class TEIFormatterTest {
     @Test
     public void testMarkReferencesFigureTEI_truncatedRef_referenceAtBeginning() throws Exception {
         String input = "5, & ";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Figure f1 = new Figure();
+        f1.setLabel(new StringBuilder("1"));
+        Figure f2 = new Figure();
+        f2.setLabel(new StringBuilder("2"));
+        Figure f3 = new Figure();
+        f3.setLabel(new StringBuilder(""));
+
+        List<Figure> figures = List.of(f1, f2, f3);
+
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset, figures, FigureTableType.FIGURE,  false);
+
+        assertThat(nodes, hasSize(6));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5</ref>"));
+        assertThat(nodes.get(1).toXML(), is(","));
+        assertThat(nodes.get(2).toXML(), is(" "));
+        assertThat(nodes.get(3).toXML(), is("&amp;"));
+        assertThat(nodes.get(4).toXML(), is(""));
+        assertThat(nodes.get(5).toXML(), is(" "));
+    }
+
+    @Test
+    public void testMarkReferencesFigureTEI_truncatedRefWithComma_referenceAtTheEnd() throws Exception {
+        String input = ", 3D";
         List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
 
 
@@ -158,11 +222,40 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesFigureTEI(input, tokensWithOffset, figures, false);
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset, figures, FigureTableType.FIGURE, false);
+
+        assertThat(nodes, hasSize(3));
+        assertThat(nodes.get(0).toXML(), is(","));
+        assertThat(nodes.get(1).toXML(), is(" "));
+        assertThat(((Element) nodes.get(2)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">3D</ref>"));
+    }
+
+    @Test
+    public void testMarkReferencesFigureTEI_truncatedRefWithComma_referenceAtBeginning() throws Exception {
+        String input = "5, ";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Figure f1 = new Figure();
+        f1.setLabel(new StringBuilder("1"));
+        Figure f2 = new Figure();
+        f2.setLabel(new StringBuilder("2"));
+        Figure f3 = new Figure();
+        f3.setLabel(new StringBuilder(""));
+
+        List<Figure> figures = List.of(f1, f2, f3);
+
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset, figures, FigureTableType.FIGURE, false);
 
         assertThat(nodes, hasSize(4));
-        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5,</ref>"));
-        assertThat(nodes.get(1).toXML(), is(" &amp;"));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"figure\">5</ref>"));
+        assertThat(nodes.get(1).toXML(), is(","));
         assertThat(nodes.get(2).toXML(), is(""));
         assertThat(nodes.get(3).toXML(), is(" "));
     }
@@ -187,7 +280,8 @@ public class TEIFormatterTest {
 
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset,
+                tables, TABLE, false);
         assertThat(nodes, hasSize(4));
         assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">3C</ref>"));
         assertThat(nodes.get(1).toXML(), is(" and"));
@@ -214,7 +308,8 @@ public class TEIFormatterTest {
         List<Table> tables = List.of(t1, t2, t3);
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset, tables,
+                FigureTableType.TABLE, false);
         assertThat(nodes, hasSize(3));
         assertThat(nodes.get(0).toXML(), is("and"));
         assertThat(nodes.get(1).toXML(), is(" "));
@@ -240,13 +335,47 @@ public class TEIFormatterTest {
         List<Table> tables = List.of(t1, t2, t3);
 
         List<Node> nodes = new TEIFormatter(null, null)
-            .markReferencesTableTEI(input, tokensWithOffset, tables, false);
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset, tables,
+                FigureTableType.TABLE, false);
 
-        assertThat(nodes, hasSize(4));
-        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">5,</ref>"));
-        assertThat(nodes.get(1).toXML(), is(" &amp;"));
-        assertThat(nodes.get(2).toXML(), is(""));
-        assertThat(nodes.get(3).toXML(), is(" "));
+        assertThat(nodes, hasSize(6));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">5</ref>"));
+        assertThat(nodes.get(1).toXML(), is(","));
+        assertThat(nodes.get(2).toXML(), is(" "));
+        assertThat(nodes.get(3).toXML(), is("&amp;"));
+        assertThat(nodes.get(4).toXML(), is(""));
+        assertThat(nodes.get(5).toXML(), is(" "));
+    }
+
+    @Test
+    public void testMarkReferencesTableTEI_truncatedRef2_referenceAtBeginning() throws Exception {
+        String input = "5 , & ";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        List<LayoutToken> tokensWithOffset = tokens.stream()
+            .peek(t -> t.setOffset(t.getOffset() + 51393))
+            .collect(Collectors.toList());
+
+        Table t1 = new Table();
+        t1.setLabel(new StringBuilder("1"));
+        Table t2 = new Table();
+        t2.setLabel(new StringBuilder("2"));
+        Table t3 = new Table();
+        t3.setLabel(new StringBuilder(""));
+
+        List<Table> tables = List.of(t1, t2, t3);
+
+        List<Node> nodes = new TEIFormatter(null, null)
+            .markReferencesFigureOrTableTEI(input, tokensWithOffset, tables,
+                FigureTableType.TABLE, false);
+
+        assertThat(nodes, hasSize(6));
+        assertThat(((Element) nodes.get(0)).toXML(), is("<ref xmlns=\"http://www.tei-c.org/ns/1.0\" type=\"table\">5</ref>"));
+        assertThat(nodes.get(1).toXML(), is(" ,"));
+        assertThat(nodes.get(2).toXML(), is(" "));
+        assertThat(nodes.get(3).toXML(), is("&amp;"));
+        assertThat(nodes.get(4).toXML(), is(""));
+        assertThat(nodes.get(5).toXML(), is(" "));
     }
 
 


### PR DESCRIPTION
This PR extends https://github.com/kermitt2/grobid/pull/1246 by including `,` as reference separator. 
We also simplify the creation of the table and figure reference in a single method with the "type" as discriminant to avoid divergent methods 