### PR TITLE
Bugfix/adjust block distance when multi columns

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1261,7 +1261,9 @@ public class Document implements Serializable {
     /**
      * This method assigns graphic objects to figures based on the proximity of the graphic object to the figure caption.
      * In addition, it removes blocks of layout tokens that are at a distance greater than a threshold from the figure caption.
-     * The method returns the updated list of layout tokens, and the list of layout tokens that have been discarded.
+     * The method returns the updated list of layout tokens and the list of layout tokens that have been discarded.
+     *
+     * LF: To bear in mind that this method was designed assuming the figure caption comes after the figure.
      */
     protected org.apache.commons.lang3.tuple.Pair<List<LayoutToken>, List<List<LayoutToken>>> getFigureLayoutTokens(Figure f) {
 
@@ -1295,9 +1297,10 @@ public class Document implements Serializable {
                         result.addAll(newBlock.getTokens());
                         previousBlock = newBlock;
                     } else {
-                        // A TEMPORARY trick would be to iterate to all the following blocks
+                        // LF: The first temporary trick was to iterate to all the following blocks
                         // and place them into the discarded token list of the figure
 //                        f.addDiscardedPieceTokens(b.getTokens());
+
                         List<LayoutToken> newBlockTrimmed = newBlock.getTokens();
 
                         String figureLayoutTokens = LayoutTokensUtil.toText(f.getLayoutTokens());
@@ -1363,11 +1366,10 @@ public class Document implements Serializable {
             } else {
                 // If the figure is contained completely into a big block,
                 // it means that we either will have the full image somewhere or not (if it's reversed),
-                // there is no risk of loosing pieces, so we don't collect the tokens
+                // there is no risk of losing pieces, so we don't collect the tokens
                 if (!LayoutTokensUtil.toText(previousBlock.getTokens()).trim().toLowerCase().contains(LayoutTokensUtil.toText(f.getLayoutTokens()).trim().toLowerCase())) {
                     f.addDiscardedPieceTokens(previousBlock.getTokens());
                 }
-//                LOGGER.info("BAD_FIGIRE_LABEL: " + norm);
             }
         }
 

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1366,7 +1366,12 @@ public class Document implements Serializable {
                 }
                 break;
             } else {
-                f.addDiscardedPieceTokens(previousBlock.getTokens());
+                // If the figure is contained completely into a big block,
+                // it means that we either will have the full image somewhere or not (if it's reversed),
+                // there is no risk of loosing pieces, so we don't collect the tokens
+                if (!LayoutTokensUtil.toText(previousBlock.getTokens()).trim().toLowerCase().contains(LayoutTokensUtil.toText(f.getLayoutTokens()).trim().toLowerCase())) {
+                    f.addDiscardedPieceTokens(previousBlock.getTokens());
+                }
 //                LOGGER.info("BAD_FIGIRE_LABEL: " + norm);
             }
         }

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1293,7 +1293,7 @@ public class Document implements Serializable {
                     newBlockPtr = it.next();
                     Block newBlock = getBlocks().get(newBlockPtr);
                     BoundingBox newBlockCoords = BoundingBox.fromPointAndDimensions(newBlock.getPageNumber(), newBlock.getX(), newBlock.getY(), newBlock.getWidth(), newBlock.getHeight());
-                    if (newBlockCoords.distanceTo(prevBlockCoords) < 15) {
+                    if (newBlockCoords.distanceTo(prevBlockCoords) < 15 || (Math.abs(newBlockCoords.verticalDistanceTo(prevBlockCoords)) == 0 && newBlockCoords.distanceTo(prevBlockCoords) < 20)) {
                         result.addAll(newBlock.getTokens());
                         previousBlock = newBlock;
                     } else {

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1311,7 +1311,7 @@ public class Document implements Serializable {
                             }
 
                             if (subListSize > 0) {
-                                newBlockTrimmed = newBlock.getTokens().subList(0, subListSize);
+                                newBlockTrimmed = new ArrayList<>(newBlock.getTokens().subList(0, subListSize));
                             } else {
                                 // If the item is not found, we discard the current block and all the following
                                 f.addDiscardedPieceTokens(newBlock.getTokens());
@@ -1341,7 +1341,7 @@ public class Document implements Serializable {
                                     subListSize -= 1;
                                 }
                                 if (subListSize > 0) {
-                                    newBlockTrimmed = newBlock.getTokens().subList(0, subListSize);
+                                    newBlockTrimmed = new ArrayList<>(newBlock.getTokens().subList(0, subListSize));
                                 } else {
                                     // If the item is not found, we discard the current block and all the following
                                     f.addDiscardedPieceTokens(previousBlock.getTokens());
@@ -1554,7 +1554,7 @@ public class Document implements Serializable {
             String text = block.getText();
             if ((text != null) && (!text.contains("@PAGE")) && (!text.contains("@IMAGE"))) {
                 double surface = block.getWidth() * block.getHeight();
-                
+
                 /*System.out.println("block.width: " + block.width);
                 System.out.println("block.height: " + block.height);
                 System.out.println("surface: " + surface);

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1287,6 +1287,7 @@ public class Document implements Serializable {
                 || norm.startsWith("quadro")
                 || norm.startsWith("wykres")
                 || norm.startsWith("fuente")
+                || norm.startsWith("video")
             ) {
                 result.addAll(figBlock.getTokens());
 

--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -1268,7 +1268,6 @@ public class Document implements Serializable {
         List<LayoutToken> result = new ArrayList<>();
         List<List<LayoutToken>> discardedPieces = new ArrayList<>();
         Iterator<Integer> it = f.getBlockPtrs().iterator();
-        List<List<LayoutToken>> discardedPieces = new ArrayList<>();
 
         while (it.hasNext()) {
             Integer newBlockPtr = it.next();

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -1,68 +1,55 @@
 package org.grobid.core.engines;
 
 import com.google.common.collect.Iterables;
-
+import nu.xom.Element;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.MutableTriple;
-import org.apache.commons.io.FileUtils;
-
-import java.nio.charset.StandardCharsets;
-
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
 import org.grobid.core.GrobidModels;
 import org.grobid.core.data.*;
-import org.grobid.core.document.Document;
-import org.grobid.core.document.DocumentPiece;
-import org.grobid.core.document.DocumentPointer;
-import org.grobid.core.document.DocumentSource;
-import org.grobid.core.document.TEIFormatter;
+import org.grobid.core.document.*;
+import org.grobid.core.engines.citations.CalloutAnalyzer;
+import org.grobid.core.engines.citations.CalloutAnalyzer.MarkerType;
 import org.grobid.core.engines.citations.LabeledReferenceResult;
 import org.grobid.core.engines.citations.ReferenceSegmenter;
 import org.grobid.core.engines.config.GrobidAnalysisConfig;
 import org.grobid.core.engines.counters.CitationParserCounters;
 import org.grobid.core.engines.label.SegmentationLabels;
-import org.grobid.core.engines.label.TaggingLabels;
 import org.grobid.core.engines.label.TaggingLabel;
+import org.grobid.core.engines.label.TaggingLabels;
 import org.grobid.core.engines.tagging.GenericTaggerUtils;
 import org.grobid.core.exceptions.GrobidException;
 import org.grobid.core.exceptions.GrobidResourceException;
 import org.grobid.core.features.FeatureFactory;
 import org.grobid.core.features.FeaturesVectorFulltext;
 import org.grobid.core.lang.Language;
-import org.grobid.core.lexicon.Lexicon;
 import org.grobid.core.layout.*;
+import org.grobid.core.lexicon.Lexicon;
 import org.grobid.core.tokenization.TaggingTokenCluster;
 import org.grobid.core.tokenization.TaggingTokenClusteror;
 import org.grobid.core.utilities.*;
-import org.grobid.core.utilities.matching.ReferenceMarkerMatcher;
 import org.grobid.core.utilities.matching.EntityMatcherException;
-import org.grobid.core.engines.citations.CalloutAnalyzer;
-import org.grobid.core.engines.citations.CalloutAnalyzer.MarkerType;
-
+import org.grobid.core.utilities.matching.ReferenceMarkerMatcher;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
-import nu.xom.Element;
-
+import static net.sf.saxon.expr.parser.Token.tokens;
 import static org.apache.commons.lang3.StringUtils.*;
-import static org.grobid.core.utilities.LabelUtils.postProcessFullTextLabeledText;
 import static org.grobid.core.GrobidModels.FULLTEXT;
-import static org.grobid.core.engines.label.TaggingLabels.PARAGRAPH_LABEL;
+import static org.grobid.core.engines.label.TaggingLabels.FIGURE_LABEL;
+import static org.grobid.core.utilities.LabelUtils.postProcessFullTextLabeledText;
 
 public class FullTextParser extends AbstractParser {
     private static final Logger LOGGER = LoggerFactory.getLogger(FullTextParser.class);
@@ -287,18 +274,42 @@ public class FullTextParser extends AbstractParser {
                 bodyResults = LabelUtils.postProcessFulltextFixInvalidTableOrFigure(bodyResults);
 
                 // we apply now the figure and table models based on the fulltext labeled output
-				figures = processFigures(bodyResults, bodyLayoutTokens.getTokenization(), doc);
+				figures = processFigures(bodyResults, bodyLayoutTokens.getTokenization());
+                doc.setFigures(figures);
+
+                List<Triple<Figure, Figure, List<List<LayoutToken>>>> updatedFigures = doc.assignGraphicObjectsToFigures();
+                for(Triple<Figure, Figure, List<List<LayoutToken>>> update: updatedFigures) {
+                    List<List<LayoutToken>> difference = update.getRight();
+
+                    long nbDifferences = difference.stream()
+                        .filter(llt -> !llt.isEmpty())
+                        .count();
+
+                    if (nbDifferences > 0) {
+                        // In this case we assume they are figures
+                        String updatedBodyResult = revertDiscardedTokensInMainResults(difference, bodyResults, true);
+                        bodyResults = updatedBodyResult;
+                    }
+                }
+
                 // further parse the caption
                 for(Figure figure : figures) {
                     if (CollectionUtils.isNotEmpty(figure.getCaptionLayoutTokens()) ) {
-                        Pair<String, List<LayoutToken>> captionProcess = processShort(figure.getCaptionLayoutTokens(), doc);
-                        figure.setLabeledCaption(captionProcess.getLeft());
-                        figure.setCaptionLayoutTokens(captionProcess.getRight());
+                        Pair<String, List<LayoutToken>> processedCaption = processShort(figure.getCaptionLayoutTokens(), doc);
+                        figure.setLabeledCaption(processedCaption.getLeft());
+                        List<LayoutToken> processedCaptionLayoutTokens = processedCaption.getRight();
+                        if (processedCaptionLayoutTokens.size() != figure.getCaptionLayoutTokens().size()) {
+                            // We might have a problem, we might loose some tokens during the processing
+                            LOGGER.warn("Changes in the figure caption: \noriginal: "
+                                + LayoutTokensUtil.toText(figure.getCaptionLayoutTokens())
+                                + "\nmodified: " + LayoutTokensUtil.toText(processedCaptionLayoutTokens));
+                        }
+                        figure.setCaptionLayoutTokens(processedCaptionLayoutTokens);
                     }
                 }
 
                 long numberFiguresFulltextModel = Arrays.stream(bodyResults.split("\n"))
-                    .filter(r -> r.endsWith("I-" + TaggingLabels.FIGURE_LABEL))
+                    .filter(r -> r.endsWith("I-" + FIGURE_LABEL))
                 .count();
 
                 List<Figure> badFigures = figures.stream()
@@ -306,8 +317,7 @@ public class FullTextParser extends AbstractParser {
                     .collect(Collectors.toList());
 
                 LOGGER.info("Number of figures badly formatted or incomplete we identified: " + badFigures.size());
-                bodyResults = revertResultsForBadItems(badFigures, bodyResults, TaggingLabels.FIGURE_LABEL,
-                     !(figures.size() > numberFiguresFulltextModel));
+                bodyResults = revertResultsForBadItems(badFigures, bodyResults, !(figures.size() > numberFiguresFulltextModel));
 
                 figures = figures.stream()
                     .filter(f -> !badFigures.contains(f))
@@ -329,8 +339,7 @@ public class FullTextParser extends AbstractParser {
                     .collect(Collectors.toList());
 
                 LOGGER.info("Number of tables badly formatted or incomplete we identified: " + badTables.size());
-                bodyResults = revertResultsForBadItems(badTables, bodyResults, TaggingLabels.TABLE_LABEL,
-                    !(tables.size() > numberTablesFulltextModel));
+                bodyResults = revertResultsForBadItems(badTables, bodyResults, !(tables.size() > numberTablesFulltextModel));
 
                 tables = tables.stream()
                     .filter(t-> !badTables.contains(t))
@@ -399,18 +408,31 @@ public class FullTextParser extends AbstractParser {
         }
     }
 
-    static String revertResultsForBadItems(List<? extends Figure> badFiguresOrTables, String resultBody, String itemLabel) {
-        return revertResultsForBadItems(badFiguresOrTables, resultBody, itemLabel, true);
+    static String revertResultsForBadItems(List<? extends Figure> badFiguresOrTables, String resultBody) {
+        return revertResultsForBadItems(badFiguresOrTables, resultBody, true);
     }
 
-    static String revertResultsForBadItems(List<? extends Figure> badFiguresOrTables, String resultBody, String itemLabel, boolean strict) {
-        //LF: we update the resultBody sequence by reverting these tables as <paragraph> elements
+    /**
+     * Revert bad figures or tables (that will likely be dropped later on) to paragraphs.
+     * The algorithm first search for candidate index in the resultBody sequence, then it tries to match the sequence
+     * of tokens of the bad figure or table with the sequence of tokens in the resultBody. If a match is found, then
+     * the figure or table is reverted to a sequence of paragraphs.
+     *
+     * At the moment the algorithm does not consider possible reference markers in the sequence of tokens.
+     */
+    static String revertResultsForBadItems(List<? extends Figure> badFiguresOrTables, String resultBody, boolean strict) {
+        //LF: we update the resultBody sequence by reverting these figure or tables as <paragraph> elements
         if (CollectionUtils.isNotEmpty(badFiguresOrTables)) {
+
             List<List<String>> labelledResultsAsList = Arrays.stream(resultBody.split("\n"))
                 .map(l -> Arrays.stream(l.split("\t")).collect(Collectors.toList()))
                 .collect(Collectors.toList());
 
             for (Figure badItem : badFiguresOrTables) {
+                if (badItem == null) {
+                    continue;
+                }
+                String itemLabel = badItem instanceof Table ? TaggingLabels.TABLE_LABEL : FIGURE_LABEL;
                 // Find the index of the first layoutToken of the table in the tokenization
                 List<LayoutToken> layoutTokenItem = badItem.getLayoutTokens();
                 List<Integer> candidateIndexes = findCandidateIndex(layoutTokenItem, labelledResultsAsList,
@@ -420,7 +442,7 @@ public class FullTextParser extends AbstractParser {
                     continue;
                 }
 
-                // At this point i have more than one candidate, which can be matched if the same first
+                // At this point I have more than one candidate, which can be matched if the same first
                 // token is repeated in the sequence. The next step is to find the matching figure/table
                 // using a large sequence
 
@@ -461,6 +483,72 @@ public class FullTextParser extends AbstractParser {
         return resultBody;
     }
 
+    static String revertDiscardedTokensInMainResults(List<List<LayoutToken>> layoutTokenPieces, String resultBody, boolean strict) {
+        return revertDiscardedTokensInMainResults(layoutTokenPieces, resultBody, FIGURE_LABEL, strict);
+    }
+
+    static String revertDiscardedTokensInMainResults(List<List<LayoutToken>> layoutTokenPieces, String resultBody, String itemLabel, boolean strict) {
+        //LF: we update the resultBody sequence by reverting the tokens as <paragraph> elements
+        if (CollectionUtils.isNotEmpty(layoutTokenPieces)) {
+            List<List<String>> labelledResultsAsList = Arrays.stream(resultBody.split("\n"))
+                .map(l -> Arrays.stream(l.split("\t")).collect(Collectors.toList()))
+                .collect(Collectors.toList());
+
+            for (List<LayoutToken> tokens: layoutTokenPieces) {
+                // Find the index of the first layoutToken of the table in the tokenization
+                List<Integer> candidateIndexes = findCandidateIndex(tokens, labelledResultsAsList, itemLabel, strict);
+                if (candidateIndexes.isEmpty()) {
+                    LOGGER.info("Cannot find the candidate index for fixing the results.");
+                    continue;
+                }
+
+                // At this point I have more than one candidate, which can be matched if the same first
+                // token is repeated in the sequence. The next step is to find the matching figure/table
+                // using a large sequence
+
+                List<String> sequenceTokenItemWithoutSpaces = tokens.stream()
+                    .map(LayoutToken::getText)
+                    .map(StringUtils::strip)
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toList());
+
+                //TODO: reduce candidate indexes after matching one sequence
+                int resultIndexCandidate = consolidateResultCandidateThroughSequence(candidateIndexes, labelledResultsAsList, sequenceTokenItemWithoutSpaces);
+
+                if (resultIndexCandidate > -1) {
+                    boolean first = true;
+                    for (int i = resultIndexCandidate;i < Math.min(resultIndexCandidate + sequenceTokenItemWithoutSpaces.size(), labelledResultsAsList.size()); i++) {
+                        List<String> line = labelledResultsAsList.get(i);
+                        String label = Iterables.getLast(line);
+                        if (first) {
+                            first = false;
+                            if (!label.startsWith("I-")) {
+                                line.set(line.size() - 1, label.replace(itemLabel, "I-" + TaggingLabels.PARAGRAPH_LABEL));
+                                continue;
+                            }
+                        } else {
+                            if (label.startsWith("I-")) {
+                                break;
+                            }
+                        }
+                        line.set(line.size() - 1, label.replace(itemLabel, TaggingLabels.PARAGRAPH_LABEL));
+                    }
+                } else {
+                    LOGGER.warn("Cannot find the result index candidate.");
+                }
+            }
+
+            String updatedResultBody = labelledResultsAsList.stream()
+                .map(l -> String.join("\t", l))
+                .collect(Collectors.joining("\n"));
+
+            resultBody = updatedResultBody;
+        }
+        return resultBody;
+    }
+
+
+
     static int consolidateResultCandidateThroughSequence(List<Integer> candidateIndexes, List<List<String>> splitResult, List<String> tokensNoSpaceItem) {
         int resultIndexCandidate = -1;
         if (candidateIndexes.size() == 1){
@@ -489,7 +577,7 @@ public class FullTextParser extends AbstractParser {
      * to the first token of the figure/table
      *
      * strict = True then it will check the items related to I-<table> or I-<figure> first
-     * and then the <table> or <figure> only if there are not candidates
+     * and then the <table> or <figure> only if there are no candidates
      * strict = False is usually necessary if there are more tables than I- token, this because a figure/table could be
      * identified within the sequence initially provided by the fulltext model
      *
@@ -2162,7 +2250,7 @@ public class FullTextParser extends AbstractParser {
     /**
      * Process figures identified by the full text model
      */
-    protected List<Figure> processFigures(String rese, List<LayoutToken> layoutTokens, Document doc) {
+    protected List<Figure> processFigures(String rese, List<LayoutToken> layoutTokens) {
 
         List<Figure> results = new ArrayList<>();
 
@@ -2197,8 +2285,6 @@ public class FullTextParser extends AbstractParser {
             result.setId("" + (results.size() - 1));
         }
 
-        doc.setFigures(results);
-		doc.assignGraphicObjectsToFigures();
         return results;
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -287,7 +287,7 @@ public class FullTextParser extends AbstractParser {
 
                     if (nbDifferences > 0) {
                         // In this case we assume they are figures
-                        String updatedBodyResult = revertDiscardedTokensInMainResults(difference, bodyResults, true);
+                        String updatedBodyResult = revertDiscardedTokensInMainResults(difference, bodyResults);
                         bodyResults = updatedBodyResult;
                     }
                 }
@@ -487,11 +487,11 @@ public class FullTextParser extends AbstractParser {
         return resultBody;
     }
 
-    static String revertDiscardedTokensInMainResults(List<List<LayoutToken>> layoutTokenPieces, String resultBody, boolean strict) {
-        return revertDiscardedTokensInMainResults(layoutTokenPieces, resultBody, FIGURE_LABEL, strict);
+    static String revertDiscardedTokensInMainResults(List<List<LayoutToken>> layoutTokenPieces, String resultBody) {
+        return revertDiscardedTokensInMainResults(layoutTokenPieces, resultBody, FIGURE_LABEL);
     }
 
-    static String revertDiscardedTokensInMainResults(List<List<LayoutToken>> layoutTokenPieces, String resultBody, String itemLabel, boolean strict) {
+    static String revertDiscardedTokensInMainResults(List<List<LayoutToken>> layoutTokenPieces, String resultBody, String itemLabel) {
         //LF: we update the resultBody sequence by reverting the tokens as <paragraph> elements
         if (CollectionUtils.isNotEmpty(layoutTokenPieces)) {
             List<List<String>> labelledResultsAsList = Arrays.stream(resultBody.split("\n"))
@@ -596,13 +596,14 @@ public class FullTextParser extends AbstractParser {
     static List<Integer> findCandidateIndex(List<LayoutToken> layoutTokenItem, List<List<String>> labelledResultsAsList, String itemLabel, boolean strict) {
         LayoutToken firstLayoutTokenItem = layoutTokenItem.get(0);
 
-        List<Integer> candidateIndexes = IntStream.range(0, labelledResultsAsList.size())
-            .filter(i -> labelledResultsAsList.get(i).get(0).equals(firstLayoutTokenItem.getText())
-                && Iterables.getLast(labelledResultsAsList.get(i)).equals("I-" + itemLabel))
-            .boxed()
-            .collect(Collectors.toList());
-
-        if (candidateIndexes.isEmpty() || !strict) {
+        List<Integer> candidateIndexes = new ArrayList<>();
+        if (strict) {
+             candidateIndexes = IntStream.range(0, labelledResultsAsList.size())
+                .filter(i -> labelledResultsAsList.get(i).get(0).equals(firstLayoutTokenItem.getText())
+                    && Iterables.getLast(labelledResultsAsList.get(i)).equals("I-" + itemLabel))
+                .boxed()
+                .collect(Collectors.toList());
+        } else {
             candidateIndexes = IntStream.range(0, labelledResultsAsList.size())
             .filter(i -> labelledResultsAsList.get(i).get(0).equals(firstLayoutTokenItem.getText())
                 && (

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -316,7 +316,9 @@ public class FullTextParser extends AbstractParser {
                     .filter(f -> !f.isCompleteForTEI())
                     .collect(Collectors.toList());
 
-                LOGGER.info("Number of figures badly formatted or incomplete we identified: " + badFigures.size());
+                if (CollectionUtils.isNotEmpty(badFigures)) {
+                    LOGGER.info("Number of figures badly formatted or incomplete we identified: " + badFigures.size());
+                }
                 bodyResults = revertResultsForBadItems(badFigures, bodyResults, !(figures.size() > numberFiguresFulltextModel));
 
                 figures = figures.stream()
@@ -338,7 +340,9 @@ public class FullTextParser extends AbstractParser {
                     .filter(t -> !(t.isCompleteForTEI() && t.validateTable()))
                     .collect(Collectors.toList());
 
-                LOGGER.info("Number of tables badly formatted or incomplete we identified: " + badTables.size());
+                if (CollectionUtils.isNotEmpty(badFigures)) {
+                    LOGGER.info("Number of tables badly formatted or incomplete we identified: " + badTables.size());
+                }
                 bodyResults = revertResultsForBadItems(badTables, bodyResults, !(tables.size() > numberTablesFulltextModel));
 
                 tables = tables.stream()
@@ -438,7 +442,7 @@ public class FullTextParser extends AbstractParser {
                 List<Integer> candidateIndexes = findCandidateIndex(layoutTokenItem, labelledResultsAsList,
                     itemLabel, strict);
                 if (candidateIndexes.isEmpty()) {
-                    LOGGER.info("Cannot find the candidate index for fixing the tables.");
+                    LOGGER.info("Cannot find the candidate index for fixing the figures/tables. Tokens: " + LayoutTokensUtil.toText(layoutTokenItem));
                     continue;
                 }
 
@@ -470,7 +474,7 @@ public class FullTextParser extends AbstractParser {
                         line.set(line.size() - 1, label.replace(itemLabel, TaggingLabels.PARAGRAPH_LABEL));
                     }
                 } else {
-                    LOGGER.warn("Cannot find the result index candidate.");
+                    LOGGER.warn("Cannot find the result index candidate for fixing the figure/table. Tokens: " + LayoutTokensUtil.toText(layoutTokenItem));
                 }
             }
 
@@ -498,7 +502,7 @@ public class FullTextParser extends AbstractParser {
                 // Find the index of the first layoutToken of the table in the tokenization
                 List<Integer> candidateIndexes = findCandidateIndex(tokens, labelledResultsAsList, itemLabel, strict);
                 if (candidateIndexes.isEmpty()) {
-                    LOGGER.info("Cannot find the candidate index for fixing the results.");
+                    LOGGER.info("Cannot find the candidate index for fixing the results. Tokens: " + LayoutTokensUtil.toText(tokens));
                     continue;
                 }
 
@@ -534,7 +538,7 @@ public class FullTextParser extends AbstractParser {
                         line.set(line.size() - 1, label.replace(itemLabel, TaggingLabels.PARAGRAPH_LABEL));
                     }
                 } else {
-                    LOGGER.warn("Cannot find the result index candidate.");
+                    LOGGER.warn("Cannot find the result index candidate for fixing the results. Tokens " + LayoutTokensUtil.toText(tokens));
                 }
             }
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -442,7 +442,7 @@ public class FullTextParser extends AbstractParser {
                 List<Integer> candidateIndexes = findCandidateIndex(layoutTokenItem, labelledResultsAsList,
                     itemLabel, strict);
                 if (candidateIndexes.isEmpty()) {
-                    LOGGER.info("Cannot find the candidate index for fixing the figures/tables. Tokens: " + LayoutTokensUtil.toText(layoutTokenItem));
+                    LOGGER.warn("Cannot find the candidate index for fixing the figures/tables. Tokens: " + LayoutTokensUtil.toText(layoutTokenItem));
                     continue;
                 }
 
@@ -503,7 +503,7 @@ public class FullTextParser extends AbstractParser {
                 // False because we might have random sequences of tokens within the figures
                 List<Integer> candidateIndexes = findCandidateIndex(tokens, labelledResultsAsList, itemLabel, false);
                 if (candidateIndexes.isEmpty()) {
-                    LOGGER.info("Cannot find the candidate index for fixing the results. Tokens: " + LayoutTokensUtil.toText(tokens));
+                    LOGGER.warn("Cannot find the candidate index for fixing the results. Tokens: " + LayoutTokensUtil.toText(tokens));
                     continue;
                 }
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -500,7 +500,8 @@ public class FullTextParser extends AbstractParser {
 
             for (List<LayoutToken> tokens: layoutTokenPieces) {
                 // Find the index of the first layoutToken of the table in the tokenization
-                List<Integer> candidateIndexes = findCandidateIndex(tokens, labelledResultsAsList, itemLabel, strict);
+                // False because we might have random sequences of tokens within the figures
+                List<Integer> candidateIndexes = findCandidateIndex(tokens, labelledResultsAsList, itemLabel, false);
                 if (candidateIndexes.isEmpty()) {
                     LOGGER.info("Cannot find the candidate index for fixing the results. Tokens: " + LayoutTokensUtil.toText(tokens));
                     continue;

--- a/grobid-core/src/test/kotlin/org/grobid/core/document/DocumentTest.kt
+++ b/grobid-core/src/test/kotlin/org/grobid/core/document/DocumentTest.kt
@@ -8,6 +8,7 @@ import org.grobid.core.utilities.GrobidProperties
 import org.grobid.core.utilities.LayoutTokensUtil
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
 import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Test
@@ -92,10 +93,72 @@ class DocumentTest {
         figure.layoutTokens = tokens
         figure.captionLayoutTokens = captionLayoutTokens
 
+        val output = doc.getFigureLayoutTokens(figure)
+
+        assertThat(LayoutTokensUtil.toText(output.left), `is`("Figure 1: This is a caption."))
+        assertThat(output.right, hasSize(1))
+        assertThat(
+            LayoutTokensUtil.toText(output.right[0]),
+            `is`(LayoutTokensUtil.toText(block5.tokens))
+        )
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun testGetFigureLayoutTokens_paragraphFarFromCaptionWithBlockNotMatching_shouldRemoveParagraph() {
+        val text = "This is some garbage that comes before the figure..\n" +
+            "d\n" +
+            "d\n" +
+            "d\n" +
+            "sss\n" +
+            "Figure 1: This is a caption.\n" +
+            "d\n" +
+            "and a paragraph we want to keep or revert back into the fulltext.\n"
+
+        val tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(text)
+        val figure = Figure()
+
+        val block1 = Block()
+        block1.tokens = tokens.subList(0, 20)
+        block1.boundingBox = BoundingBox.fromPointAndDimensions(1, 10.0, 10.0, 10.0, 10.0)
+        val block2 = Block()
+        block2.tokens = tokens.subList(20, 25)
+        block2.boundingBox = BoundingBox.fromPointAndDimensions(1, 10.0, 20.0, 10.0, 10.0)
+        val block3 = Block()
+        block3.tokens = tokens.subList(25, 28)
+        block3.boundingBox = BoundingBox.fromPointAndDimensions(1, 10.0, 30.0, 10.0, 10.0)
+        val block4 = Block()
+        block4.tokens = tokens.subList(28, 41)
+        block4.boundingBox = BoundingBox.fromPointAndDimensions(1, 10.0, 50.0, 10.0, 10.0)
+        val block5 = Block()
+        val block5OriginalTokens= tokens.subList(41, 71)
+        block5.tokens = block5OriginalTokens + GrobidAnalyzer.getInstance().tokenizeWithLayoutToken("Some additional text.")
+        block5.boundingBox = BoundingBox.fromPointAndDimensions(1, 10.0, 80.0, 10.0, 10.0)
+
+        val doc = Document()
+        doc.blocks = Arrays.asList(
+            block1,
+            block2,
+            block3,
+            block4,
+            block5
+        )
+
+        figure.blockPtrs = TreeSet(listOf(0, 1, 2, 3, 4))
+
+        val captionString = "This is a caption."
+        val captionLayoutTokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(captionString)
+        figure.setCaption(StringBuilder(captionString))
+        figure.layoutTokens = tokens
+        figure.captionLayoutTokens = captionLayoutTokens
 
         val output = doc.getFigureLayoutTokens(figure)
 
         assertThat(LayoutTokensUtil.toText(output.left), `is`("Figure 1: This is a caption."))
+        assertThat(
+            LayoutTokensUtil.toText(output.right[0]),
+            `is`(LayoutTokensUtil.toText(block5OriginalTokens))
+        )
     }
 
     @Test
@@ -144,7 +207,10 @@ class DocumentTest {
 
         val output = doc.getFigureLayoutTokens(figure)
 
-        assertThat(LayoutTokensUtil.toText(output.left), `is`("Figure 1: This is a caption.\nd\nand a paragraph we want to keep or revert back into the fulltext.\n"))
+        assertThat(
+            LayoutTokensUtil.toText(output.left),
+            `is`("Figure 1: This is a caption.\nd\nand a paragraph we want to keep or revert back into the fulltext.\n")
+        )
     }
 
     companion object {

--- a/grobid-core/src/test/kotlin/org/grobid/core/document/DocumentTest.kt
+++ b/grobid-core/src/test/kotlin/org/grobid/core/document/DocumentTest.kt
@@ -95,7 +95,7 @@ class DocumentTest {
 
         val output = doc.getFigureLayoutTokens(figure)
 
-        assertThat(LayoutTokensUtil.toText(output), `is`("Figure 1: This is a caption."))
+        assertThat(LayoutTokensUtil.toText(output.left), `is`("Figure 1: This is a caption."))
     }
 
     @Test
@@ -144,7 +144,7 @@ class DocumentTest {
 
         val output = doc.getFigureLayoutTokens(figure)
 
-        assertThat(LayoutTokensUtil.toText(output), `is`("Figure 1: This is a caption.\nd\nand a paragraph we want to keep or revert back into the fulltext.\n"))
+        assertThat(LayoutTokensUtil.toText(output.left), `is`("Figure 1: This is a caption.\nd\nand a paragraph we want to keep or revert back into the fulltext.\n"))
     }
 
     companion object {

--- a/grobid-core/src/test/kotlin/org/grobid/core/engines/FullTextParserTest.kt
+++ b/grobid-core/src/test/kotlin/org/grobid/core/engines/FullTextParserTest.kt
@@ -8,8 +8,7 @@ import org.grobid.core.data.Table
 import org.grobid.core.document.Document
 import org.grobid.core.document.DocumentPiece
 import org.grobid.core.document.DocumentPointer
-import org.grobid.core.engines.label.TaggingLabels.FIGURE_LABEL
-import org.grobid.core.engines.label.TaggingLabels.TABLE_LABEL
+import org.grobid.core.engines.label.TaggingLabels.*
 import org.grobid.core.factory.GrobidFactory
 import org.grobid.core.layout.LayoutToken
 import org.grobid.core.main.LibraryLoader
@@ -401,8 +400,8 @@ class FullTextParserTest {
             "lines[0] fields",
             Arrays.asList(
                 *lines[0].split("\\s".toRegex())
-                .dropLastWhile { it.isEmpty() }
-                .toTypedArray()), `is`(Matchers.hasItem("BLOCKSTART"))
+                    .dropLastWhile { it.isEmpty() }
+                    .toTypedArray()), `is`(Matchers.hasItem("BLOCKSTART"))
         )
     }
 
@@ -478,20 +477,20 @@ class FullTextParserTest {
         val table1 = Table()
         table1.layoutTokens = tokens.subList(25, 61)
 
-        val output = FullTextParser.revertResultsForBadItems(Arrays.asList(table1), wapitiResults, TABLE_LABEL, true)
+        val output = FullTextParser.revertResultsForBadItems(listOf(table1), wapitiResults, true)
 
         val wapitiResultsAsList = convertResultsToList(output)
 
-        val tableCount = wapitiResultsAsList.stream()
+        val tablesCount = wapitiResultsAsList.stream()
             .filter { l: List<String> -> l[1] == "I-$TABLE_LABEL" }
             .count()
 
-        assertThat(tableCount, `is`(2))
+        assertThat(tablesCount, `is`(2))
     }
 
     @Test
-    fun testRevertResultsForBadItems_shouldRemoveOneFigures() {
-        var sequence = "This article solves the problem where some of our interaction are fauly. " +
+    fun testRevertResultsForBadItems_shouldLeaveOneFigures() {
+        val sequence = "This article solves the problem where some of our interaction are fauly. " +
             "a 8 9 j 92j 3 3j 9 j 9j Table 1: The reconstruction of the national anthem " +
             "We are interested in the relation between certain information and " +
             "a b b d 1 2 3 4 s 3 3 d9 Table 2: The relation between information and noise " +
@@ -499,7 +498,7 @@ class FullTextParserTest {
             "a b b d 1 2 3 4 5 6 7 Table 3: The relation between homicides and donuts eating " +
             "The relation between homicides and donuts eating is a very important one. "
 
-        var tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(sequence)
+        val tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(sequence)
 
         // These triples made in following way: label, starting index (included), ending index (excluded)
         val labels = listOf(
@@ -528,15 +527,128 @@ class FullTextParserTest {
         val badFigure2 = Figure()
         badFigure2.layoutTokens = tokens.subList(130, 171)
 
-        val output = FullTextParser.revertResultsForBadItems(Arrays.asList(badFigure1, badFigure2), wapitiResults, FIGURE_LABEL, true)
+        val output = FullTextParser.revertResultsForBadItems(listOf(badFigure1, badFigure2), wapitiResults, true)
 
         val wapitiResultsAsList = convertResultsToList(output)
 
-        val tableCount = wapitiResultsAsList.stream()
+        val figuresCount = wapitiResultsAsList.stream()
             .filter { l: List<String> -> l[1] == "I-$FIGURE_LABEL" }
             .count()
 
-        assertThat(tableCount, `is`(1))
+        val tablesCount = wapitiResultsAsList.stream()
+            .filter { l: List<String> -> l[1] == "I-$TABLE_LABEL" }
+            .count()
+
+        assertThat(figuresCount, `is`(1))
+        assertThat(tablesCount, `is`(0))
+    }
+
+    @Test
+    fun testRevertResultsForBadItems_mixedFiguresTables_shouldRemoveOneFiguresAndOneTable() {
+        val sequence = "This article solves the problem where some of our interaction are fauly. " +
+            "a 8 9 j 92j 3 3j 9 j 9j Table 1: The reconstruction of the national anthem " +
+            "We are interested in the relation between certain information and " +
+            "a b b d 1 2 3 4 s 3 3 d9 Table 2: The relation between information " +
+            "and noise the related affectionality. " +
+            "a b b d 1 2 3 4 5 6 7 Table 3: The relation between homicides and donuts eating " +
+            "The relation between homicides and donuts eating is a very important one. "
+
+        val tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(sequence)
+
+        // These triples made in following way: label, starting index (included), ending index (excluded)
+        val labels = listOf(
+            Triple.of("I-<paragraph>", 0, 1),
+            Triple.of("<paragraph>", 1, 24),
+            Triple.of("I-<figure>", 25, 26),
+            Triple.of("<figure>", 26, 61),
+            Triple.of("I-<paragraph>", 62, 63),
+            Triple.of("<paragraph>", 63, 81),
+            Triple.of("I-<table>", 82, 83),
+            Triple.of("<table>", 82, 118),
+            Triple.of("I-<paragraph>", 119, 120),
+            Triple.of("<paragraph>", 120, 129),
+            Triple.of("I-<figure>", 130, 131),
+            Triple.of("<figure>", 131, 171),
+            Triple.of("I-<paragraph>", 171, 172),
+            Triple.of("<paragraph>", 172, 195),
+        )
+
+        val features = tokens.stream().map { it.text }.collect(Collectors.toList())
+        val wapitiResults = GrobidTestUtils.getWapitiResult(features, labels, "\t")
+
+        val badTable1 = Table()
+        badTable1.layoutTokens = tokens.subList(82, 118)
+
+        val badFigure1 = Figure()
+        badFigure1.layoutTokens = tokens.subList(130, 171)
+
+        val output = FullTextParser.revertResultsForBadItems(listOf(badTable1, badFigure1), wapitiResults, true)
+
+        val wapitiResultsAsList = convertResultsToList(output)
+
+        val figuresCount = wapitiResultsAsList.stream()
+            .filter { l: List<String> -> l[1] == "I-$FIGURE_LABEL" }
+            .count()
+        val tablesCount = wapitiResultsAsList.stream()
+            .filter { l: List<String> -> l[1] == "I-$TABLE_LABEL" }
+            .count()
+
+        assertThat(figuresCount, `is`(1))
+        assertThat(tablesCount, `is`(0))
+    }
+
+    @Test
+    fun testRevertDiscardedTokensInMainResults_mixedFiguresTables_shouldRemoveOneFiguresAndOneTable() {
+        val sequence = "This article solves the problem where some of our interaction are fauly. " +
+            "a 8 9 j 92j 3 3j 9 j 9j Table 1: The reconstruction of the national anthem " +
+            "We are interested in the relation between certain information and " +
+            "a b b d 1 2 3 4 s 3 3 d9 Table 2: The relation between information " +
+            "and noise the related affectionality. " +
+            "a b b d 1 2 3 4 5 6 7 Table 3: The relation between homicides and donuts eating " +
+            "The relation between homicides and donuts eating is a very important one. "
+
+        val tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(sequence)
+
+        // These triples made in following way: label, starting index (included), ending index (excluded)
+        val labels = listOf(
+            Triple.of("I-<paragraph>", 0, 1),
+            Triple.of("<paragraph>", 1, 25),
+            Triple.of("I-<figure>", 25, 26),
+            Triple.of("<figure>", 26, 71),
+            Triple.of("I-<paragraph>", 71, 73),
+            Triple.of("<paragraph>", 73, 81),
+            Triple.of("I-<table>", 82, 83),
+            Triple.of("<table>", 83, 118),
+            Triple.of("I-<paragraph>", 119, 120),
+            Triple.of("<paragraph>", 120, 129),
+            Triple.of("I-<figure>", 130, 131),
+            Triple.of("<figure>", 131, 171),
+            Triple.of("I-<paragraph>", 171, 172),
+            Triple.of("<paragraph>", 172, 195),
+        )
+
+        val features = tokens.stream().map { it.text }.collect(Collectors.toList())
+        val wapitiResults = GrobidTestUtils.getWapitiResult(features, labels, "\t")
+
+        val discardedElements = tokens.subList(62, 71)
+
+        val output = FullTextParser.revertDiscardedTokensInMainResults(listOf(discardedElements), wapitiResults, true)
+
+        val wapitiResultsAsList = convertResultsToList(output)
+
+        val paragraphsCount = wapitiResultsAsList.stream()
+            .filter { l: List<String> -> l[1] == "I-$PARAGRAPH_LABEL" }
+            .count()
+        val figuresCount = wapitiResultsAsList.stream()
+            .filter { l: List<String> -> l[1] == "I-$FIGURE_LABEL" }
+            .count()
+        val tablesCount = wapitiResultsAsList.stream()
+            .filter { l: List<String> -> l[1] == "I-$TABLE_LABEL" }
+            .count()
+
+        assertThat(paragraphsCount, `is`(5))
+        assertThat(figuresCount, `is`(2))
+        assertThat(tablesCount, `is`(1))
     }
 
     private fun convertResultsToList(output: String): MutableList<List<String>> =

--- a/grobid-core/src/test/kotlin/org/grobid/core/engines/FullTextParserTest.kt
+++ b/grobid-core/src/test/kotlin/org/grobid/core/engines/FullTextParserTest.kt
@@ -632,7 +632,7 @@ class FullTextParserTest {
 
         val discardedElements = tokens.subList(62, 71)
 
-        val output = FullTextParser.revertDiscardedTokensInMainResults(listOf(discardedElements), wapitiResults, true)
+        val output = FullTextParser.revertDiscardedTokensInMainResults(listOf(discardedElements), wapitiResults)
 
         val wapitiResultsAsList = convertResultsToList(output)
 


### PR DESCRIPTION
There is a piece of code:

https://github.com/kermitt2/grobid/blob/92ea31edc391c56f6fd1eab61a16aaab5fda960c/grobid-core/src/main/java/org/grobid/core/document/Document.java#L1276

that decided whether blocks around a figure caption (something starting with fig, and tagged as `<figure>` is "close" enough to it (15px fixed distance) so that consider it or not as part of the figure. Before #1266, certain part of the document were discarded, however now are added as paragraphs. 

Now, this works in many cases, but it relies on the fact that the blocks distance is consistent. 

in this [article](https://doi.org/10.1038/s41587-025-02565-4), for example, the figure caption blocks are correctly recognized: 

Figure 1 is correctly assembled: 

<img width="910" alt="image" src="https://github.com/user-attachments/assets/90bfe81a-f999-4271-9cb8-a6d7ab0c0611" />

Figure 2 is not, because the blocks dimensions are too "far" (15.16px > 15px): 

<img width="892" alt="image" src="https://github.com/user-attachments/assets/40545afe-0c66-40cc-bb3f-755955d963b7" />

I did relax the rule of the 15px when the two blocks are at the same hight, but is not a solution that will cover all cases. 

any comment is welcome 😄 