### PR TITLE
Extract URLs from annotations in any part of the fulltext

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -1274,6 +1274,7 @@ public class Lexicon {
         // we calculate the token positions of all the URLs in the layout tokens
         List<Pair<OffsetPosition, String>> urlPositions = new ArrayList<>();
         for (PDFAnnotation annotation : mergedAnnotations) {
+            String destination = annotation.getDestination();
             List<LayoutToken> urlTokens = layoutTokens.stream()
                 .filter(
                     annotation::cover
@@ -1282,6 +1283,23 @@ public class Lexicon {
 
             if (urlTokens.isEmpty()) {
                 continue;
+            }
+
+            //Cleanup edges
+
+            if (Iterables.getFirst(urlTokens, new LayoutToken()).getText().endsWith("(")) {
+                urlTokens.remove(0);
+            }
+            if (Iterables.getLast(urlTokens).getText().endsWith(")")) {
+                long openedParenthesis = LayoutTokensUtil.toText(urlTokens).chars().filter(ch -> ch == '(').count();
+                long closedParenthesis = LayoutTokensUtil.toText(urlTokens).chars().filter(ch -> ch == ')').count();
+                if (openedParenthesis < closedParenthesis) {
+                    urlTokens.remove(urlTokens.size() - 1);
+                }
+            }
+
+            if (Iterables.getLast(urlTokens).getText().equals(".")) {
+                urlTokens.remove(urlTokens.size() - 1);
             }
 
             //Find the token index positions in the layoutTokens object

--- a/grobid-core/src/main/java/org/grobid/core/sax/PDFALTOAnnotationSaxHandler.java
+++ b/grobid-core/src/main/java/org/grobid/core/sax/PDFALTOAnnotationSaxHandler.java
@@ -1,20 +1,16 @@
 package org.grobid.core.sax;
 
-import org.grobid.core.layout.Block;
-import org.grobid.core.layout.Page;
-import org.grobid.core.layout.PDFAnnotation;
 import org.grobid.core.document.Document;
-import org.grobid.core.layout.LayoutToken;
-import org.grobid.core.layout.GraphicObject;
 import org.grobid.core.layout.BoundingBox;
-import org.grobid.core.utilities.TextUtilities;
-import org.grobid.core.analyzers.GrobidAnalyzer;
+import org.grobid.core.layout.PDFAnnotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.*;
-import org.xml.sax.helpers.*;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  *  SAX parser for ALTO XML representation of the annotations present on PDF files 


### PR DESCRIPTION
This PR extends the functionality already implemented to recognise URLs and provide a clean target URI, by covering the cases where the URLs are not identified by regex (here the DATAmic13 token is annotated with an URL)

<img width="773" height="289" alt="image" src="https://github.com/user-attachments/assets/1476a8d3-dd9f-490d-be69-a121ca4a9aa2" />
