### PR TITLE
Keep the original filename in the generated training file 

### DIFF
--- a/grobid-service/src/main/java/org/grobid/service/GrobidRestService.java
+++ b/grobid-service/src/main/java/org/grobid/service/GrobidRestService.java
@@ -740,12 +740,13 @@ public class GrobidRestService implements GrobidPaths {
     @POST
     public Response processAnnotatePDF(
         @FormDataParam(INPUT) InputStream inputStream,
-        @FormDataParam("name") String fileName,
+        @FormDataParam(INPUT) FormDataBodyPart inputBodyPart,
         @DefaultValue("0") @FormDataParam(CONSOLIDATE_HEADER) String consolidateHeader,
         @DefaultValue("0") @FormDataParam(CONSOLIDATE_CITATIONS) String consolidateCitations,
         @DefaultValue("0") @FormDataParam(INCLUDE_RAW_AFFILIATIONS) String includeRawAffiliations,
         @DefaultValue("0") @FormDataParam(INCLUDE_RAW_CITATIONS) String includeRawCitations,
         @FormDataParam("type") int type) throws Exception {
+        String fileName = inputBodyPart.getFormDataContentDisposition().getFileName();
         int consolHeader = validateConsolidationParam(consolidateHeader);
         int consolCitations = validateConsolidationParam(consolidateCitations);
         boolean includeRaw = validateIncludeRawParam(includeRawCitations);
@@ -860,10 +861,11 @@ public class GrobidRestService implements GrobidPaths {
     @POST
     public Response createTraining_post(
         @FormDataParam(INPUT) InputStream inputStream,
-        @FormDataParam("name") String fileName,
+        @FormDataParam(INPUT) FormDataBodyPart inputBodyPart,
         @FormDataParam(FLAVOR) String flavor
     ) {
         GrobidModels.Flavor validatedModelFlavor = validateModelFlavor(flavor);
+        String fileName = inputBodyPart.getFormDataContentDisposition().getFileName();
         return restProcessTraining.createTraining(
             inputStream, fileName, validatedModelFlavor
         );

--- a/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessTraining.java
+++ b/grobid-service/src/main/java/org/grobid/service/process/GrobidRestProcessTraining.java
@@ -1,51 +1,40 @@
 package org.grobid.service.process;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.grobid.core.GrobidModel;
+import org.grobid.core.GrobidModels;
 import org.grobid.core.engines.Engine;
-import org.grobid.core.engines.ProcessEngine;
-import org.grobid.core.engines.config.GrobidAnalysisConfig;
 import org.grobid.core.factory.GrobidPoolingFactory;
-import org.grobid.core.main.batch.GrobidMainArgs;
 import org.grobid.core.utilities.GrobidProperties;
 import org.grobid.core.utilities.IOUtilities;
 import org.grobid.core.utilities.KeyGen;
-import org.grobid.core.GrobidModels;
-import org.grobid.core.GrobidModel;
 import org.grobid.service.exceptions.GrobidServiceException;
 import org.grobid.service.util.GrobidRestUtils;
-//import org.grobid.core.engines.AbstractParser.Collection;
 import org.grobid.trainer.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.Response.Status;
-import jakarta.ws.rs.core.UriInfo;
-import jakarta.ws.rs.WebApplicationException;
-import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.StreamingOutput;
-
-import java.nio.charset.StandardCharsets;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import java.util.NoSuchElementException;
-import java.util.List;
-import java.io.*;
-import java.nio.charset.Charset;
-import java.util.concurrent.*;  
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.FileUtils;
-
-import javax.xml.bind.DatatypeConverter;
 
 
 @Singleton
@@ -75,7 +64,7 @@ public class GrobidRestProcessTraining {
      * models)
      *
      * @return a response object containing the zipped model
-     */ 
+     */
     public Response getModel(String model, String architecture) {
         LOGGER.debug(">> " + GrobidRestProcessGeneric.class.getName() + ".getModel");
         Response response = null;
@@ -102,13 +91,13 @@ public class GrobidRestProcessTraining {
 
             if (theModel == null) {
                 throw new GrobidServiceException(
-                    "The indicated model name " + model + " is invalid or unsupported.", 
+                    "The indicated model name " + model + " is invalid or unsupported.",
                     Status.BAD_REQUEST);
             } else if (theModelFile == null || !theModelFile.exists()) {
                 // model name was valid but no trained model available
                 //response = Response.status(Status.NO_CONTENT).build();
                 throw new GrobidServiceException(
-                    "The indicated model name " + model + " is valid but not trained.", 
+                    "The indicated model name " + model + " is valid but not trained.",
                     Status.BAD_REQUEST);
             } else  {
                 ByteArrayOutputStream ouputStream = new ByteArrayOutputStream();
@@ -116,7 +105,7 @@ public class GrobidRestProcessTraining {
 
                 if (architecture.toLowerCase().equals("crf")) {
                     response = Response.status(Status.OK).type("application/zip").build();
-    
+
                     out.putNextEntry(new ZipEntry("model.wapiti"));
                     byte[] buffer = new byte[1024];
                     try {
@@ -128,7 +117,7 @@ public class GrobidRestProcessTraining {
                         in.close();
                         out.closeEntry();
                     } catch (IOException e) {
-                        throw new GrobidServiceException("IO Exception when zipping model file", e, 
+                        throw new GrobidServiceException("IO Exception when zipping model file", e,
                             Status.INTERNAL_SERVER_ERROR);
                     }
                 } else {
@@ -141,7 +130,7 @@ public class GrobidRestProcessTraining {
                         byte[] buffer = new byte[1024];
                         for (final File currFile : files) {
                             if (currFile.getName().toLowerCase().endsWith(".hdf5")
-                                || currFile.getName().toLowerCase().endsWith(".json") 
+                                || currFile.getName().toLowerCase().endsWith(".json")
                                 || currFile.getName().toLowerCase().endsWith(".pkl")
                                 || currFile.getName().toLowerCase().endsWith(".txt")) {
                                 try {
@@ -155,7 +144,7 @@ public class GrobidRestProcessTraining {
                                     in.close();
                                     out.closeEntry();
                                 } catch (IOException e) {
-                                    throw new GrobidServiceException("IO Exception when zipping", e, 
+                                    throw new GrobidServiceException("IO Exception when zipping", e,
                                         Status.INTERNAL_SERVER_ERROR);
                                 }
                             }
@@ -189,15 +178,15 @@ public class GrobidRestProcessTraining {
 
 
     /**
-     * Start the training of a model based on its name and a target architecture (CRF default, BiLSTM-CRF or 
-     * BiLSMT-CRF-ELMo) and a training mode. Send back a token to the calling client to retrieve training 
+     * Start the training of a model based on its name and a target architecture (CRF default, BiLSTM-CRF or
+     * BiLSMT-CRF-ELMo) and a training mode. Send back a token to the calling client to retrieve training
      * state and eventually the evaluation metrics via the service /api/resultTraining
      *
      * @return a response object containing the token corresponding to the launched training
-     */ 
+     */
     public Response trainModel(String model, String architecture, String type, double ratio, int n, boolean incremental) {
         Response response = null;
-        
+
         try {
             // is the model name valid?
             /*if (!containsModel(model)) {
@@ -208,7 +197,7 @@ public class GrobidRestProcessTraining {
             // create a token for the training
             String token = KeyGen.getKey();
             GrobidProperties.getInstance();
-            
+
             File home = GrobidProperties.getInstance().getGrobidHomePath();
             AbstractTrainer trainer = getTrainer(model);
 
@@ -297,7 +286,7 @@ public class GrobidRestProcessTraining {
         return trainer;
     }
 
-    private static class TrainTask implements Runnable {  
+    private static class TrainTask implements Runnable {
         private AbstractTrainer trainer;
         private String type;
         private String token;
@@ -305,7 +294,7 @@ public class GrobidRestProcessTraining {
         private double ratio = 1.0;
         private boolean incremental = false;
 
-        public TrainTask(AbstractTrainer trainer, String type, String token, double ratio, int n, boolean incremental) { 
+        public TrainTask(AbstractTrainer trainer, String type, String token, double ratio, int n, boolean incremental) {
             this.trainer = trainer;
             this.type = type;
             this.token = token;
@@ -313,9 +302,9 @@ public class GrobidRestProcessTraining {
             this.n = n;
             this.incremental = incremental;
         }
-          
+
         @Override
-        public void run() { 
+        public void run() {
             try {
                 File home = GrobidProperties.getInstance().getGrobidHomePath();
                 String tokenPath = home.getAbsolutePath() + "/training-history/" + this.token;
@@ -345,7 +334,7 @@ public class GrobidRestProcessTraining {
                         break;
                     default:
                         throw new IllegalStateException("Invalid training type: " + this.type);
-                }                
+                }
                 //java.lang.System.setErr(java.lang.System.err);
 
                 // update status
@@ -358,18 +347,18 @@ public class GrobidRestProcessTraining {
             } catch(IOException e) {
                 LOGGER.error("Failed to write training results for token " + token, e);
             }
-        } 
-    } 
+        }
+    }
 
     /**
-     * Given a training token delivered by the service `modelTraining`, this service gives the possibility 
-     * of following the advancement of the training and eventually get back the associated evaluation. 
+     * Given a training token delivered by the service `modelTraining`, this service gives the possibility
+     * of following the advancement of the training and eventually get back the associated evaluation.
      * Depending on the state of the training, the service will returns:
      * - if the training is ongoing, an indication of advancement as a string
      * - it the training is completed, evaluation statistics dependeing on the selected type of training
      *
      * @return a response object containing information on the training corresponding to the token
-     */ 
+     */
     public Response resultTraining(String token) {
         Response response = null;
         try {
@@ -409,7 +398,7 @@ public class GrobidRestProcessTraining {
                 File report = new File(tokenDirectory.getAbsolutePath() + "/report.txt");
                 if (!report.exists()) {
                     throw new GrobidServiceException(
-                        "The indicated token " + token + " is not matching an existing ongoing or completed training.", 
+                        "The indicated token " + token + " is not matching an existing ongoing or completed training.",
                         Status.BAD_REQUEST);
                 } else {
                     String reportStr = FileUtils.readFileToString(report, "UTF-8");
@@ -434,7 +423,7 @@ public class GrobidRestProcessTraining {
             response = Response.status(Status.INTERNAL_SERVER_ERROR).entity(exp.getMessage()).build();
         } finally {
         }
-        
+
         return response;
     }
 
@@ -468,6 +457,23 @@ public class GrobidRestProcessTraining {
 
             Files.createDirectories(Path.of(outputPath));
             engine.createTraining(originFile, outputPath, outputPath, -1, flavor);
+
+            // Rename all the generated output files with the original filename as suffix
+            File[] outputFileList = new File(outputPath).listFiles();
+            if (ArrayUtils.isNotEmpty(outputFileList)) {
+                String[] split = outputFileList[0].getName().split(".training");
+                String trainingDataBaseName = split[0];
+                String inputFileBaseName = FilenameUtils.getBaseName(filename);
+                for (File file : outputFileList) {
+                    if (file.isFile() && file.getName().startsWith(trainingDataBaseName)) {
+                        String newFileName = file.getName().replace(trainingDataBaseName, inputFileBaseName);
+                        File newFile = new File(outputPath, newFileName);
+                        Files.move(file.toPath(), newFile.toPath());
+                    }
+                }
+            } else {
+                LOGGER.warn("No training files generated.");
+            }
 
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             ZipOutputStream out = new ZipOutputStream(outputStream);


### PR DESCRIPTION
Avoid using the temporary file name, rename temporary files with the original filename as prefix