### PR TITLE
Add configurable timeout to the consolidation requests

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/Consolidation.java
@@ -90,10 +90,11 @@ public class Consolidation {
      * Hidden constructor
      */
     private Consolidation() {
-        if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON)
+        if (GrobidProperties.getInstance().getConsolidationService() == GrobidConsolidationService.GLUTTON) {
             client = GluttonClient.getInstance();
-        else
+        } else {
             client = CrossrefClient.getInstance();
+        }
         workDeserializer = new WorkDeserializer();
         funderDeserializer = new FunderDeserializer();
     }
@@ -264,11 +265,16 @@ public class Consolidation {
                 doiQuery = false;
             }
 
-            client.pushRequest("works", arguments, workDeserializer, threadId, new CrossrefRequestListener<BiblioItem>(0) {
+            client.pushRequest(
+                "works",
+                arguments,
+                workDeserializer,
+                threadId,
+                new CrossrefRequestListener<BiblioItem>(0) {
 
                 @Override
                 public void onSuccess(List<BiblioItem> res) {
-                    if ((res != null) && (res.size() > 0) ) {
+                    if (CollectionUtils.isNotEmpty(res)) {
                         // we need here to post-check that the found item corresponds
                         // correctly to the one requested in order to avoid false positive
                         for(BiblioItem oneRes : res) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidConfig.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidConfig.java
@@ -44,6 +44,7 @@ public class GrobidConfig {
 
     public static class ConsolidationParameters {
         public String service;
+        public int timeoutSec = 60;
         public HostParameters glutton;
         public CrossrefParameters crossref;
     }

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -753,10 +753,18 @@ public class GrobidProperties {
     }
 
     /**
+     * Get the timeout in seconds for consolidation service requests.
+     * @return timeout in seconds
+     */
+    public static int getConsolidationTimeout() {
+        return grobidConfig.grobid.consolidation.timeoutSec;
+    }
+
+    /**
      * Returns if the execution context is stand alone or server.
      *
      * @return the context of execution. Return false if the property value is
-     * not readable.
+     * null or empty.
      */
     public static boolean isContextExecutionServer() {
         return contextExecutionServer;

--- a/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefClient.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefClient.java
@@ -9,9 +9,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.*;
 
-import org.apache.commons.lang3.concurrent.TimedSemaphore;
 import org.apache.http.client.ClientProtocolException;
-import org.grobid.core.utilities.crossref.CrossrefRequestListener.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,20 +17,20 @@ import org.slf4j.LoggerFactory;
  * Request pool to get data from api.crossref.org without exceeding limits
  * supporting multi-thread.
  *
- * Note: the provided interval for the query rate returned by CrossRef appeared to be note reliable, 
- * so we have to use the rate limit (X-Rate-Limit-Interval) as a global parallel query limit, without 
- * interval consideration.  
+ * Note: the provided interval for the query rate returned by CrossRef appeared to be not reliable,
+ * so we have to use the rate limit (X-Rate-Limit-Interval) as a global parallel query limit, without
+ * interval consideration.
  * See https://github.com/kermitt2/grobid/pull/725
- * 
+ *
  */
 public class CrossrefClient implements Closeable {
 	public static final Logger logger = LoggerFactory.getLogger(CrossrefClient.class);
-	
+
 	protected static volatile CrossrefClient instance;
 
 	protected volatile ExecutorService executorService;
 
-	protected int max_pool_size = 1;
+	protected int maxPoolSize = 1;
 	protected static boolean limitAuto = true;
 
 	// this list is used to maintain a list of Futures that were submitted,
@@ -60,13 +58,18 @@ public class CrossrefClient implements Closeable {
      */
     protected CrossrefClient() {
     	// note: by default timeout with newCachedThreadPool is set to 60s, which might be too much for crossref usage,
-    	// hanging grobid significantly, so we might want to use rather a custom instance of ThreadPoolExecutor and set 
-    	// the timeout sifferently
-		this.executorService = Executors.newCachedThreadPool(r -> {
-            Thread t = Executors.defaultThreadFactory().newThread(r);
-            t.setDaemon(true);
-            return t;
-        });
+    	// hanging grobid significantly, so we might want to use rather a custom instance of ThreadPoolExecutor and set
+    	// the timeout differently
+		this.executorService = new ThreadPoolExecutor(
+            0, Integer.MAX_VALUE,
+            5L, TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            r -> {
+                Thread t = Executors.defaultThreadFactory().newThread(r);
+                t.setDaemon(true);
+                return t;
+            }
+        );
 		this.futures = new HashMap<>();
 		setLimits(1, 1000);
 	}
@@ -75,12 +78,12 @@ public class CrossrefClient implements Closeable {
 		logger.debug((request != null ? request+": " : "")+message);
 		//System.out.println((request != null ? request+": " : "")+message);
 	}
-	
+
 	public void setLimits(int iterations, int interval) {
-		this.setMax_pool_size(iterations);
+		this.setMaxPoolSize(iterations);
 		// interval is not usable anymore, we need to wait termination of threads independently from any time interval
 	}
-	
+
 	public void updateLimits(int iterations, int interval) {
 		if (this.limitAuto) {
 			//printLog(null, "Updating limits... " + iterations + " / " + interval);
@@ -88,18 +91,18 @@ public class CrossrefClient implements Closeable {
 			// note: interval not used anymore
 		}
 	}
-	
+
 	/**
 	 * Push a request in pool to be executed as soon as possible, then wait a response through the listener.
 	 * API Documentation : https://github.com/CrossRef/rest-api-doc/blob/master/rest_api.md
 	 */
-	public <T extends Object> void pushRequest(CrossrefRequest<T> request, CrossrefRequestListener<T> listener, 
-		long threadId) throws URISyntaxException, ClientProtocolException, IOException {
+	public <T extends Object> void pushRequest(CrossrefRequest<T> request, CrossrefRequestListener<T> listener,
+		long threadId) {
 		if (listener != null)
 			request.addListener(listener);
 		synchronized(this) {
 			// we limit the number of active threads to the crossref api dynamic limit returned in the response header
-			while(((ThreadPoolExecutor)executorService).getActiveCount() >= this.getMax_pool_size()) {
+			while(((ThreadPoolExecutor)executorService).getActiveCount() >= this.getMaxPoolSize()) {
 				try {
 					TimeUnit.MICROSECONDS.sleep(10);
 				} catch (InterruptedException e) {
@@ -107,28 +110,27 @@ public class CrossrefClient implements Closeable {
 				}
 			}
 			Future<?> f = executorService.submit(new CrossrefRequestTask<T>(this, request));
-			List<Future<?>> localFutures = this.futures.get(Long.valueOf(threadId));
+			List<Future<?>> localFutures = this.futures.get(threadId);
 			if (localFutures == null)
-				localFutures = new ArrayList<Future<?>>();
+				localFutures = new ArrayList<>();
 			localFutures.add(f);
 			this.futures.put(threadId, localFutures);
-			logger.debug("add request to thread " + threadId +
+			logger.debug("Add request to thread " + threadId +
 					"active threads count is now " + ((ThreadPoolExecutor) executorService).getActiveCount()
 			);
-//System.out.println("add request to thread " + threadId + " / current total for the thread: " +  localFutures.size());			
 		}
 	}
-	
+
 	/**
 	 * Push a request in pool to be executed soon as possible, then wait a response through the listener.
 	 * @see <a href="https://github.com/CrossRef/rest-api-doc/blob/master/rest_api.md">Crossref API Documentation</a>
-	 * 
+	 *
 	 * @param params		query parameters, can be null, ex: ?query.title=[title]&query.author=[author]
 	 * @param deserializer	json response deserializer, ex: WorkDeserializer to convert Work to BiblioItem
 	 * @param threadId		the java identifier of the thread providing the request (e.g. via Thread.currentThread().getId())
 	 * @param listener		catch response from request
 	 */
-	public <T extends Object> void pushRequest(String model, Map<String, String> params, CrossrefDeserializer<T> deserializer, 
+	public <T extends Object> void pushRequest(String model, Map<String, String> params, CrossrefDeserializer<T> deserializer,
 			long threadId, CrossrefRequestListener<T> listener) throws URISyntaxException, ClientProtocolException, IOException {
 		CrossrefRequest<T> request = new CrossrefRequest<T>(model, params, deserializer);
 		synchronized(this) {
@@ -160,12 +162,12 @@ public class CrossrefClient implements Closeable {
 		}
 	}
 
-	public int getMax_pool_size() {
-		return max_pool_size;
+	public int getMaxPoolSize() {
+		return maxPoolSize;
 	}
 
-	public void setMax_pool_size(int max_pool_size) {
-		this.max_pool_size = max_pool_size;
+	public void setMaxPoolSize(int maxPoolSize) {
+		this.maxPoolSize = maxPoolSize;
 	}
 
 	@Override

--- a/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefRequest.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/crossref/CrossrefRequest.java
@@ -85,16 +85,21 @@ public class CrossrefRequest<T extends Object> extends Observable {
 	public void execute() {
 		if (params == null) {
             // this should not happen
-            CrossrefRequestListener.Response<T> message = new CrossrefRequestListener.Response<T>();
+            CrossrefRequestListener.Response<T> message = new CrossrefRequestListener.Response<>();
             message.setException(new Exception("Empty list of parameter, cannot build request to the consolidation service"), this.toString());
             notifyListeners(message);
             return;
         }
 
         CloseableHttpClient httpclient = null;
+        int timeout = GrobidProperties.getConsolidationTimeout() * 1000; // Convert to milliseconds
         RequestConfig requestConfig = RequestConfig.custom()
-                                .setCookieSpec(CookieSpecs.STANDARD)
-                                .build();
+                .setCookieSpec(CookieSpecs.STANDARD)
+                .setConnectTimeout(timeout)
+                .setSocketTimeout(timeout)
+                .setConnectionRequestTimeout(timeout)
+                .build();
+
         if (GrobidProperties.getProxyHost() != null) {
             HttpHost proxy = new HttpHost(GrobidProperties.getProxyHost(), GrobidProperties.getProxyPort());
             DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
@@ -145,9 +150,9 @@ public class CrossrefRequest<T extends Object> extends Observable {
 
             if (GrobidProperties.getCrossrefMailto() != null) {
             	httpget.setHeader("User-Agent", 
-            		"GROBID/0.6.1 (https://github.com/kermitt2/grobid; mailto:" + GrobidProperties.getCrossrefMailto() + ")");
+            		"GROBID/0.8.2 (https://github.com/kermitt2/grobid; mailto:" + GrobidProperties.getCrossrefMailto() + ")");
 			} else {
-				httpget.setHeader("User-Agent", "GROBID/0.6.1 (https://github.com/kermitt2/grobid)");
+				httpget.setHeader("User-Agent", "GROBID/0.8.2 (https://github.com/kermitt2/grobid)");
 			}
             
 			// set the authorization token for the Metadata Plus service if available

--- a/grobid-core/src/main/java/org/grobid/core/utilities/glutton/GluttonRequest.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/glutton/GluttonRequest.java
@@ -1,39 +1,25 @@
 package org.grobid.core.utilities.glutton;
 
-import org.grobid.core.utilities.GrobidProperties;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Observable;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.http.Header;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.client.ClientProtocolException;
+import org.apache.http.HttpHost;
 import org.apache.http.client.ResponseHandler;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.apache.http.util.EntityUtils;
-import org.apache.http.HttpHost;
-import org.apache.http.conn.params.*;
-import org.apache.http.impl.conn.*;
-
+import org.grobid.core.exceptions.GrobidResourceException;
+import org.grobid.core.utilities.GrobidProperties;
+import org.grobid.core.utilities.crossref.CrossrefDeserializer;
 import org.grobid.core.utilities.crossref.CrossrefRequestListener;
 import org.grobid.core.utilities.crossref.CrossrefRequestListener.Response;
-import org.grobid.core.utilities.crossref.CrossrefDeserializer;
-import org.grobid.core.utilities.crossref.CrossrefRequest;
-import org.grobid.core.exceptions.GrobidResourceException;
 
-import org.apache.commons.io.IOUtils;
-import java.net.URL;
-import java.io.*;
+import java.io.IOException;
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Glutton request
@@ -91,14 +77,26 @@ public class GluttonRequest<T extends Object> extends Observable {
             return;
         }
         CloseableHttpClient httpclient = null;
+        
+        // Get the configured timeout in milliseconds
+        int timeout = GrobidProperties.getConsolidationTimeout() * 1000;
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setConnectTimeout(timeout)
+            .setSocketTimeout(timeout)
+            .setConnectionRequestTimeout(timeout)
+            .build();
+            
         if (GrobidProperties.getProxyHost() != null) {
             HttpHost proxy = new HttpHost(GrobidProperties.getProxyHost(), GrobidProperties.getProxyPort());
             DefaultProxyRoutePlanner routePlanner = new DefaultProxyRoutePlanner(proxy);
             httpclient = HttpClients.custom()
                 .setRoutePlanner(routePlanner)
+                .setDefaultRequestConfig(requestConfig)
                 .build();
         } else {
-            httpclient = HttpClients.createDefault();   
+            httpclient = HttpClients.custom()
+                .setDefaultRequestConfig(requestConfig)
+                .build();   
         }
 
         try {

--- a/grobid-home/config/grobid.yaml
+++ b/grobid-home/config/grobid.yaml
@@ -27,6 +27,11 @@ grobid:
     # "glutton" for https://github.com/kermitt2/biblio-glutton
     service: "crossref"
     #service: "glutton"
+    timeoutSec: 60
+    # timeout for the REST API call, reduce it if you want to reduce
+    # the waiting time for the Grobid service.
+    # NOTE: setting a low timeout and then hammer CrossRef will get you banned,
+    #   so be careful and polite with this setting!
     glutton:
       #url: "https://cloud.science-miner.com/glutton"
       url: "http://localhost:8080" 
@@ -57,7 +62,7 @@ grobid:
   
   # maximum concurrency allowed to GROBID server for processing parallel requests - change it according to your CPU/GPU capacities
   # for a production server running only GROBID, set the value slightly above the available number of threads of the server
-  # to get best performance and security
+  # to get the best performance and security
   concurrency: 10
   # when the pool is full, for queries waiting for the availability of a Grobid engine, this is the maximum time wait to try 
   # to get an engine (in seconds) - normally never change it


### PR DESCRIPTION
This PR adds a way to configure the timeout (by default 60 seconds, if not mistaken) for the consolidation. 

