### PR TITLE
Fix figure/tables/equations id

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/document/Document.java
+++ b/grobid-core/src/main/java/org/grobid/core/document/Document.java
@@ -146,11 +146,15 @@ public class Document implements Serializable {
     protected boolean titleMatchNum = false; // true if the section titles of the document are numbered
 
     protected transient List<Figure> figures;
+    protected transient List<Figure> annexFigures;
     protected transient Predicate<GraphicObject> validGraphicObjectPredicate;
     protected int m;
 
     protected transient List<Table> tables;
+
+    protected transient List<Table> annexTables;
     protected transient List<Equation> equations;
+    protected transient List<Equation> annexEquations;
 
     // the analyzer/tokenizer used for processing this document
     protected transient Analyzer analyzer = GrobidAnalyzer.getInstance();
@@ -1674,5 +1678,29 @@ public class Document implements Serializable {
             return documentSource.getMD5();
         else
             return null;
+    }
+
+    public List<Table> getAnnexTables() {
+        return annexTables;
+    }
+
+    public void setAnnexTables(List<Table> annexTables) {
+        this.annexTables = annexTables;
+    }
+
+    public List<Equation> getAnnexEquations() {
+        return annexEquations;
+    }
+
+    public void setAnnexEquations(List<Equation> annexEquations) {
+        this.annexEquations = annexEquations;
+    }
+
+    public List<Figure> getAnnexFigures() {
+        return annexFigures;
+    }
+
+    public void setAnnexFigures(List<Figure> annexFigures) {
+        this.annexFigures = annexFigures;
     }
 }

--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -302,6 +302,8 @@ public class FullTextParser extends AbstractParser {
                     .peek(f -> f.setId(String.valueOf(figureIndex.getAndIncrement())))
                     .collect(Collectors.toList());
 
+                doc.setFigures(bodyFigures);
+
                 // Tables
                 bodyTables = processTables(bodyResults, bodyTokenization.getTokenization(), doc);
 
@@ -323,9 +325,11 @@ public class FullTextParser extends AbstractParser {
                     .collect(Collectors.toList());
 
                 postProcessTableCaptions(bodyTables, doc);
+                doc.setTables(bodyTables);
 
                 // Processing equations
-                bodyEquations = processEquations(bodyResults, bodyTokenization.getTokenization(), doc);
+                bodyEquations = processEquations(bodyResults, bodyTokenization.getTokenization());
+                doc.setEquations(bodyEquations);
             } else {
                 LOGGER.debug("Fulltext model: The featured body is empty");
             }
@@ -368,6 +372,7 @@ public class FullTextParser extends AbstractParser {
                     .collect(Collectors.toList());
                 postProcessFigureCaptions(annexFigures, doc);
 
+                doc.setAnnexFigures(annexFigures);
 
                 annexTables = processTables(annexResults, annexTokenization, doc, CollectionUtils.size(bodyTables));
 
@@ -393,13 +398,14 @@ public class FullTextParser extends AbstractParser {
                     .collect(Collectors.toList());
 
                 postProcessTableCaptions(annexTables, doc);
+                doc.setAnnexTables(annexTables);
 
                 annexEquations = processEquations(
                     annexResults,
                     annexTokenization,
-                    doc,
                     CollectionUtils.size(bodyEquations)
                 );
+                doc.setAnnexEquations(annexEquations);
             }
 
             // post-process reference and footnote callout to keep them consistent (e.g. for example avoid that a footnote
@@ -2715,14 +2721,13 @@ public class FullTextParser extends AbstractParser {
     /**
      * Process equations identified by the full text model
      */
-    protected List<Equation> processEquations(String rese, List<LayoutToken> layoutTokens, Document doc) {
-        return processEquations(rese, layoutTokens, doc, 0);
+    protected List<Equation> processEquations(String rese, List<LayoutToken> layoutTokens) {
+        return processEquations(rese, layoutTokens, 0);
     }
 
     protected List<Equation> processEquations(
         String rese,
         List<LayoutToken> tokenizations,
-        Document doc,
         int startEquationID
     ) {
         List<Equation> results = new ArrayList<>();
@@ -2784,8 +2789,6 @@ public class FullTextParser extends AbstractParser {
         results = results.stream()
                 .peek(e -> e.setId(String.valueOf(equationsIndex.getAndIncrement())))
                 .collect(Collectors.toList());
-
-        doc.setEquations(results);
 
         return results;
     }


### PR DESCRIPTION
This PR should fix duplicated xml:id. After removing bad figures/tables we regenerate the ids and pass the correct starting id number to the annex figure/table/formula extraction. 