### PR TITLE
Avoid IndexOutOfBoundException in ORCID search by annotation

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/BiblioItem.java
@@ -1333,7 +1333,7 @@ public class BiblioItem {
 
     public void addKeyword(String k) {
         if (keywords == null)
-            keywords = new ArrayList<Keyword>();
+            keywords = new ArrayList<>();
 		String theKey = cleanKeywords(k);
 		if (theKey.toLowerCase().contains("introduction")) {
 			// if the keyword contains introduction, this is normally a segmentation error

--- a/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
@@ -139,10 +139,15 @@ public class AuthorParser {
                                         Matcher orcidMatcher = TextUtilities.ORCIDPattern.matcher(pdfAnnotation.getDestination());
                                         if (orcidMatcher.find()) {
                                             // !! here we consider the annot is at the tail or end of the names
-                                            //LF: sometimes there is no token at the end of the name, and the annotation covers all the name.
-                                            String newToken = authorsToken.getText().substring(0, authorsToken.getText().length() - charsCovered);
-                                            if (StringUtils.isNotBlank(newToken)) {
-                                                authorsToken.setText(newToken);
+
+                                            // LF: sometimes there is no token at the end of the name, and the annotation covers all the name
+                                            // Add boundary check to prevent StringIndexOutOfBoundsException
+                                            int textLength = authorsToken.getText().length();
+                                            if (charsCovered > 0 && charsCovered < textLength) {
+                                                String newToken = authorsToken.getText().substring(0, textLength - charsCovered);
+                                                if (StringUtils.isNotBlank(newToken)) {
+                                                    authorsToken.setText(newToken);
+                                                }
                                             }
                                             aut.setORCID(orcidMatcher.group(1) + "-"
                                                 + orcidMatcher.group(2) + "-" + orcidMatcher.group(3)+ "-" + orcidMatcher.group(4));

--- a/grobid-core/src/test/java/org/grobid/core/test/TestNameParser.java
+++ b/grobid-core/src/test/java/org/grobid/core/test/TestNameParser.java
@@ -5,10 +5,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.grobid.core.data.Person;
 import org.grobid.core.factory.GrobidFactory;
+import org.grobid.core.layout.BoundingBox;
+import org.grobid.core.layout.LayoutToken;
+import org.grobid.core.layout.PDFAnnotation;
 import org.junit.AfterClass;
 import org.junit.Test;
 
@@ -89,5 +93,76 @@ public class TestNameParser extends EngineTest{
 			}
 		}
 	}
-	
+
+	@Test
+	public void testORCIDExtractionEdgeCase() throws Exception {
+		// This test simulates the edge case that would cause StringIndexOutOfBoundsException
+		// in ORCID extraction when charsCovered > authorsToken.getText().length()
+
+		// We need to create a scenario where the calculation:
+		// int charsCovered = (int) ((intersectBox.getWidth() / pixPerChar) + 0.5);
+		// results in a value larger than the token text length
+
+		String authorText = "John Smith"; // 10 characters
+
+		// Create LayoutTokens manually to control the width parameter
+		List<org.grobid.core.layout.LayoutToken> tokens = new java.util.ArrayList<>();
+
+		// Create a token with very small width to make pixPerChar very small
+		LayoutToken smallWidthToken = new org.grobid.core.layout.LayoutToken();
+		smallWidthToken.setText(authorText);
+		smallWidthToken.setWidth(1.0); // Very small width: 1.0 pixels for 10 chars = 0.1 pixPerChar
+
+		tokens.add(smallWidthToken);
+
+		// Create a mock PDF annotation that would overlap significantly
+		org.grobid.core.layout.PDFAnnotation mockAnnotation = new PDFAnnotation();
+		mockAnnotation.setDestination("https://orcid.org/1234-5678-9012-3456");
+
+		// Create a bounding box that covers more area than the token itself
+		// This will result in a large intersectBox.getWidth()
+		org.grobid.core.layout.BoundingBox largeBoundingBox = BoundingBox.fromPointAndDimensions(
+            1, 0.0, 0.0, 100.0, 20.0 // Much larger than the token's 1.0 width
+		);
+		mockAnnotation.setBoundingBoxes(List.of(largeBoundingBox));
+
+		// Set the token's bounding box to be much smaller
+		org.grobid.core.layout.BoundingBox tokenBoundingBox = BoundingBox.fromPointAndDimensions(
+            1, 0.0, 0.0, 1.0, 10.0 // Small box: 1.0 x 10.0
+        );
+		smallWidthToken.setX(tokenBoundingBox.getX());
+        smallWidthToken.setY(tokenBoundingBox.getY());
+        smallWidthToken.setWidth(tokenBoundingBox.getWidth());
+        smallWidthToken.setHeight(tokenBoundingBox.getHeight());
+        smallWidthToken.setPage(1);
+
+		List<org.grobid.core.layout.PDFAnnotation> annotations = new java.util.ArrayList<>();
+		annotations.add(mockAnnotation);
+
+		// Before the fix, this would cause:
+		// pixPerChar = 1.0 / 10 = 0.1
+		// charsCovered = (100.0 / 0.1 + 0.5) = 1000.5 -> 1000 chars
+		// substring(0, 10 - 1000) = substring(0, -990) -> StringIndexOutOfBoundsException
+
+		// After the fix, the boundary check should prevent the exception
+		try {
+			// This should not throw StringIndexOutOfBoundsException after the fix
+			List<Person> result = engine.getParsers().getAuthorParser().processingHeaderWithLayoutTokens(tokens, annotations);
+
+			// The test passes if no exception is thrown
+			assertNotNull("Processing should complete without exception", result);
+
+			// Additionally, verify that ORCID was extracted correctly despite the edge case
+			if (result != null && !result.isEmpty()) {
+				Person author = result.get(0);
+				// The ORCID should be extracted if the annotation processing worked
+				// Note: This depends on the exact ORCID extraction logic working correctly
+			}
+
+		} catch (StringIndexOutOfBoundsException e) {
+			// If this exception is thrown, it means the bug is not fixed
+			throw new AssertionError("StringIndexOutOfBoundsException should have been prevented by boundary check", e);
+		}
+	}
+
 }


### PR DESCRIPTION
Add boundary check for matching ORCID to prevent StringIndexOutOfBoundsException