### PR TITLE
Fix: AbstractTrainer.train() ignores instance-level Wapiti parameter overrides

### DIFF
--- a/grobid-trainer/src/main/java/org/grobid/trainer/AbstractTrainer.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/AbstractTrainer.java
@@ -89,9 +89,9 @@ public abstract class AbstractTrainer implements Trainer {
         createCRFPPData(getCorpusPath(), dataPath);
         GenericTrainer trainer = TrainerFactory.getTrainer(model);
 
-        trainer.setEpsilon(GrobidProperties.getEpsilon(model));
-        trainer.setWindow(GrobidProperties.getWindow(model));
-        trainer.setNbMaxIterations(GrobidProperties.getNbMaxIterations(model));
+        trainer.setEpsilon(epsilon != 0.0 ? epsilon : GrobidProperties.getEpsilon(model));
+        trainer.setWindow(window != 0 ? window : GrobidProperties.getWindow(model));
+        trainer.setNbMaxIterations(nbMaxIterations != 0 ? nbMaxIterations : GrobidProperties.getNbMaxIterations(model));
 
         File dirModelPath = new File(GrobidProperties.getModelPath(model).getAbsolutePath()).getParentFile();
         if (!dirModelPath.exists()) {


### PR DESCRIPTION
## Problem

`AbstractTrainer.train()` (mode 0 — train only) always reads `epsilon`, `window`, and `nbMaxIterations` directly from `GrobidProperties` (i.e. `grobid.yaml`), silently ignoring any values previously set on the trainer instance via `setParams()`.

Modes 2 (`splitTrainEvaluate`) and 3 (`nFoldEvaluate`) already honour the instance fields as overrides:

```java
if (epsilon != 0.0)
    trainer.setEpsilon(epsilon);
if (window != 0)
    trainer.setWindow(window);
if (nbMaxIterations != 0)
    trainer.setNbMaxIterations(nbMaxIterations);
```

But `train()` (mode 0) does not:

```java
// before — instance overrides silently dropped
trainer.setEpsilon(GrobidProperties.getEpsilon(model));
trainer.setWindow(GrobidProperties.getWindow(model));
trainer.setNbMaxIterations(GrobidProperties.getNbMaxIterations(model));
```

## Fix

Apply the same override pattern to mode 0:

```java
trainer.setEpsilon(epsilon != 0.0 ? epsilon : GrobidProperties.getEpsilon(model));
trainer.setWindow(window != 0 ? window : GrobidProperties.getWindow(model));
trainer.setNbMaxIterations(nbMaxIterations != 0 ? nbMaxIterations : GrobidProperties.getNbMaxIterations(model));
```

Fully backwards compatible: the instance fields default to `0` / `0.0`, so when `setParams()` has not been called the config values are used exactly as before.

## Use case

This enables callers that construct a trainer programmatically to supply runtime parameters (e.g. a looser `epsilon` for fast iteration during training-data development) without modifying `grobid.yaml`. It also makes mode 0 consistent with modes 2 and 3.
