### PR TITLE
Refactor Lexicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+- Lexicon: introduced `Lexicon.builder()` as the canonical entry point with explicit gazetteer opt-in (`.withDefaults()`, `.withJournals()`, `.withFunders()`, `.withOrganisations()`, etc.). `withDefaults()` reproduces only the original constructor's eager set (wordforms, people, countries); every other gazetteer is an explicit opt-in. `Lexicon.getInstance()` is now `@Deprecated` but still works — internally enables every gazetteer that was previously available via lazy-init. Lookup methods now throw `IllegalStateException` if their gazetteer wasn't requested — opt in through the Builder.
+- Lexicon: added 4 missing ISO 3166-1 country codes (BQ, CW, SS, SX) and migrated AN (Netherlands Antilles) to its ISO 3166-3 transitional form ANHH.
+
 ## [0.9.0] - 2026-04-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
-- Lexicon: introduced `Lexicon.builder()` as the canonical entry point with explicit gazetteer opt-in (`.withDefaults()`, `.withJournals()`, `.withFunders()`, `.withOrganisations()`, etc.). `withDefaults()` reproduces only the original constructor's eager set (wordforms, people, countries); every other gazetteer is an explicit opt-in. `Lexicon.getInstance()` is now `@Deprecated` but still works — internally enables every gazetteer that was previously available via lazy-init. Lookup methods now throw `IllegalStateException` if their gazetteer wasn't requested — opt in through the Builder.
+- Lexicon: introduced `Lexicon.builder()` to optionally pre-load chosen gazetteers *eagerly* (`.withDefaults()`, `.withJournals()`, `.withFunders()`, `.withOrganisations()`, etc.). Loading stays **lazy by default**: any gazetteer not named in the builder loads transparently on first lookup, so a `Lexicon` from any entry point is always fully functional and never throws for a missing gazetteer — `withX()` only controls *when* a gazetteer loads, not whether a lookup succeeds. `withDefaults()` eagerly loads the original constructor's set (wordforms, people, countries). `Lexicon.getInstance()` is now `@Deprecated` (prefer the builder) but its behavior is unchanged: eager wordforms/people/countries, everything else lazy.
 - Lexicon: added 4 missing ISO 3166-1 country codes (BQ, CW, SS, SX) and migrated AN (Netherlands Antilles) to its ISO 3166-3 transitional form ANHH.
 
 ## [0.9.0] - 2026-04-07

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -56,11 +56,11 @@ public class Lexicon {
     private FastMatcher publisherPattern = null;
     private FastMatcher journalPattern = null;
     private FastMatcher cityPattern = null;
-    // private FastMatcher organisationPattern = null;
+    private FastMatcher organisationPattern = null;
     private FastMatcher researchInfrastructurePattern = null;
     private FastMatcher locationPattern = null;
     private FastMatcher countryPattern = null;
-    // private FastMatcher orgFormPattern = null;
+    private FastMatcher orgFormPattern = null;
     private FastMatcher collaborationPattern = null;
     private FastMatcher funderPattern = null;
     private FastMatcher personTitlePattern = null;
@@ -84,6 +84,67 @@ public class Lexicon {
         LOGGER.debug("Get new instance of Lexicon");
         GrobidProperties.getInstance();
         instance = new Lexicon();
+    }
+
+    /**
+     * Returns a builder for opting into optional gazetteers on top of the singleton's
+     * defaults. The default {@link #getInstance()} eagerly loads wordforms, person names,
+     * and country codes; other gazetteers (journals, locations, person titles, funders, etc.)
+     * are loaded lazily on first lookup. Some gazetteers — currently <i>organisations</i>
+     * and <i>organisation forms</i> — are off by default; the builder is the explicit way
+     * to enable them.
+     *
+     * <pre>
+     * Lexicon lex = Lexicon.builder()
+     *         .withOrganisations()
+     *         .build();
+     * </pre>
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent configurator for {@link Lexicon}. Each {@code withX()} call enables an
+     * optional gazetteer. The terminal {@link #build()} call returns the singleton
+     * instance after triggering the requested loaders. Calls are idempotent — building
+     * twice with the same flags only loads each gazetteer once.
+     */
+    public static class Builder {
+        private boolean organisations = false;
+        private boolean orgForms = false;
+
+        /**
+         * Enables the organisation gazetteer (Wikipedia orgs + government agencies +
+         * known corporations + venture-funded companies). ~133K entries.
+         */
+        public Builder withOrganisations() {
+            this.organisations = true;
+            return this;
+        }
+
+        /**
+         * Enables the organisation-form gazetteer (Inc., Ltd., Corp., GmbH, etc.).
+         */
+        public Builder withOrgForms() {
+            this.orgForms = true;
+            return this;
+        }
+
+        /**
+         * Returns the {@link Lexicon} singleton, ensuring every requested gazetteer
+         * has been loaded. Already-loaded gazetteers are not reloaded.
+         */
+        public Lexicon build() {
+            Lexicon lex = Lexicon.getInstance();
+            if (organisations && lex.organisationPattern == null) {
+                lex.initOrganisations();
+            }
+            if (orgForms && lex.orgFormPattern == null) {
+                lex.initOrgForms();
+            }
+            return lex;
+        }
     }
 
     /**
@@ -186,10 +247,10 @@ public class Lexicon {
     }
 
     private void initDictionary() {
-        LOGGER.info("Initiating dictionary");
+        LOGGER.debug("Initiating dictionary");
         dictionary_en = new HashSet<>();
         dictionary_de = new HashSet<>();
-        LOGGER.info("End of Initialization of dictionary");
+        LOGGER.debug("End of Initialization of dictionary");
     }
 
     public final void addDictionary(String path, String lang) {
@@ -258,18 +319,18 @@ public class Lexicon {
     }
 
     private void initNames() {
-        LOGGER.info("Initiating names");
-        firstNames = new HashSet<String>();
-        lastNames = new HashSet<String>();
-        LOGGER.info("End of initialization of names");
+        LOGGER.debug("Initiating names");
+        firstNames = new HashSet<>();
+        lastNames = new HashSet<>();
+        LOGGER.debug("End of initialization of names");
     }
 
     private void initCountryCodes() {
-        LOGGER.info("Initiating country codes");
+        LOGGER.debug("Initiating country codes");
         countryCodes = new HashMap<String, String>();
         countries = new HashSet<String>();
         countryPattern = new FastMatcher();
-        LOGGER.info("End of initialization of country codes");
+        LOGGER.debug("End of initialization of country codes");
     }
 
     private void addCountryCodes(String path) {
@@ -311,7 +372,7 @@ public class Lexicon {
     }
 
     public void initCountryPatterns() {
-        if (countries == null || countries.size() == 0) {
+        if (countries == null || countries.isEmpty()) {
             // it should never be the case
             addCountryCodes(
                     GrobidProperties.getGrobidHomePath()
@@ -520,47 +581,54 @@ public class Lexicon {
         }
     }
 
-    // Disabled: the organisation/org-form gazetteers are loaded into RAM but
-    // no parser or feature vector queries them today. Commented out (not
-    // deleted) so the matchers can be re-enabled when the affiliation/header
-    // feature pipelines are extended to use them. Lexicon files preserved.
-    // public void initOrganisations() {
-    //     try {
-    //         organisationPattern = new FastMatcher(
-    //                 new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/WikiOrganizations.lst"));
-    //         organisationPattern.loadTerms(
-    //                 new File(GrobidProperties.getGrobidHomePath()
-    //                         +
-    //                         "/lexicon/organisations/government.government_agency"));
-    //         organisationPattern.loadTerms(
-    //                 new File(GrobidProperties.getGrobidHomePath()
-    //                         +
-    //                         "/lexicon/organisations/known_corporations.lst"));
-    //         organisationPattern.loadTerms(
-    //                 new File(GrobidProperties.getGrobidHomePath()
-    //                         +
-    //                         "/lexicon/organisations/venture_capital.venture_funded_company"));
-    //     } catch (PatternSyntaxException e) {
-    //         throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
-    //     } catch (IOException e) {
-    //         throw new GrobidResourceException("Cannot add term to matcher, because the lexicon resource file "
-    //                 +
-    //                 "does not exist or cannot be read.", e);
-    //     } catch (Exception e) {
-    //         throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
-    //     }
-    // }
+    /**
+     * Loads the organisation gazetteer (Wikipedia organisations, government agencies,
+     * known corporations, venture-funded companies). Not loaded by the default
+     * {@link #getInstance()}; use {@link Lexicon#builder()} with {@code .withOrganisations()}
+     * to enable, or call this method directly.
+     */
+    public void initOrganisations() {
+        try {
+            organisationPattern = new FastMatcher(
+                    new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/WikiOrganizations.lst"));
+            organisationPattern.loadTerms(
+                    new File(GrobidProperties.getGrobidHomePath()
+                            +
+                            "/lexicon/organisations/government.government_agency"));
+            organisationPattern.loadTerms(
+                    new File(GrobidProperties.getGrobidHomePath()
+                            +
+                            "/lexicon/organisations/known_corporations.lst"));
+            organisationPattern.loadTerms(
+                    new File(GrobidProperties.getGrobidHomePath()
+                            +
+                            "/lexicon/organisations/venture_capital.venture_funded_company"));
+        } catch (PatternSyntaxException e) {
+            throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
+        } catch (IOException e) {
+            throw new GrobidResourceException("Cannot add term to matcher, because the lexicon resource file "
+                    +
+                    "does not exist or cannot be read.", e);
+        } catch (Exception e) {
+            throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
+        }
+    }
 
-    // public void initOrgForms() {
-    //     try {
-    //         orgFormPattern = new FastMatcher(
-    //                 new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/orgClosings.txt"));
-    //     } catch (PatternSyntaxException e) {
-    //         throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
-    //     } catch (Exception e) {
-    //         throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
-    //     }
-    // }
+    /**
+     * Loads the organisation-form gazetteer (org closings like "Inc.", "Ltd."). Not loaded
+     * by the default {@link #getInstance()}; use {@link Lexicon#builder()} with
+     * {@code .withOrgForms()} to enable.
+     */
+    public void initOrgForms() {
+        try {
+            orgFormPattern = new FastMatcher(
+                    new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/orgClosings.txt"));
+        } catch (PatternSyntaxException e) {
+            throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
+        } catch (Exception e) {
+            throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
+        }
+    }
 
     public void initLocations() {
         try {
@@ -705,19 +773,20 @@ public class Lexicon {
         return lastNames.contains(s);
     }
 
-    /**
-     * Indicate if we have a punctuation
-     */
-    public boolean isPunctuation(String s) {
-        if (s.length() != 1)
-            return false;
-        else {
-            char c = s.charAt(0);
-            if ((!Character.isLetterOrDigit(c)) & !(c == '-'))
-                return true;
-        }
-        return false;
-    }
+    // Disabled: no callers in production or tests.
+    // /**
+    //  * Indicate if we have a punctuation
+    //  */
+    // public boolean isPunctuation(String s) {
+    //     if (s.length() != 1)
+    //         return false;
+    //     else {
+    //         char c = s.charAt(0);
+    //         if ((!Character.isLetterOrDigit(c)) & !(c == '-'))
+    //             return true;
+    //     }
+    //     return false;
+    // }
 
     public List<OrganizationRecord> getOrganizationNamingInfo(String name) {
         if (researchOrganizations == null)
@@ -725,53 +794,54 @@ public class Lexicon {
         return researchOrganizations.get(name.toLowerCase());
     }
 
-    /**
-     * Map the language codes used by the language identifier component to the normal
-     * language name.
-     * <p>
-     * Note: due to an older bug, kr is currently map to Korean too - this should
-     * disappear at some point in the future after retraining of models
-     *
-     * @param code the language to be mapped
-     */
-    public String mapLanguageCode(String code) {
-        if (code == null)
-            return "";
-        else if (code.length() == 0)
-            return "";
-        else if (code.equals(Language.EN))
-            return "English";
-        else if (code.equals(Language.FR))
-            return "French";
-        else if (code.equals(Language.DE))
-            return "German";
-        else if (code.equals("cat"))
-            return "Catalan";
-        else if (code.equals("dk"))
-            return "Danish";
-        else if (code.equals("ee"))
-            return "Estonian";
-        else if (code.equals("fi"))
-            return "Finish";
-        else if (code.equals("it"))
-            return "Italian";
-        else if (code.equals("jp"))
-            return "Japanese";
-        else if (code.equals("kr") || code.equals("ko"))
-            return "Korean";
-        else if (code.equals("nl"))
-            return "Deutch";
-        else if (code.equals("no"))
-            return "Norvegian";
-        else if (code.equals("se"))
-            return "Swedish";
-        else if (code.equals("sorb"))
-            return "Sorbian";
-        else if (code.equals("tr"))
-            return "Turkish";
-        else
-            return "";
-    }
+    // Disabled: no callers in production or tests.
+    // /**
+    //  * Map the language codes used by the language identifier component to the normal
+    //  * language name.
+    //  * <p>
+    //  * Note: due to an older bug, kr is currently map to Korean too - this should
+    //  * disappear at some point in the future after retraining of models
+    //  *
+    //  * @param code the language to be mapped
+    //  */
+    // public String mapLanguageCode(String code) {
+    //     if (code == null)
+    //         return "";
+    //     else if (code.length() == 0)
+    //         return "";
+    //     else if (code.equals(Language.EN))
+    //         return "English";
+    //     else if (code.equals(Language.FR))
+    //         return "French";
+    //     else if (code.equals(Language.DE))
+    //         return "German";
+    //     else if (code.equals("cat"))
+    //         return "Catalan";
+    //     else if (code.equals("dk"))
+    //         return "Danish";
+    //     else if (code.equals("ee"))
+    //         return "Estonian";
+    //     else if (code.equals("fi"))
+    //         return "Finish";
+    //     else if (code.equals("it"))
+    //         return "Italian";
+    //     else if (code.equals("jp"))
+    //         return "Japanese";
+    //     else if (code.equals("kr") || code.equals("ko"))
+    //         return "Korean";
+    //     else if (code.equals("nl"))
+    //         return "Deutch";
+    //     else if (code.equals("no"))
+    //         return "Norvegian";
+    //     else if (code.equals("se"))
+    //         return "Swedish";
+    //     else if (code.equals("sorb"))
+    //         return "Sorbian";
+    //     else if (code.equals("tr"))
+    //         return "Turkish";
+    //     else
+    //         return "";
+    // }
 
     /**
      * Soft look-up in journal name gazetteer with token positions
@@ -922,30 +992,30 @@ public class Lexicon {
         return results;
     }
 
-    // /** Organisation names **/
-    //
-    // /**
-    //  * Soft look-up in organisation name gazetteer for a given string with token positions
-    //  */
-    // public List<OffsetPosition> tokenPositionsOrganisationNames(String s) {
-    //     if (organisationPattern == null) {
-    //         initOrganisations();
-    //     }
-    //     List<OffsetPosition> results = organisationPattern.matchToken(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in organisation name gazetteer for a given list of LayoutToken objects
-    //  * with token positions
-    //  */
-    // public List<OffsetPosition> tokenPositionsOrganisationNames(List<LayoutToken> s) {
-    //     if (organisationPattern == null) {
-    //         initOrganisations();
-    //     }
-    //     List<OffsetPosition> results = organisationPattern.matchLayoutToken(s);
-    //     return results;
-    // }
+    /** Organisation names **/
+
+    /**
+     * Soft look-up in organisation name gazetteer for a given string with token positions
+     */
+    public List<OffsetPosition> tokenPositionsOrganisationNames(String s) {
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
+        List<OffsetPosition> results = organisationPattern.matchToken(s);
+        return results;
+    }
+
+    /**
+     * Soft look-up in organisation name gazetteer for a given list of LayoutToken objects
+     * with token positions
+     */
+    public List<OffsetPosition> tokenPositionsOrganisationNames(List<LayoutToken> s) {
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
+        List<OffsetPosition> results = organisationPattern.matchLayoutToken(s);
+        return results;
+    }
 
     /**
      * Soft look-up in country name gazetteer for a given list of LayoutToken objects
@@ -959,89 +1029,89 @@ public class Lexicon {
         return results;
     }
 
-    // /**
-    //  * Soft look-up in organisation names gazetteer for a string.
-    //  * It return a list of positions referring to the character positions within the string.
-    //  *
-    //  * @param s the input string
-    //  * @return a list of positions referring to the character position in the input string
-    //  */
-    // public List<OffsetPosition> charPositionsOrganisationNames(String s) {
-    //     if (organisationPattern == null) {
-    //         initOrganisations();
-    //     }
-    //     List<OffsetPosition> results = organisationPattern.matchCharacter(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in organisation names gazetteer for a tokenize sequence.
-    //  * It return a list of positions referring to the character positions within the input
-    //  * sequence.
-    //  *
-    //  * @param s the input list of LayoutToken
-    //  * @return a list of positions referring to the character position in the input sequence
-    //  */
-    // public List<OffsetPosition> charPositionsOrganisationNames(List<LayoutToken> s) {
-    //     if (organisationPattern == null) {
-    //         initOrganisations();
-    //     }
-    //     List<OffsetPosition> results = organisationPattern.matchCharacterLayoutToken(s);
-    //     return results;
-    // }
+    /**
+     * Soft look-up in organisation names gazetteer for a string.
+     * It return a list of positions referring to the character positions within the string.
+     *
+     * @param s the input string
+     * @return a list of positions referring to the character position in the input string
+     */
+    public List<OffsetPosition> charPositionsOrganisationNames(String s) {
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
+        List<OffsetPosition> results = organisationPattern.matchCharacter(s);
+        return results;
+    }
 
-    // /**
-    //  * Soft look-up in organisation form name gazetteer for a given string with token positions
-    //  */
-    // public List<OffsetPosition> tokenPositionsOrgForm(String s) {
-    //     if (orgFormPattern == null) {
-    //         initOrgForms();
-    //     }
-    //     List<OffsetPosition> results = orgFormPattern.matchToken(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in organisation form name gazetteer for a given list of LayoutToken objects
-    //  * with token positions
-    //  */
-    // public List<OffsetPosition> tokenPositionsOrgForm(List<LayoutToken> s) {
-    //     if (orgFormPattern == null) {
-    //         initOrgForms();
-    //     }
-    //     List<OffsetPosition> results = orgFormPattern.matchLayoutToken(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in org form names gazetteer for a string.
-    //  * It return a list of positions referring to the character positions within the string.
-    //  *
-    //  * @param s the input string
-    //  * @return a list of positions referring to the character position in the input string
-    //  */
-    // public List<OffsetPosition> charPositionsOrgForm(String s) {
-    //     if (orgFormPattern == null) {
-    //         initOrgForms();
-    //     }
-    //     List<OffsetPosition> results = orgFormPattern.matchCharacter(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in org form names gazetteer for a tokenized string.
-    //  * It return a list of positions referring to the character positions within the sequence.
-    //  *
-    //  * @param s the input list of LayoutToken
-    //  * @return a list of positions referring to the character position in the input sequence
-    //  */
-    // public List<OffsetPosition> charPositionsOrgForm(List<LayoutToken> s) {
-    //     if (orgFormPattern == null) {
-    //         initOrgForms();
-    //     }
-    //     List<OffsetPosition> results = orgFormPattern.matchCharacterLayoutToken(s);
-    //     return results;
-    // }
+    /**
+     * Soft look-up in organisation names gazetteer for a tokenize sequence.
+     * It return a list of positions referring to the character positions within the input
+     * sequence.
+     *
+     * @param s the input list of LayoutToken
+     * @return a list of positions referring to the character position in the input sequence
+     */
+    public List<OffsetPosition> charPositionsOrganisationNames(List<LayoutToken> s) {
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
+        List<OffsetPosition> results = organisationPattern.matchCharacterLayoutToken(s);
+        return results;
+    }
+
+    /**
+     * Soft look-up in organisation form name gazetteer for a given string with token positions
+     */
+    public List<OffsetPosition> tokenPositionsOrgForm(String s) {
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
+        List<OffsetPosition> results = orgFormPattern.matchToken(s);
+        return results;
+    }
+
+    /**
+     * Soft look-up in organisation form name gazetteer for a given list of LayoutToken objects
+     * with token positions
+     */
+    public List<OffsetPosition> tokenPositionsOrgForm(List<LayoutToken> s) {
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
+        List<OffsetPosition> results = orgFormPattern.matchLayoutToken(s);
+        return results;
+    }
+
+    /**
+     * Soft look-up in org form names gazetteer for a string.
+     * It return a list of positions referring to the character positions within the string.
+     *
+     * @param s the input string
+     * @return a list of positions referring to the character position in the input string
+     */
+    public List<OffsetPosition> charPositionsOrgForm(String s) {
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
+        List<OffsetPosition> results = orgFormPattern.matchCharacter(s);
+        return results;
+    }
+
+    /**
+     * Soft look-up in org form names gazetteer for a tokenized string.
+     * It return a list of positions referring to the character positions within the sequence.
+     *
+     * @param s the input list of LayoutToken
+     * @return a list of positions referring to the character position in the input sequence
+     */
+    public List<OffsetPosition> charPositionsOrgForm(List<LayoutToken> s) {
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
+        List<OffsetPosition> results = orgFormPattern.matchCharacterLayoutToken(s);
+        return results;
+    }
 
     /**
      * Soft look-up in location name gazetteer for a given string with token positions
@@ -1066,39 +1136,40 @@ public class Lexicon {
         return results;
     }
 
-    /**
-     * Soft look-up in location name gazetteer for a string, return a list of positions referring
-     * to the character positions within the string.
-     * <p>
-     * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
-     *
-     * @param s the input string
-     * @return a list of positions referring to the character position in the input string
-     */
-    public List<OffsetPosition> charPositionsLocationNames(String s) {
-        if (locationPattern == null) {
-            initLocations();
-        }
-        List<OffsetPosition> results = locationPattern.matchCharacter(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in location name gazetteer for a list of LayoutToken, return a list of
-     * positions referring to the character positions in the input sequence.
-     * <p>
-     * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
-     *
-     * @param s the input list of LayoutToken
-     * @return a list of positions referring to the character position in the input sequence
-     */
-    public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
-        if (locationPattern == null) {
-            initLocations();
-        }
-        List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
-        return results;
-    }
+    // Disabled: only test callers, no production usage.
+    // /**
+    //  * Soft look-up in location name gazetteer for a string, return a list of positions referring
+    //  * to the character positions within the string.
+    //  * <p>
+    //  * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
+    //  *
+    //  * @param s the input string
+    //  * @return a list of positions referring to the character position in the input string
+    //  */
+    // public List<OffsetPosition> charPositionsLocationNames(String s) {
+    //     if (locationPattern == null) {
+    //         initLocations();
+    //     }
+    //     List<OffsetPosition> results = locationPattern.matchCharacter(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in location name gazetteer for a list of LayoutToken, return a list of
+    //  * positions referring to the character positions in the input sequence.
+    //  * <p>
+    //  * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
+    //  *
+    //  * @param s the input list of LayoutToken
+    //  * @return a list of positions referring to the character position in the input sequence
+    //  */
+    // public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
+    //     if (locationPattern == null) {
+    //         initLocations();
+    //     }
+    //     List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
+    //     return results;
+    // }
 
     /**
      * Soft look-up in person title gazetteer for a given string with token positions
@@ -1135,36 +1206,37 @@ public class Lexicon {
         return results;
     }
 
-    /**
-     * Soft look-up in person title name gazetteer for a string.
-     * It return a list of positions referring to the character positions within the string.
-     *
-     * @param s the input string
-     * @return a list of positions referring to the character position in the input string
-     */
-    public List<OffsetPosition> charPositionsPersonTitle(String s) {
-        if (personTitlePattern == null) {
-            initPersonTitles();
-        }
-        List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in person title name gazetteer for a list of LayoutToken.
-     * It return a list of positions referring to the character positions in the input
-     * sequence.
-     *
-     * @param s the input list of LayoutToken
-     * @return a list of positions referring to the character position in the input sequence
-     */
-    public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
-        if (personTitlePattern == null) {
-            initPersonTitles();
-        }
-        List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
-        return results;
-    }
+    // Disabled: only test callers, no production usage.
+    // /**
+    //  * Soft look-up in person title name gazetteer for a string.
+    //  * It return a list of positions referring to the character positions within the string.
+    //  *
+    //  * @param s the input string
+    //  * @return a list of positions referring to the character position in the input string
+    //  */
+    // public List<OffsetPosition> charPositionsPersonTitle(String s) {
+    //     if (personTitlePattern == null) {
+    //         initPersonTitles();
+    //     }
+    //     List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in person title name gazetteer for a list of LayoutToken.
+    //  * It return a list of positions referring to the character positions in the input
+    //  * sequence.
+    //  *
+    //  * @param s the input list of LayoutToken
+    //  * @return a list of positions referring to the character position in the input sequence
+    //  */
+    // public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
+    //     if (personTitlePattern == null) {
+    //         initPersonTitles();
+    //     }
+    //     List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
+    //     return results;
+    // }
 
     /**
      * Identify in tokenized input the positions of identifier patterns with token positions
@@ -1215,27 +1287,28 @@ public class Lexicon {
         return convertStringOffsetToTokenOffset(textResult, tokens);
     }
 
-    /**
-     * Identify in tokenized input the positions of ISSN patterns with token positions
-     */
-    public List<OffsetPosition> tokenPositionsISSNPattern(List<LayoutToken> tokens) {
-        List<OffsetPosition> result = new ArrayList<OffsetPosition>();
-
-        // TBD !
-
-        return result;
-    }
-
-    /**
-     * Identify in tokenized input the positions of ISBN patterns with token positions
-     */
-    public List<OffsetPosition> tokenPositionsISBNPattern(List<LayoutToken> tokens) {
-        List<OffsetPosition> result = new ArrayList<OffsetPosition>();
-
-        // TBD !!
-
-        return result;
-    }
+    // Disabled: stub returning an empty list, never implemented, no callers.
+    // /**
+    //  * Identify in tokenized input the positions of ISSN patterns with token positions
+    //  */
+    // public List<OffsetPosition> tokenPositionsISSNPattern(List<LayoutToken> tokens) {
+    //     List<OffsetPosition> result = new ArrayList<OffsetPosition>();
+    //
+    //     // TBD !
+    //
+    //     return result;
+    // }
+    //
+    // /**
+    //  * Identify in tokenized input the positions of ISBN patterns with token positions
+    //  */
+    // public List<OffsetPosition> tokenPositionsISBNPattern(List<LayoutToken> tokens) {
+    //     List<OffsetPosition> result = new ArrayList<OffsetPosition>();
+    //
+    //     // TBD !!
+    //
+    //     return result;
+    // }
 
     /**
      * Identify in tokenized input the positions of an URL pattern with token positions
@@ -1366,42 +1439,43 @@ public class Lexicon {
         return new OffsetPosition(startTokenIndex, endTokensIndex);
     }
 
-    public static OffsetPosition getTokenIndexMatchingURLDestination(List<LayoutToken> urlTokens, String destination) {
-        String urlString = LayoutTokensUtil.toText(urlTokens);
-
-        String joinedNoSpaces = urlString.replaceAll("\\s", "");
-        String destinationNoSpaces = destination.replaceAll("\\s", "");
-
-        // Find the start index in the space-less string
-        int destStartNoSpaces = joinedNoSpaces.indexOf(destinationNoSpaces);
-        if (destStartNoSpaces == -1) {
-            // Not found, handle as needed
-            return new OffsetPosition();
-        }
-
-        int destEndNoSpaces = destStartNoSpaces + destinationNoSpaces.length();
-
-        // Map to token indices
-        int charCount = 0;
-        int indexStart = -1, indexEnd = -1;
-        for (int i = 0; i < urlTokens.size(); i++) {
-            String tokenText = urlTokens.get(i).getText();
-            for (int j = 0; j < tokenText.length(); j++) {
-                if (!Character.isWhitespace(tokenText.charAt(j))) {
-                    if (charCount == destStartNoSpaces && indexStart == -1) {
-                        indexStart = i;
-                    }
-                    if (charCount == destEndNoSpaces - 1) {
-                        indexEnd = i;
-                    }
-                    charCount++;
-                }
-            }
-            if (indexEnd != -1)
-                break;
-        }
-        return new OffsetPosition(indexStart, indexEnd);
-    }
+    // Disabled: only test callers, no production usage.
+    // public static OffsetPosition getTokenIndexMatchingURLDestination(List<LayoutToken> urlTokens, String destination) {
+    //     String urlString = LayoutTokensUtil.toText(urlTokens);
+    //
+    //     String joinedNoSpaces = urlString.replaceAll("\\s", "");
+    //     String destinationNoSpaces = destination.replaceAll("\\s", "");
+    //
+    //     // Find the start index in the space-less string
+    //     int destStartNoSpaces = joinedNoSpaces.indexOf(destinationNoSpaces);
+    //     if (destStartNoSpaces == -1) {
+    //         // Not found, handle as needed
+    //         return new OffsetPosition();
+    //     }
+    //
+    //     int destEndNoSpaces = destStartNoSpaces + destinationNoSpaces.length();
+    //
+    //     // Map to token indices
+    //     int charCount = 0;
+    //     int indexStart = -1, indexEnd = -1;
+    //     for (int i = 0; i < urlTokens.size(); i++) {
+    //         String tokenText = urlTokens.get(i).getText();
+    //         for (int j = 0; j < tokenText.length(); j++) {
+    //             if (!Character.isWhitespace(tokenText.charAt(j))) {
+    //                 if (charCount == destStartNoSpaces && indexStart == -1) {
+    //                     indexStart = i;
+    //                 }
+    //                 if (charCount == destEndNoSpaces - 1) {
+    //                     indexEnd = i;
+    //                 }
+    //                 charCount++;
+    //             }
+    //         }
+    //         if (indexEnd != -1)
+    //             break;
+    //     }
+    //     return new OffsetPosition(indexStart, indexEnd);
+    // }
 
     /**
      * This method returns the character offsets in relation to the string obtained by the layout tokens.

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -19,6 +19,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,32 +69,15 @@ public class Lexicon {
 
     /**
      * @deprecated Use {@link #builder()} instead. This method is preserved for backward
-     *     compatibility with existing call sites: it loads {@link Builder#withDefaults()
-     *     the historical eager set} (wordforms, person names, country codes) plus every
-     *     formerly lazy-loaded gazetteer that production code historically auto-loaded
-     *     on first lookup (journals, conferences, publishers, cities, locations, person
-     *     titles/suffixes, funders, research infrastructures, collaborations). Migrate
-     *     to {@link #builder()} and request only the gazetteers your code actually uses.
-     *     <p>Lookup methods now throw {@link IllegalStateException} if their gazetteer
-     *     was not loaded — opt in through the {@link Builder}
-     *     ({@code .withOrganisations()}, {@code .withOrgForms()}) for gazetteers off
-     *     by default.
+     *     compatibility with existing call sites and reproduces the original behavior
+     *     exactly: it eagerly loads {@link Builder#withDefaults() the historical eager
+     *     set} (wordforms, person names, country codes); every other gazetteer loads
+     *     lazily on first lookup. Migrate to {@link #builder()} and, optionally, request
+     *     the gazetteers you want pre-warmed eagerly.
      */
     @Deprecated
     public static Lexicon getInstance() {
-        return builder()
-                .withDefaults()
-                .withJournals()
-                .withConferences()
-                .withPublishers()
-                .withCities()
-                .withLocations()
-                .withPersonTitles()
-                .withPersonSuffixes()
-                .withFunders()
-                .withResearchInfrastructures()
-                .withCollaborations()
-                .build();
+        return builder().withDefaults().build();
     }
 
     /**
@@ -111,29 +95,33 @@ public class Lexicon {
     }
 
     /**
-     * Returns a builder for declaratively configuring a {@link Lexicon}. The Builder
-     * is the canonical entry point: each {@code withX()} call opts the singleton in
-     * to one gazetteer; {@link Builder#build()} returns the singleton after triggering
-     * the requested loaders.
+     * Returns a builder for declaratively configuring a {@link Lexicon}. The Builder is
+     * the canonical entry point and declares only what to load <em>eagerly</em>: each
+     * {@code withX()} call pre-loads one gazetteer at {@link Builder#build() build()}
+     * time instead of waiting for first use.
      *
      * <pre>
      * Lexicon lex = Lexicon.builder()
-     *         .withDefaults()           // wordforms + people + countries + all wired gazetteers
-     *         .withOrganisations()      // optional org gazetteer
+     *         .withDefaults()           // eager: wordforms + people + countries
+     *         .withOrganisations()      // eager: pre-load the org gazetteer too
      *         .build();
      * </pre>
      *
-     * Lookup methods on the returned {@link Lexicon} throw {@link IllegalStateException}
-     * if their gazetteer wasn't requested — there is no implicit lazy-loading.
+     * Loading is <strong>lazy by default</strong>: any gazetteer not named here loads
+     * transparently on first lookup, so a {@link Lexicon} obtained from any entry point
+     * is always fully functional and never throws for a missing gazetteer.
      */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Fluent configurator for {@link Lexicon}. Each {@code withX()} call enables one
-     * gazetteer. {@link #build()} returns the singleton after triggering each requested
-     * loader once (idempotent — already-loaded gazetteers are not reloaded).
+     * Fluent configurator for {@link Lexicon}. Each {@code withX()} call marks one
+     * gazetteer for <em>eager</em> pre-loading. {@link #build()} returns the singleton
+     * after triggering each requested loader once (idempotent — already-loaded
+     * gazetteers are not reloaded). Gazetteers not requested here still load lazily on
+     * first lookup; {@code withX()} only controls <em>when</em> a gazetteer loads, never
+     * whether a lookup succeeds.
      */
     public static class Builder {
         private boolean wordforms = false;
@@ -246,11 +234,11 @@ public class Lexicon {
         }
 
         /**
-         * Reproduces the historical eager-loaded set from the original {@code Lexicon()}
+         * Eagerly pre-loads the historical eager set from the original {@code Lexicon()}
          * constructor: wordforms, people (first/last names), and country codes. These
          * are the gazetteers every parser flow needs at startup; everything else
-         * (journals, locations, funders, etc.) was previously lazy-loaded on first
-         * lookup and is now an explicit opt-in via the corresponding {@code withX()}.
+         * (journals, locations, funders, etc.) still loads lazily on first lookup, or
+         * can be pre-warmed eagerly via the corresponding {@code withX()}.
          */
         public Builder withDefaults() {
             return withWordforms()
@@ -405,8 +393,8 @@ public class Lexicon {
         if (countryCodes != null) {
             return;
         }
-        countryCodes = new HashMap<String, String>();
-        countries = new HashSet<String>();
+        countryCodes = new HashMap<>();
+        countries = new HashSet<>();
         countryPattern = new FastMatcher();
         addCountryCodes(
                 GrobidProperties.getGrobidHomePath()
@@ -417,18 +405,6 @@ public class Lexicon {
                         + "countries"
                         + File.separator
                         + "CountryCodes.xml");
-    }
-
-    /**
-     * Throws {@link IllegalStateException} if a gazetteer field is null, with a message
-     * pointing the caller at the {@link Builder} method that loads it. Used by every
-     * lookup method to enforce explicit opt-in.
-     */
-    private static void requireLoaded(Object field, String name, String builderMethod) {
-        if (field == null) {
-            throw new IllegalStateException(
-                    name + " not loaded; call Lexicon.builder()." + builderMethod + "().build() first");
-        }
     }
 
     /**
@@ -515,39 +491,14 @@ public class Lexicon {
     }
 
     public boolean isCountry(String tok) {
-        requireLoaded(countries, "Country gazetteer", "withCountries");
+        if (countries == null) {
+            loadCountries();
+        }
         return countries.contains(tok.toLowerCase());
     }
 
-    private void initNames() {
-        LOGGER.debug("Initiating names");
-        firstNames = new HashSet<>();
-        lastNames = new HashSet<>();
-        LOGGER.debug("End of initialization of names");
-    }
-
-    private void initCountryCodes() {
-        LOGGER.debug("Initiating country codes");
-        countryCodes = new HashMap<String, String>();
-        countries = new HashSet<String>();
-        countryPattern = new FastMatcher();
-        LOGGER.debug("End of initialization of country codes");
-    }
-
     private void addCountryCodes(String path) {
-        File file = new File(path);
-        if (!file.exists()) {
-            throw new GrobidResourceException("Cannot add country codes to dictionary, because file '"
-                    +
-                    file.getAbsolutePath()
-                    + "' does not exists.");
-        }
-        if (!file.canRead()) {
-            throw new GrobidResourceException("Cannot add country codes to dictionary, because cannot read file '"
-                    +
-                    file.getAbsolutePath()
-                    + "'.");
-        }
+        File file = getFile(path, "country codes");
         InputStream ist = null;
         try {
             ist = new FileInputStream(file);
@@ -567,8 +518,30 @@ public class Lexicon {
         }
     }
 
+    private static @NonNull File getFile(String path, String lexiconName) {
+        File file = new File(path);
+        if (!file.exists()) {
+            throw new GrobidResourceException("Cannot add "
+                    + lexiconName
+                    + " to dictionary, because file '"
+                    + file.getAbsolutePath()
+                    + "' does not exists.");
+        }
+        if (!file.canRead()) {
+            throw new GrobidResourceException("Cannot add "
+                    + lexiconName
+                    + " to dictionary, because cannot read file '"
+                    +
+                    file.getAbsolutePath()
+                    + "'.");
+        }
+        return file;
+    }
+
     public String getCountryCode(String country) {
-        requireLoaded(countryCodes, "Country gazetteer", "withCountries");
+        if (countryCodes == null) {
+            loadCountries();
+        }
         String code = (String) countryCodes.get(country.toLowerCase());
         return code;
     }
@@ -593,19 +566,7 @@ public class Lexicon {
     }
 
     public final void addFirstNames(String path) {
-        File file = new File(path);
-        if (!file.exists()) {
-            throw new GrobidResourceException("Cannot add first names to dictionary, because file '"
-                    +
-                    file.getAbsolutePath()
-                    + "' does not exists.");
-        }
-        if (!file.canRead()) {
-            throw new GrobidResourceException("Cannot add first names to dictionary, because cannot read file '"
-                    +
-                    file.getAbsolutePath()
-                    + "'.");
-        }
+        File file = getFile(path, "first names");
         InputStream ist = null;
         InputStreamReader isr = null;
         BufferedReader dis = null;
@@ -634,19 +595,7 @@ public class Lexicon {
     }
 
     public final void addLastNames(String path) {
-        File file = new File(path);
-        if (!file.exists()) {
-            throw new GrobidResourceException("Cannot add last names to dictionary, because file '"
-                    +
-                    file.getAbsolutePath()
-                    + "' does not exists.");
-        }
-        if (!file.canRead()) {
-            throw new GrobidResourceException("Cannot add last names to dictionary, because cannot read file '"
-                    +
-                    file.getAbsolutePath()
-                    + "'.");
-        }
+        File file = getFile(path, "last names");
         InputStream ist = null;
         InputStreamReader isr = null;
         BufferedReader dis = null;
@@ -687,7 +636,9 @@ public class Lexicon {
     }
 
     public boolean inDictionary(String s, String lang) {
-        requireLoaded(dictionary_en, "Wordforms dictionary", "withWordforms");
+        if (dictionary_en == null) {
+            loadWordforms();
+        }
         if (s == null)
             return false;
         if ((s.endsWith(".")) | (s.endsWith(",")) | (s.endsWith(":")) | (s.endsWith(";")) | (s.endsWith(".")))
@@ -874,34 +825,20 @@ public class Lexicon {
 
     public void initResearchInfrastructures() {
         try {
+            String infrastructureFilePath = GrobidProperties.getGrobidHomePath()
+                    + "/lexicon/organisations/research_infrastructures.txt";
             researchInfrastructurePattern = new FastMatcher(
-                    new File(GrobidProperties.getGrobidHomePath()
-                            + "/lexicon/organisations/research_infrastructures.txt"),
+                    new File(infrastructureFilePath),
                     GrobidAnalyzer.getInstance(), true);
             // store some name mapping
             researchOrganizations = new TreeMap<>();
 
-            File file = new File(
-                    GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/research_infrastructures_map.txt");
-            if (!file.exists()) {
-                throw new GrobidResourceException(
-                        "Cannot add research infrastructure names to dictionary, because file '"
-                                +
-                                file.getAbsolutePath()
-                                + "' does not exists.");
-            }
-            if (!file.canRead()) {
-                throw new GrobidResourceException(
-                        "Cannot add research infrastructure to dictionary, because cannot read file '"
-                                +
-                                file.getAbsolutePath()
-                                + "'.");
-            }
+            File file = getFile(infrastructureFilePath, "infrastructure names");
             InputStream ist = null;
             BufferedReader dis = null;
             try {
                 ist = new FileInputStream(file);
-                dis = new BufferedReader(new InputStreamReader(ist, "UTF8"));
+                dis = new BufferedReader(new InputStreamReader(ist, StandardCharsets.UTF_8));
 
                 String line;
                 while ((line = dis.readLine()) != null) {
@@ -966,7 +903,9 @@ public class Lexicon {
      * Look-up in first name gazetteer
      */
     public boolean inFirstNames(String s) {
-        requireLoaded(firstNames, "Person-names gazetteer", "withPeople");
+        if (firstNames == null) {
+            loadPeople();
+        }
         return firstNames.contains(s);
     }
 
@@ -974,12 +913,16 @@ public class Lexicon {
      * Look-up in last name gazetteer
      */
     public boolean inLastNames(String s) {
-        requireLoaded(lastNames, "Person-names gazetteer", "withPeople");
+        if (lastNames == null) {
+            loadPeople();
+        }
         return lastNames.contains(s);
     }
 
     public List<OrganizationRecord> getOrganizationNamingInfo(String name) {
-        requireLoaded(researchOrganizations, "Research-infrastructure gazetteer", "withResearchInfrastructures");
+        if (researchOrganizations == null) {
+            initResearchInfrastructures();
+        }
         return researchOrganizations.get(name.toLowerCase());
     }
 
@@ -987,7 +930,9 @@ public class Lexicon {
      * Soft look-up in journal name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsJournalNames(String s) {
-        requireLoaded(journalPattern, "Journal gazetteer", "withJournals");
+        if (journalPattern == null) {
+            initJournals();
+        }
         List<OffsetPosition> results = journalPattern.matchToken(s);
         return results;
     }
@@ -997,7 +942,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsJournalNames(List<LayoutToken> s) {
-        requireLoaded(journalPattern, "Journal gazetteer", "withJournals");
+        if (journalPattern == null) {
+            initJournals();
+        }
         List<OffsetPosition> results = journalPattern.matchLayoutToken(s);
         return results;
     }
@@ -1006,7 +953,9 @@ public class Lexicon {
      * Soft look-up in journal abbreviated name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsAbbrevJournalNames(String s) {
-        requireLoaded(abbrevJournalPattern, "Abbreviated journal gazetteer", "withJournals");
+        if (abbrevJournalPattern == null) {
+            initJournals();
+        }
         List<OffsetPosition> results = abbrevJournalPattern.matchToken(s);
         return results;
     }
@@ -1016,7 +965,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsAbbrevJournalNames(List<LayoutToken> s) {
-        requireLoaded(abbrevJournalPattern, "Abbreviated journal gazetteer", "withJournals");
+        if (abbrevJournalPattern == null) {
+            initJournals();
+        }
         List<OffsetPosition> results = abbrevJournalPattern.matchLayoutToken(s);
         return results;
     }
@@ -1025,7 +976,9 @@ public class Lexicon {
      * Soft look-up in conference/proceedings name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsConferenceNames(String s) {
-        requireLoaded(conferencePattern, "Conference gazetteer", "withConferences");
+        if (conferencePattern == null) {
+            initConferences();
+        }
         List<OffsetPosition> results = conferencePattern.matchToken(s);
         return results;
     }
@@ -1035,7 +988,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsConferenceNames(List<LayoutToken> s) {
-        requireLoaded(conferencePattern, "Conference gazetteer", "withConferences");
+        if (conferencePattern == null) {
+            initConferences();
+        }
         List<OffsetPosition> results = conferencePattern.matchLayoutToken(s);
         return results;
     }
@@ -1044,7 +999,9 @@ public class Lexicon {
      * Soft look-up in conference/proceedings name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsPublisherNames(String s) {
-        requireLoaded(publisherPattern, "Publisher gazetteer", "withPublishers");
+        if (publisherPattern == null) {
+            initPublishers();
+        }
         List<OffsetPosition> results = publisherPattern.matchToken(s);
         return results;
     }
@@ -1054,7 +1011,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsPublisherNames(List<LayoutToken> s) {
-        requireLoaded(publisherPattern, "Publisher gazetteer", "withPublishers");
+        if (publisherPattern == null) {
+            initPublishers();
+        }
         List<OffsetPosition> results = publisherPattern.matchLayoutToken(s);
         return results;
     }
@@ -1064,7 +1023,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsCollaborationNames(List<LayoutToken> s) {
-        requireLoaded(collaborationPattern, "Collaboration gazetteer", "withCollaborations");
+        if (collaborationPattern == null) {
+            initCollaborations();
+        }
         List<OffsetPosition> results = collaborationPattern.matchLayoutToken(s);
         return results;
     }
@@ -1074,7 +1035,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsFunderNames(List<LayoutToken> s) {
-        requireLoaded(funderPattern, "Funder gazetteer", "withFunders");
+        if (funderPattern == null) {
+            initFunders();
+        }
         List<OffsetPosition> results = funderPattern.matchLayoutToken(s, true, true);
         return results;
     }
@@ -1084,10 +1047,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsResearchInfrastructureNames(List<LayoutToken> s) {
-        requireLoaded(
-                researchInfrastructurePattern,
-                "Research-infrastructure gazetteer",
-                "withResearchInfrastructures");
+        if (researchInfrastructurePattern == null) {
+            initResearchInfrastructures();
+        }
         List<OffsetPosition> results = researchInfrastructurePattern.matchLayoutToken(s, true, true);
         return results;
     }
@@ -1096,7 +1058,9 @@ public class Lexicon {
      * Soft look-up in city name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsCityNames(String s) {
-        requireLoaded(cityPattern, "City gazetteer", "withCities");
+        if (cityPattern == null) {
+            initCities();
+        }
         List<OffsetPosition> results = cityPattern.matchToken(s);
         return results;
     }
@@ -1106,7 +1070,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsCityNames(List<LayoutToken> s) {
-        requireLoaded(cityPattern, "City gazetteer", "withCities");
+        if (cityPattern == null) {
+            initCities();
+        }
         List<OffsetPosition> results = cityPattern.matchLayoutToken(s);
         return results;
     }
@@ -1117,7 +1083,9 @@ public class Lexicon {
      * Soft look-up in organisation name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsOrganisationNames(String s) {
-        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
         List<OffsetPosition> results = organisationPattern.matchToken(s);
         return results;
     }
@@ -1127,7 +1095,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsOrganisationNames(List<LayoutToken> s) {
-        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
         List<OffsetPosition> results = organisationPattern.matchLayoutToken(s);
         return results;
     }
@@ -1137,7 +1107,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsCountryNames(List<LayoutToken> s) {
-        requireLoaded(countryPattern, "Country gazetteer", "withCountries");
+        if (countryPattern == null) {
+            loadCountries();
+        }
         List<OffsetPosition> results = countryPattern.matchLayoutToken(s);
         return results;
     }
@@ -1150,7 +1122,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input string
      */
     public List<OffsetPosition> charPositionsOrganisationNames(String s) {
-        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
         List<OffsetPosition> results = organisationPattern.matchCharacter(s);
         return results;
     }
@@ -1164,7 +1138,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input sequence
      */
     public List<OffsetPosition> charPositionsOrganisationNames(List<LayoutToken> s) {
-        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
+        if (organisationPattern == null) {
+            initOrganisations();
+        }
         List<OffsetPosition> results = organisationPattern.matchCharacterLayoutToken(s);
         return results;
     }
@@ -1173,7 +1149,9 @@ public class Lexicon {
      * Soft look-up in organisation form name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsOrgForm(String s) {
-        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
         List<OffsetPosition> results = orgFormPattern.matchToken(s);
         return results;
     }
@@ -1183,7 +1161,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsOrgForm(List<LayoutToken> s) {
-        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
         List<OffsetPosition> results = orgFormPattern.matchLayoutToken(s);
         return results;
     }
@@ -1196,7 +1176,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input string
      */
     public List<OffsetPosition> charPositionsOrgForm(String s) {
-        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
         List<OffsetPosition> results = orgFormPattern.matchCharacter(s);
         return results;
     }
@@ -1209,7 +1191,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input sequence
      */
     public List<OffsetPosition> charPositionsOrgForm(List<LayoutToken> s) {
-        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
+        if (orgFormPattern == null) {
+            initOrgForms();
+        }
         List<OffsetPosition> results = orgFormPattern.matchCharacterLayoutToken(s);
         return results;
     }
@@ -1218,7 +1202,9 @@ public class Lexicon {
      * Soft look-up in location name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsLocationNames(String s) {
-        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
+        if (locationPattern == null) {
+            initLocations();
+        }
         List<OffsetPosition> results = locationPattern.matchToken(s);
         return results;
     }
@@ -1228,7 +1214,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsLocationNames(List<LayoutToken> s) {
-        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
+        if (locationPattern == null) {
+            initLocations();
+        }
         List<OffsetPosition> results = locationPattern.matchLayoutToken(s);
         return results;
     }
@@ -1243,7 +1231,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input string
      */
     public List<OffsetPosition> charPositionsLocationNames(String s) {
-        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
+        if (locationPattern == null) {
+            initLocations();
+        }
         List<OffsetPosition> results = locationPattern.matchCharacter(s);
         return results;
     }
@@ -1258,7 +1248,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input sequence
      */
     public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
-        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
+        if (locationPattern == null) {
+            initLocations();
+        }
         List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
         return results;
     }
@@ -1267,7 +1259,9 @@ public class Lexicon {
      * Soft look-up in person title gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsPersonTitle(String s) {
-        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
+        if (personTitlePattern == null) {
+            initPersonTitles();
+        }
         List<OffsetPosition> results = personTitlePattern.matchToken(s);
         return results;
     }
@@ -1277,7 +1271,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsPersonTitle(List<LayoutToken> s) {
-        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
+        if (personTitlePattern == null) {
+            initPersonTitles();
+        }
         List<OffsetPosition> results = personTitlePattern.matchLayoutToken(s);
         return results;
     }
@@ -1287,7 +1283,9 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsPersonSuffix(List<LayoutToken> s) {
-        requireLoaded(personSuffixPattern, "Person-suffix gazetteer", "withPersonSuffixes");
+        if (personSuffixPattern == null) {
+            initPersonSuffix();
+        }
         List<OffsetPosition> results = personSuffixPattern.matchLayoutToken(s);
         return results;
     }
@@ -1300,7 +1298,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input string
      */
     public List<OffsetPosition> charPositionsPersonTitle(String s) {
-        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
+        if (personTitlePattern == null) {
+            initPersonTitles();
+        }
         List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
         return results;
     }
@@ -1314,7 +1314,9 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input sequence
      */
     public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
-        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
+        if (personTitlePattern == null) {
+            initPersonTitles();
+        }
         List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
         return results;
     }

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -66,46 +66,169 @@ public class Lexicon {
     private FastMatcher personTitlePattern = null;
     private FastMatcher personSuffixPattern = null;
 
+    /**
+     * @deprecated Use {@link #builder()} instead. This method is preserved for backward
+     *     compatibility with existing call sites: it loads {@link Builder#withDefaults()
+     *     the historical eager set} (wordforms, person names, country codes) plus every
+     *     formerly lazy-loaded gazetteer that production code historically auto-loaded
+     *     on first lookup (journals, conferences, publishers, cities, locations, person
+     *     titles/suffixes, funders, research infrastructures, collaborations). Migrate
+     *     to {@link #builder()} and request only the gazetteers your code actually uses.
+     *     <p>Lookup methods now throw {@link IllegalStateException} if their gazetteer
+     *     was not loaded — opt in through the {@link Builder}
+     *     ({@code .withOrganisations()}, {@code .withOrgForms()}) for gazetteers off
+     *     by default.
+     */
+    @Deprecated
     public static Lexicon getInstance() {
+        return builder()
+                .withDefaults()
+                .withJournals()
+                .withConferences()
+                .withPublishers()
+                .withCities()
+                .withLocations()
+                .withPersonTitles()
+                .withPersonSuffixes()
+                .withFunders()
+                .withResearchInfrastructures()
+                .withCollaborations()
+                .build();
+    }
+
+    /**
+     * Returns the bare singleton without triggering any loading. Used internally by
+     * {@link Builder#build()}; not part of the public API — callers go through
+     * {@link #builder()}.
+     */
+    static synchronized Lexicon getRawInstance() {
         if (instance == null) {
-            synchronized (Lexicon.class) {
-                if (instance == null) {
-                    LOGGER.debug("Get new instance of Lexicon");
-                    GrobidProperties.getInstance();
-                    instance = new Lexicon();
-                }
-            }
+            LOGGER.debug("Get new instance of Lexicon");
+            GrobidProperties.getInstance();
+            instance = new Lexicon();
         }
         return instance;
     }
 
     /**
-     * Returns a builder for opting into optional gazetteers on top of the singleton's
-     * defaults. The default {@link #getInstance()} eagerly loads wordforms, person names,
-     * and country codes; other gazetteers (journals, locations, person titles, funders, etc.)
-     * are loaded lazily on first lookup. Some gazetteers — currently <i>organisations</i>
-     * and <i>organisation forms</i> — are off by default; the builder is the explicit way
-     * to enable them.
+     * Returns a builder for declaratively configuring a {@link Lexicon}. The Builder
+     * is the canonical entry point: each {@code withX()} call opts the singleton in
+     * to one gazetteer; {@link Builder#build()} returns the singleton after triggering
+     * the requested loaders.
      *
      * <pre>
      * Lexicon lex = Lexicon.builder()
-     *         .withOrganisations()
+     *         .withDefaults()           // wordforms + people + countries + all wired gazetteers
+     *         .withOrganisations()      // optional org gazetteer
      *         .build();
      * </pre>
+     *
+     * Lookup methods on the returned {@link Lexicon} throw {@link IllegalStateException}
+     * if their gazetteer wasn't requested — there is no implicit lazy-loading.
      */
     public static Builder builder() {
         return new Builder();
     }
 
     /**
-     * Fluent configurator for {@link Lexicon}. Each {@code withX()} call enables an
-     * optional gazetteer. The terminal {@link #build()} call returns the singleton
-     * instance after triggering the requested loaders. Calls are idempotent — building
-     * twice with the same flags only loads each gazetteer once.
+     * Fluent configurator for {@link Lexicon}. Each {@code withX()} call enables one
+     * gazetteer. {@link #build()} returns the singleton after triggering each requested
+     * loader once (idempotent — already-loaded gazetteers are not reloaded).
      */
     public static class Builder {
+        private boolean wordforms = false;
+        private boolean people = false;
+        private boolean countries = false;
+        private boolean journals = false;
+        private boolean conferences = false;
+        private boolean publishers = false;
+        private boolean cities = false;
+        private boolean locations = false;
+        private boolean personTitles = false;
+        private boolean personSuffixes = false;
+        private boolean funders = false;
+        private boolean researchInfrastructures = false;
+        private boolean collaborations = false;
         private boolean organisations = false;
         private boolean orgForms = false;
+
+        /** Enables the English/German wordform dictionaries (english.wf, german.wf). */
+        public Builder withWordforms() {
+            this.wordforms = true;
+            return this;
+        }
+
+        /** Enables the first/last name lists (names.family, lastname.5k, names.female, names.male, firstname.5k). */
+        public Builder withPeople() {
+            this.people = true;
+            return this;
+        }
+
+        /** Enables ISO 3166 country codes and the country-name pattern (CountryCodes.xml). */
+        public Builder withCountries() {
+            this.countries = true;
+            return this;
+        }
+
+        /** Enables the journal-name gazetteer (journals.txt + abbrev_journals.txt). */
+        public Builder withJournals() {
+            this.journals = true;
+            return this;
+        }
+
+        /** Enables the conference/proceedings gazetteer (proceedings.txt). */
+        public Builder withConferences() {
+            this.conferences = true;
+            return this;
+        }
+
+        /** Enables the publisher gazetteer (publishers.txt). */
+        public Builder withPublishers() {
+            this.publishers = true;
+            return this;
+        }
+
+        /** Enables the city gazetteer (cities15000.txt). */
+        public Builder withCities() {
+            this.cities = true;
+            return this;
+        }
+
+        /** Enables the location gazetteer (places/location.txt). */
+        public Builder withLocations() {
+            this.locations = true;
+            return this;
+        }
+
+        /** Enables the person-title gazetteer (VincentNgPeopleTitles.txt). */
+        public Builder withPersonTitles() {
+            this.personTitles = true;
+            return this;
+        }
+
+        /** Enables the person-name suffix gazetteer (suffix.txt). */
+        public Builder withPersonSuffixes() {
+            this.personSuffixes = true;
+            return this;
+        }
+
+        /** Enables the funder gazetteer (funders.txt) used by the funding model. */
+        public Builder withFunders() {
+            this.funders = true;
+            return this;
+        }
+
+        /** Enables the research-infrastructure gazetteer (research_infrastructures.txt + research_infrastructures_map.txt). */
+        public Builder withResearchInfrastructures() {
+            this.researchInfrastructures = true;
+            return this;
+        }
+
+        /** Enables the collaboration gazetteer (inspire_collaborations.txt) used by the citation model. */
+        public Builder withCollaborations() {
+            this.collaborations = true;
+            return this;
+        }
 
         /**
          * Enables the organisation gazetteer (Wikipedia orgs + government agencies +
@@ -116,12 +239,23 @@ public class Lexicon {
             return this;
         }
 
-        /**
-         * Enables the organisation-form gazetteer (Inc., Ltd., Corp., GmbH, etc.).
-         */
+        /** Enables the organisation-form gazetteer (Inc., Ltd., Corp., GmbH, etc.). */
         public Builder withOrgForms() {
             this.orgForms = true;
             return this;
+        }
+
+        /**
+         * Reproduces the historical eager-loaded set from the original {@code Lexicon()}
+         * constructor: wordforms, people (first/last names), and country codes. These
+         * are the gazetteers every parser flow needs at startup; everything else
+         * (journals, locations, funders, etc.) was previously lazy-loaded on first
+         * lookup and is now an explicit opt-in via the corresponding {@code withX()}.
+         */
+        public Builder withDefaults() {
+            return withWordforms()
+                    .withPeople()
+                    .withCountries();
         }
 
         /**
@@ -129,7 +263,46 @@ public class Lexicon {
          * has been loaded. Already-loaded gazetteers are not reloaded.
          */
         public Lexicon build() {
-            Lexicon lex = Lexicon.getInstance();
+            Lexicon lex = getRawInstance();
+            if (wordforms && lex.dictionary_en == null) {
+                lex.loadWordforms();
+            }
+            if (people && lex.firstNames == null) {
+                lex.loadPeople();
+            }
+            if (countries && lex.countryCodes == null) {
+                lex.loadCountries();
+            }
+            if (journals && lex.journalPattern == null) {
+                lex.initJournals();
+            }
+            if (conferences && lex.conferencePattern == null) {
+                lex.initConferences();
+            }
+            if (publishers && lex.publisherPattern == null) {
+                lex.initPublishers();
+            }
+            if (cities && lex.cityPattern == null) {
+                lex.initCities();
+            }
+            if (locations && lex.locationPattern == null) {
+                lex.initLocations();
+            }
+            if (personTitles && lex.personTitlePattern == null) {
+                lex.initPersonTitles();
+            }
+            if (personSuffixes && lex.personSuffixPattern == null) {
+                lex.initPersonSuffix();
+            }
+            if (funders && lex.funderPattern == null) {
+                lex.initFunders();
+            }
+            if (researchInfrastructures && lex.researchInfrastructurePattern == null) {
+                lex.initResearchInfrastructures();
+            }
+            if (collaborations && lex.collaborationPattern == null) {
+                lex.initCollaborations();
+            }
             if (organisations && lex.organisationPattern == null) {
                 lex.initOrganisations();
             }
@@ -141,12 +314,18 @@ public class Lexicon {
     }
 
     /**
-     * Hidden constructor
+     * Hidden constructor. The constructor performs no loading — every gazetteer is
+     * loaded explicitly via {@link Builder#build()} based on the requested flags.
      */
     private Lexicon() {
-        initDictionary();
-        initNames();
-        // the loading of the journal and conference names is lazy
+    }
+
+    private synchronized void loadWordforms() {
+        if (dictionary_en != null) {
+            return;
+        }
+        dictionary_en = new HashSet<>();
+        dictionary_de = new HashSet<>();
         addDictionary(
                 GrobidProperties.getGrobidHomePath()
                         + File.separator
@@ -167,6 +346,14 @@ public class Lexicon {
                         + File.separator
                         + "german.wf",
                 Language.DE);
+    }
+
+    private synchronized void loadPeople() {
+        if (firstNames != null) {
+            return;
+        }
+        firstNames = new HashSet<>();
+        lastNames = new HashSet<>();
         addLastNames(
                 GrobidProperties.getGrobidHomePath()
                         + File.separator
@@ -212,7 +399,15 @@ public class Lexicon {
                         + "names"
                         + File.separator
                         + "firstname.5k");
-        initCountryCodes();
+    }
+
+    private synchronized void loadCountries() {
+        if (countryCodes != null) {
+            return;
+        }
+        countryCodes = new HashMap<String, String>();
+        countries = new HashSet<String>();
+        countryPattern = new FastMatcher();
         addCountryCodes(
                 GrobidProperties.getGrobidHomePath()
                         + File.separator
@@ -222,6 +417,18 @@ public class Lexicon {
                         + "countries"
                         + File.separator
                         + "CountryCodes.xml");
+    }
+
+    /**
+     * Throws {@link IllegalStateException} if a gazetteer field is null, with a message
+     * pointing the caller at the {@link Builder} method that loads it. Used by every
+     * lookup method to enforce explicit opt-in.
+     */
+    private static void requireLoaded(Object field, String name, String builderMethod) {
+        if (field == null) {
+            throw new IllegalStateException(
+                    name + " not loaded; call Lexicon.builder()." + builderMethod + "().build() first");
+        }
     }
 
     /**
@@ -308,6 +515,7 @@ public class Lexicon {
     }
 
     public boolean isCountry(String tok) {
+        requireLoaded(countries, "Country gazetteer", "withCountries");
         return countries.contains(tok.toLowerCase());
     }
 
@@ -360,6 +568,7 @@ public class Lexicon {
     }
 
     public String getCountryCode(String country) {
+        requireLoaded(countryCodes, "Country gazetteer", "withCountries");
         String code = (String) countryCodes.get(country.toLowerCase());
         return code;
     }
@@ -478,6 +687,7 @@ public class Lexicon {
     }
 
     public boolean inDictionary(String s, String lang) {
+        requireLoaded(dictionary_en, "Wordforms dictionary", "withWordforms");
         if (s == null)
             return false;
         if ((s.endsWith(".")) | (s.endsWith(",")) | (s.endsWith(":")) | (s.endsWith(";")) | (s.endsWith(".")))
@@ -756,6 +966,7 @@ public class Lexicon {
      * Look-up in first name gazetteer
      */
     public boolean inFirstNames(String s) {
+        requireLoaded(firstNames, "Person-names gazetteer", "withPeople");
         return firstNames.contains(s);
     }
 
@@ -763,12 +974,12 @@ public class Lexicon {
      * Look-up in last name gazetteer
      */
     public boolean inLastNames(String s) {
+        requireLoaded(lastNames, "Person-names gazetteer", "withPeople");
         return lastNames.contains(s);
     }
 
     public List<OrganizationRecord> getOrganizationNamingInfo(String name) {
-        if (researchOrganizations == null)
-            return null;
+        requireLoaded(researchOrganizations, "Research-infrastructure gazetteer", "withResearchInfrastructures");
         return researchOrganizations.get(name.toLowerCase());
     }
 
@@ -776,9 +987,7 @@ public class Lexicon {
      * Soft look-up in journal name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsJournalNames(String s) {
-        if (journalPattern == null) {
-            initJournals();
-        }
+        requireLoaded(journalPattern, "Journal gazetteer", "withJournals");
         List<OffsetPosition> results = journalPattern.matchToken(s);
         return results;
     }
@@ -788,9 +997,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsJournalNames(List<LayoutToken> s) {
-        if (journalPattern == null) {
-            initJournals();
-        }
+        requireLoaded(journalPattern, "Journal gazetteer", "withJournals");
         List<OffsetPosition> results = journalPattern.matchLayoutToken(s);
         return results;
     }
@@ -799,9 +1006,7 @@ public class Lexicon {
      * Soft look-up in journal abbreviated name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsAbbrevJournalNames(String s) {
-        if (abbrevJournalPattern == null) {
-            initJournals();
-        }
+        requireLoaded(abbrevJournalPattern, "Abbreviated journal gazetteer", "withJournals");
         List<OffsetPosition> results = abbrevJournalPattern.matchToken(s);
         return results;
     }
@@ -811,9 +1016,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsAbbrevJournalNames(List<LayoutToken> s) {
-        if (abbrevJournalPattern == null) {
-            initJournals();
-        }
+        requireLoaded(abbrevJournalPattern, "Abbreviated journal gazetteer", "withJournals");
         List<OffsetPosition> results = abbrevJournalPattern.matchLayoutToken(s);
         return results;
     }
@@ -822,9 +1025,7 @@ public class Lexicon {
      * Soft look-up in conference/proceedings name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsConferenceNames(String s) {
-        if (conferencePattern == null) {
-            initConferences();
-        }
+        requireLoaded(conferencePattern, "Conference gazetteer", "withConferences");
         List<OffsetPosition> results = conferencePattern.matchToken(s);
         return results;
     }
@@ -834,9 +1035,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsConferenceNames(List<LayoutToken> s) {
-        if (conferencePattern == null) {
-            initConferences();
-        }
+        requireLoaded(conferencePattern, "Conference gazetteer", "withConferences");
         List<OffsetPosition> results = conferencePattern.matchLayoutToken(s);
         return results;
     }
@@ -845,9 +1044,7 @@ public class Lexicon {
      * Soft look-up in conference/proceedings name gazetteer with token positions
      */
     public List<OffsetPosition> tokenPositionsPublisherNames(String s) {
-        if (publisherPattern == null) {
-            initPublishers();
-        }
+        requireLoaded(publisherPattern, "Publisher gazetteer", "withPublishers");
         List<OffsetPosition> results = publisherPattern.matchToken(s);
         return results;
     }
@@ -857,9 +1054,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsPublisherNames(List<LayoutToken> s) {
-        if (publisherPattern == null) {
-            initPublishers();
-        }
+        requireLoaded(publisherPattern, "Publisher gazetteer", "withPublishers");
         List<OffsetPosition> results = publisherPattern.matchLayoutToken(s);
         return results;
     }
@@ -869,9 +1064,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsCollaborationNames(List<LayoutToken> s) {
-        if (collaborationPattern == null) {
-            initCollaborations();
-        }
+        requireLoaded(collaborationPattern, "Collaboration gazetteer", "withCollaborations");
         List<OffsetPosition> results = collaborationPattern.matchLayoutToken(s);
         return results;
     }
@@ -881,8 +1074,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsFunderNames(List<LayoutToken> s) {
-        if (funderPattern == null)
-            initFunders();
+        requireLoaded(funderPattern, "Funder gazetteer", "withFunders");
         List<OffsetPosition> results = funderPattern.matchLayoutToken(s, true, true);
         return results;
     }
@@ -892,8 +1084,10 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsResearchInfrastructureNames(List<LayoutToken> s) {
-        if (researchInfrastructurePattern == null)
-            initResearchInfrastructures();
+        requireLoaded(
+                researchInfrastructurePattern,
+                "Research-infrastructure gazetteer",
+                "withResearchInfrastructures");
         List<OffsetPosition> results = researchInfrastructurePattern.matchLayoutToken(s, true, true);
         return results;
     }
@@ -902,9 +1096,7 @@ public class Lexicon {
      * Soft look-up in city name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsCityNames(String s) {
-        if (cityPattern == null) {
-            initCities();
-        }
+        requireLoaded(cityPattern, "City gazetteer", "withCities");
         List<OffsetPosition> results = cityPattern.matchToken(s);
         return results;
     }
@@ -914,9 +1106,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsCityNames(List<LayoutToken> s) {
-        if (cityPattern == null) {
-            initCities();
-        }
+        requireLoaded(cityPattern, "City gazetteer", "withCities");
         List<OffsetPosition> results = cityPattern.matchLayoutToken(s);
         return results;
     }
@@ -927,9 +1117,7 @@ public class Lexicon {
      * Soft look-up in organisation name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsOrganisationNames(String s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
+        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
         List<OffsetPosition> results = organisationPattern.matchToken(s);
         return results;
     }
@@ -939,9 +1127,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsOrganisationNames(List<LayoutToken> s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
+        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
         List<OffsetPosition> results = organisationPattern.matchLayoutToken(s);
         return results;
     }
@@ -951,9 +1137,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsCountryNames(List<LayoutToken> s) {
-        if (countryPattern == null) {
-            initCountryPatterns();
-        }
+        requireLoaded(countryPattern, "Country gazetteer", "withCountries");
         List<OffsetPosition> results = countryPattern.matchLayoutToken(s);
         return results;
     }
@@ -966,9 +1150,7 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input string
      */
     public List<OffsetPosition> charPositionsOrganisationNames(String s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
+        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
         List<OffsetPosition> results = organisationPattern.matchCharacter(s);
         return results;
     }
@@ -982,9 +1164,7 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input sequence
      */
     public List<OffsetPosition> charPositionsOrganisationNames(List<LayoutToken> s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
+        requireLoaded(organisationPattern, "Organisation gazetteer", "withOrganisations");
         List<OffsetPosition> results = organisationPattern.matchCharacterLayoutToken(s);
         return results;
     }
@@ -993,9 +1173,7 @@ public class Lexicon {
      * Soft look-up in organisation form name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsOrgForm(String s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
+        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
         List<OffsetPosition> results = orgFormPattern.matchToken(s);
         return results;
     }
@@ -1005,9 +1183,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsOrgForm(List<LayoutToken> s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
+        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
         List<OffsetPosition> results = orgFormPattern.matchLayoutToken(s);
         return results;
     }
@@ -1020,9 +1196,7 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input string
      */
     public List<OffsetPosition> charPositionsOrgForm(String s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
+        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
         List<OffsetPosition> results = orgFormPattern.matchCharacter(s);
         return results;
     }
@@ -1035,9 +1209,7 @@ public class Lexicon {
      * @return a list of positions referring to the character position in the input sequence
      */
     public List<OffsetPosition> charPositionsOrgForm(List<LayoutToken> s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
+        requireLoaded(orgFormPattern, "Organisation-form gazetteer", "withOrgForms");
         List<OffsetPosition> results = orgFormPattern.matchCharacterLayoutToken(s);
         return results;
     }
@@ -1046,9 +1218,7 @@ public class Lexicon {
      * Soft look-up in location name gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsLocationNames(String s) {
-        if (locationPattern == null) {
-            initLocations();
-        }
+        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
         List<OffsetPosition> results = locationPattern.matchToken(s);
         return results;
     }
@@ -1058,54 +1228,46 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsLocationNames(List<LayoutToken> s) {
-        if (locationPattern == null) {
-            initLocations();
-        }
+        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
         List<OffsetPosition> results = locationPattern.matchLayoutToken(s);
         return results;
     }
 
-     /**
-      * Soft look-up in location name gazetteer for a string, return a list of positions referring
-      * to the character positions within the string.
-      * <p>
-      * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
-      *
-      * @param s the input string
-      * @return a list of positions referring to the character position in the input string
-      */
-     public List<OffsetPosition> charPositionsLocationNames(String s) {
-         if (locationPattern == null) {
-             initLocations();
-         }
-         List<OffsetPosition> results = locationPattern.matchCharacter(s);
-         return results;
-     }
+    /**
+     * Soft look-up in location name gazetteer for a string, return a list of positions referring
+     * to the character positions within the string.
+     * <p>
+     * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
+     *
+     * @param s the input string
+     * @return a list of positions referring to the character position in the input string
+     */
+    public List<OffsetPosition> charPositionsLocationNames(String s) {
+        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
+        List<OffsetPosition> results = locationPattern.matchCharacter(s);
+        return results;
+    }
 
-     /**
-      * Soft look-up in location name gazetteer for a list of LayoutToken, return a list of
-      * positions referring to the character positions in the input sequence.
-      * <p>
-      * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
-      *
-      * @param s the input list of LayoutToken
-      * @return a list of positions referring to the character position in the input sequence
-      */
-     public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
-         if (locationPattern == null) {
-             initLocations();
-         }
-         List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
-         return results;
-     }
+    /**
+     * Soft look-up in location name gazetteer for a list of LayoutToken, return a list of
+     * positions referring to the character positions in the input sequence.
+     * <p>
+     * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
+     *
+     * @param s the input list of LayoutToken
+     * @return a list of positions referring to the character position in the input sequence
+     */
+    public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
+        requireLoaded(locationPattern, "Location gazetteer", "withLocations");
+        List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
+        return results;
+    }
 
     /**
      * Soft look-up in person title gazetteer for a given string with token positions
      */
     public List<OffsetPosition> tokenPositionsPersonTitle(String s) {
-        if (personTitlePattern == null) {
-            initPersonTitles();
-        }
+        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
         List<OffsetPosition> results = personTitlePattern.matchToken(s);
         return results;
     }
@@ -1115,9 +1277,7 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsPersonTitle(List<LayoutToken> s) {
-        if (personTitlePattern == null) {
-            initPersonTitles();
-        }
+        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
         List<OffsetPosition> results = personTitlePattern.matchLayoutToken(s);
         return results;
     }
@@ -1127,43 +1287,37 @@ public class Lexicon {
      * with token positions
      */
     public List<OffsetPosition> tokenPositionsPersonSuffix(List<LayoutToken> s) {
-        if (personSuffixPattern == null) {
-            initPersonSuffix();
-        }
+        requireLoaded(personSuffixPattern, "Person-suffix gazetteer", "withPersonSuffixes");
         List<OffsetPosition> results = personSuffixPattern.matchLayoutToken(s);
         return results;
     }
 
-     /**
-      * Soft look-up in person title name gazetteer for a string.
-      * It returns a list of positions referring to the character positions within the string.
-      *
-      * @param s the input string
-      * @return a list of positions referring to the character position in the input string
-      */
-     public List<OffsetPosition> charPositionsPersonTitle(String s) {
-         if (personTitlePattern == null) {
-             initPersonTitles();
-         }
-         List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
-         return results;
-     }
+    /**
+     * Soft look-up in person title name gazetteer for a string.
+     * It returns a list of positions referring to the character positions within the string.
+     *
+     * @param s the input string
+     * @return a list of positions referring to the character position in the input string
+     */
+    public List<OffsetPosition> charPositionsPersonTitle(String s) {
+        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
+        List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
+        return results;
+    }
 
-     /**
-      * Soft look-up in person title name gazetteer for a list of LayoutToken.
-      * It return a list of positions referring to the character positions in the input
-      * sequence.
-      *
-      * @param s the input list of LayoutToken
-      * @return a list of positions referring to the character position in the input sequence
-      */
-     public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
-         if (personTitlePattern == null) {
-             initPersonTitles();
-         }
-         List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
-         return results;
-     }
+    /**
+     * Soft look-up in person title name gazetteer for a list of LayoutToken.
+     * It return a list of positions referring to the character positions in the input
+     * sequence.
+     *
+     * @param s the input list of LayoutToken
+     * @return a list of positions referring to the character position in the input sequence
+     */
+    public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
+        requireLoaded(personTitlePattern, "Person-title gazetteer", "withPersonTitles");
+        List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
+        return results;
+    }
 
     /**
      * Identify in tokenized input the positions of identifier patterns with token positions
@@ -1214,27 +1368,27 @@ public class Lexicon {
         return convertStringOffsetToTokenOffset(textResult, tokens);
     }
 
-     /**
-      * Identify in tokenized input the positions of ISSN patterns with token positions
-      */
-     public List<OffsetPosition> tokenPositionsISSNPattern(List<LayoutToken> tokens) {
-         List<OffsetPosition> result = new ArrayList<OffsetPosition>();
+    /**
+     * Identify in tokenized input the positions of ISSN patterns with token positions
+     */
+    public List<OffsetPosition> tokenPositionsISSNPattern(List<LayoutToken> tokens) {
+        List<OffsetPosition> result = new ArrayList<OffsetPosition>();
 
-         // TBD !
+        // TBD !
 
-         return result;
-     }
+        return result;
+    }
 
-     /**
-      * Identify in tokenized input the positions of ISBN patterns with token positions
-      */
-     public List<OffsetPosition> tokenPositionsISBNPattern(List<LayoutToken> tokens) {
-         List<OffsetPosition> result = new ArrayList<OffsetPosition>();
+    /**
+     * Identify in tokenized input the positions of ISBN patterns with token positions
+     */
+    public List<OffsetPosition> tokenPositionsISBNPattern(List<LayoutToken> tokens) {
+        List<OffsetPosition> result = new ArrayList<OffsetPosition>();
 
-         // TBD !!
+        // TBD !!
 
-         return result;
-     }
+        return result;
+    }
 
     /**
      * Identify in tokenized input the positions of an URL pattern with token positions
@@ -1365,42 +1519,42 @@ public class Lexicon {
         return new OffsetPosition(startTokenIndex, endTokensIndex);
     }
 
-     public static OffsetPosition getTokenIndexMatchingURLDestination(List<LayoutToken> urlTokens, String destination) {
-         String urlString = LayoutTokensUtil.toText(urlTokens);
+    public static OffsetPosition getTokenIndexMatchingURLDestination(List<LayoutToken> urlTokens, String destination) {
+        String urlString = LayoutTokensUtil.toText(urlTokens);
 
-         String joinedNoSpaces = urlString.replaceAll("\\s", "");
-         String destinationNoSpaces = destination.replaceAll("\\s", "");
+        String joinedNoSpaces = urlString.replaceAll("\\s", "");
+        String destinationNoSpaces = destination.replaceAll("\\s", "");
 
-         // Find the start index in the space-less string
-         int destStartNoSpaces = joinedNoSpaces.indexOf(destinationNoSpaces);
-         if (destStartNoSpaces == -1) {
-             // Not found, handle as needed
-             return new OffsetPosition();
-         }
+        // Find the start index in the space-less string
+        int destStartNoSpaces = joinedNoSpaces.indexOf(destinationNoSpaces);
+        if (destStartNoSpaces == -1) {
+            // Not found, handle as needed
+            return new OffsetPosition();
+        }
 
-         int destEndNoSpaces = destStartNoSpaces + destinationNoSpaces.length();
+        int destEndNoSpaces = destStartNoSpaces + destinationNoSpaces.length();
 
-         // Map to token indices
-         int charCount = 0;
-         int indexStart = -1, indexEnd = -1;
-         for (int i = 0; i < urlTokens.size(); i++) {
-             String tokenText = urlTokens.get(i).getText();
-             for (int j = 0; j < tokenText.length(); j++) {
-                 if (!Character.isWhitespace(tokenText.charAt(j))) {
-                     if (charCount == destStartNoSpaces && indexStart == -1) {
-                         indexStart = i;
-                     }
-                     if (charCount == destEndNoSpaces - 1) {
-                         indexEnd = i;
-                     }
-                     charCount++;
-                 }
-             }
-             if (indexEnd != -1)
-                 break;
-         }
-         return new OffsetPosition(indexStart, indexEnd);
-     }
+        // Map to token indices
+        int charCount = 0;
+        int indexStart = -1, indexEnd = -1;
+        for (int i = 0; i < urlTokens.size(); i++) {
+            String tokenText = urlTokens.get(i).getText();
+            for (int j = 0; j < tokenText.length(); j++) {
+                if (!Character.isWhitespace(tokenText.charAt(j))) {
+                    if (charCount == destStartNoSpaces && indexStart == -1) {
+                        indexStart = i;
+                    }
+                    if (charCount == destEndNoSpaces - 1) {
+                        indexEnd = i;
+                    }
+                    charCount++;
+                }
+            }
+            if (indexEnd != -1)
+                break;
+        }
+        return new OffsetPosition(indexStart, indexEnd);
+    }
 
     /**
      * This method returns the character offsets in relation to the string obtained by the layout tokens.

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -56,11 +56,11 @@ public class Lexicon {
     private FastMatcher publisherPattern = null;
     private FastMatcher journalPattern = null;
     private FastMatcher cityPattern = null;
-    private FastMatcher organisationPattern = null;
+    // private FastMatcher organisationPattern = null;
     private FastMatcher researchInfrastructurePattern = null;
     private FastMatcher locationPattern = null;
     private FastMatcher countryPattern = null;
-    private FastMatcher orgFormPattern = null;
+    // private FastMatcher orgFormPattern = null;
     private FastMatcher collaborationPattern = null;
     private FastMatcher funderPattern = null;
     private FastMatcher personTitlePattern = null;
@@ -520,43 +520,47 @@ public class Lexicon {
         }
     }
 
-    public void initOrganisations() {
-        try {
-            organisationPattern = new FastMatcher(
-                    new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/WikiOrganizations.lst"));
-            organisationPattern.loadTerms(
-                    new File(GrobidProperties.getGrobidHomePath()
-                            +
-                            "/lexicon/organisations/government.government_agency"));
-            organisationPattern.loadTerms(
-                    new File(GrobidProperties.getGrobidHomePath()
-                            +
-                            "/lexicon/organisations/known_corporations.lst"));
-            organisationPattern.loadTerms(
-                    new File(GrobidProperties.getGrobidHomePath()
-                            +
-                            "/lexicon/organisations/venture_capital.venture_funded_company"));
-        } catch (PatternSyntaxException e) {
-            throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
-        } catch (IOException e) {
-            throw new GrobidResourceException("Cannot add term to matcher, because the lexicon resource file "
-                    +
-                    "does not exist or cannot be read.", e);
-        } catch (Exception e) {
-            throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
-        }
-    }
+    // Disabled: the organisation/org-form gazetteers are loaded into RAM but
+    // no parser or feature vector queries them today. Commented out (not
+    // deleted) so the matchers can be re-enabled when the affiliation/header
+    // feature pipelines are extended to use them. Lexicon files preserved.
+    // public void initOrganisations() {
+    //     try {
+    //         organisationPattern = new FastMatcher(
+    //                 new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/WikiOrganizations.lst"));
+    //         organisationPattern.loadTerms(
+    //                 new File(GrobidProperties.getGrobidHomePath()
+    //                         +
+    //                         "/lexicon/organisations/government.government_agency"));
+    //         organisationPattern.loadTerms(
+    //                 new File(GrobidProperties.getGrobidHomePath()
+    //                         +
+    //                         "/lexicon/organisations/known_corporations.lst"));
+    //         organisationPattern.loadTerms(
+    //                 new File(GrobidProperties.getGrobidHomePath()
+    //                         +
+    //                         "/lexicon/organisations/venture_capital.venture_funded_company"));
+    //     } catch (PatternSyntaxException e) {
+    //         throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
+    //     } catch (IOException e) {
+    //         throw new GrobidResourceException("Cannot add term to matcher, because the lexicon resource file "
+    //                 +
+    //                 "does not exist or cannot be read.", e);
+    //     } catch (Exception e) {
+    //         throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
+    //     }
+    // }
 
-    public void initOrgForms() {
-        try {
-            orgFormPattern = new FastMatcher(
-                    new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/orgClosings.txt"));
-        } catch (PatternSyntaxException e) {
-            throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
-        } catch (Exception e) {
-            throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
-        }
-    }
+    // public void initOrgForms() {
+    //     try {
+    //         orgFormPattern = new FastMatcher(
+    //                 new File(GrobidProperties.getGrobidHomePath() + "/lexicon/organisations/orgClosings.txt"));
+    //     } catch (PatternSyntaxException e) {
+    //         throw new GrobidResourceException("Error when compiling lexicon matcher for organisations.", e);
+    //     } catch (Exception e) {
+    //         throw new GrobidException("An exception occurred while running Grobid Lexicon init.", e);
+    //     }
+    // }
 
     public void initLocations() {
         try {
@@ -918,30 +922,30 @@ public class Lexicon {
         return results;
     }
 
-    /** Organisation names **/
-
-    /**
-     * Soft look-up in organisation name gazetteer for a given string with token positions
-     */
-    public List<OffsetPosition> tokenPositionsOrganisationNames(String s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
-        List<OffsetPosition> results = organisationPattern.matchToken(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in organisation name gazetteer for a given list of LayoutToken objects
-     * with token positions
-     */
-    public List<OffsetPosition> tokenPositionsOrganisationNames(List<LayoutToken> s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
-        List<OffsetPosition> results = organisationPattern.matchLayoutToken(s);
-        return results;
-    }
+    // /** Organisation names **/
+    //
+    // /**
+    //  * Soft look-up in organisation name gazetteer for a given string with token positions
+    //  */
+    // public List<OffsetPosition> tokenPositionsOrganisationNames(String s) {
+    //     if (organisationPattern == null) {
+    //         initOrganisations();
+    //     }
+    //     List<OffsetPosition> results = organisationPattern.matchToken(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in organisation name gazetteer for a given list of LayoutToken objects
+    //  * with token positions
+    //  */
+    // public List<OffsetPosition> tokenPositionsOrganisationNames(List<LayoutToken> s) {
+    //     if (organisationPattern == null) {
+    //         initOrganisations();
+    //     }
+    //     List<OffsetPosition> results = organisationPattern.matchLayoutToken(s);
+    //     return results;
+    // }
 
     /**
      * Soft look-up in country name gazetteer for a given list of LayoutToken objects
@@ -955,89 +959,89 @@ public class Lexicon {
         return results;
     }
 
-    /**
-     * Soft look-up in organisation names gazetteer for a string.
-     * It return a list of positions referring to the character positions within the string.
-     *
-     * @param s the input string
-     * @return a list of positions referring to the character position in the input string
-     */
-    public List<OffsetPosition> charPositionsOrganisationNames(String s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
-        List<OffsetPosition> results = organisationPattern.matchCharacter(s);
-        return results;
-    }
+    // /**
+    //  * Soft look-up in organisation names gazetteer for a string.
+    //  * It return a list of positions referring to the character positions within the string.
+    //  *
+    //  * @param s the input string
+    //  * @return a list of positions referring to the character position in the input string
+    //  */
+    // public List<OffsetPosition> charPositionsOrganisationNames(String s) {
+    //     if (organisationPattern == null) {
+    //         initOrganisations();
+    //     }
+    //     List<OffsetPosition> results = organisationPattern.matchCharacter(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in organisation names gazetteer for a tokenize sequence.
+    //  * It return a list of positions referring to the character positions within the input
+    //  * sequence.
+    //  *
+    //  * @param s the input list of LayoutToken
+    //  * @return a list of positions referring to the character position in the input sequence
+    //  */
+    // public List<OffsetPosition> charPositionsOrganisationNames(List<LayoutToken> s) {
+    //     if (organisationPattern == null) {
+    //         initOrganisations();
+    //     }
+    //     List<OffsetPosition> results = organisationPattern.matchCharacterLayoutToken(s);
+    //     return results;
+    // }
 
-    /**
-     * Soft look-up in organisation names gazetteer for a tokenize sequence.
-     * It return a list of positions referring to the character positions within the input
-     * sequence.
-     *
-     * @param s the input list of LayoutToken
-     * @return a list of positions referring to the character position in the input sequence
-     */
-    public List<OffsetPosition> charPositionsOrganisationNames(List<LayoutToken> s) {
-        if (organisationPattern == null) {
-            initOrganisations();
-        }
-        List<OffsetPosition> results = organisationPattern.matchCharacterLayoutToken(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in organisation form name gazetteer for a given string with token positions
-     */
-    public List<OffsetPosition> tokenPositionsOrgForm(String s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
-        List<OffsetPosition> results = orgFormPattern.matchToken(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in organisation form name gazetteer for a given list of LayoutToken objects
-     * with token positions
-     */
-    public List<OffsetPosition> tokenPositionsOrgForm(List<LayoutToken> s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
-        List<OffsetPosition> results = orgFormPattern.matchLayoutToken(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in org form names gazetteer for a string.
-     * It return a list of positions referring to the character positions within the string.
-     *
-     * @param s the input string
-     * @return a list of positions referring to the character position in the input string
-     */
-    public List<OffsetPosition> charPositionsOrgForm(String s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
-        List<OffsetPosition> results = orgFormPattern.matchCharacter(s);
-        return results;
-    }
-
-    /**
-     * Soft look-up in org form names gazetteer for a tokenized string.
-     * It return a list of positions referring to the character positions within the sequence.
-     *
-     * @param s the input list of LayoutToken
-     * @return a list of positions referring to the character position in the input sequence
-     */
-    public List<OffsetPosition> charPositionsOrgForm(List<LayoutToken> s) {
-        if (orgFormPattern == null) {
-            initOrgForms();
-        }
-        List<OffsetPosition> results = orgFormPattern.matchCharacterLayoutToken(s);
-        return results;
-    }
+    // /**
+    //  * Soft look-up in organisation form name gazetteer for a given string with token positions
+    //  */
+    // public List<OffsetPosition> tokenPositionsOrgForm(String s) {
+    //     if (orgFormPattern == null) {
+    //         initOrgForms();
+    //     }
+    //     List<OffsetPosition> results = orgFormPattern.matchToken(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in organisation form name gazetteer for a given list of LayoutToken objects
+    //  * with token positions
+    //  */
+    // public List<OffsetPosition> tokenPositionsOrgForm(List<LayoutToken> s) {
+    //     if (orgFormPattern == null) {
+    //         initOrgForms();
+    //     }
+    //     List<OffsetPosition> results = orgFormPattern.matchLayoutToken(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in org form names gazetteer for a string.
+    //  * It return a list of positions referring to the character positions within the string.
+    //  *
+    //  * @param s the input string
+    //  * @return a list of positions referring to the character position in the input string
+    //  */
+    // public List<OffsetPosition> charPositionsOrgForm(String s) {
+    //     if (orgFormPattern == null) {
+    //         initOrgForms();
+    //     }
+    //     List<OffsetPosition> results = orgFormPattern.matchCharacter(s);
+    //     return results;
+    // }
+    //
+    // /**
+    //  * Soft look-up in org form names gazetteer for a tokenized string.
+    //  * It return a list of positions referring to the character positions within the sequence.
+    //  *
+    //  * @param s the input list of LayoutToken
+    //  * @return a list of positions referring to the character position in the input sequence
+    //  */
+    // public List<OffsetPosition> charPositionsOrgForm(List<LayoutToken> s) {
+    //     if (orgFormPattern == null) {
+    //         initOrgForms();
+    //     }
+    //     List<OffsetPosition> results = orgFormPattern.matchCharacterLayoutToken(s);
+    //     return results;
+    // }
 
     /**
      * Soft look-up in location name gazetteer for a given string with token positions

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -70,20 +70,13 @@ public class Lexicon {
         if (instance == null) {
             synchronized (Lexicon.class) {
                 if (instance == null) {
-                    getNewInstance();
+                    LOGGER.debug("Get new instance of Lexicon");
+                    GrobidProperties.getInstance();
+                    instance = new Lexicon();
                 }
             }
         }
         return instance;
-    }
-
-    /**
-     * Creates a new instance.
-     */
-    private static synchronized void getNewInstance() {
-        LOGGER.debug("Get new instance of Lexicon");
-        GrobidProperties.getInstance();
-        instance = new Lexicon();
     }
 
     /**

--- a/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
+++ b/grobid-core/src/main/java/org/grobid/core/lexicon/Lexicon.java
@@ -773,75 +773,11 @@ public class Lexicon {
         return lastNames.contains(s);
     }
 
-    // Disabled: no callers in production or tests.
-    // /**
-    //  * Indicate if we have a punctuation
-    //  */
-    // public boolean isPunctuation(String s) {
-    //     if (s.length() != 1)
-    //         return false;
-    //     else {
-    //         char c = s.charAt(0);
-    //         if ((!Character.isLetterOrDigit(c)) & !(c == '-'))
-    //             return true;
-    //     }
-    //     return false;
-    // }
-
     public List<OrganizationRecord> getOrganizationNamingInfo(String name) {
         if (researchOrganizations == null)
             return null;
         return researchOrganizations.get(name.toLowerCase());
     }
-
-    // Disabled: no callers in production or tests.
-    // /**
-    //  * Map the language codes used by the language identifier component to the normal
-    //  * language name.
-    //  * <p>
-    //  * Note: due to an older bug, kr is currently map to Korean too - this should
-    //  * disappear at some point in the future after retraining of models
-    //  *
-    //  * @param code the language to be mapped
-    //  */
-    // public String mapLanguageCode(String code) {
-    //     if (code == null)
-    //         return "";
-    //     else if (code.length() == 0)
-    //         return "";
-    //     else if (code.equals(Language.EN))
-    //         return "English";
-    //     else if (code.equals(Language.FR))
-    //         return "French";
-    //     else if (code.equals(Language.DE))
-    //         return "German";
-    //     else if (code.equals("cat"))
-    //         return "Catalan";
-    //     else if (code.equals("dk"))
-    //         return "Danish";
-    //     else if (code.equals("ee"))
-    //         return "Estonian";
-    //     else if (code.equals("fi"))
-    //         return "Finish";
-    //     else if (code.equals("it"))
-    //         return "Italian";
-    //     else if (code.equals("jp"))
-    //         return "Japanese";
-    //     else if (code.equals("kr") || code.equals("ko"))
-    //         return "Korean";
-    //     else if (code.equals("nl"))
-    //         return "Deutch";
-    //     else if (code.equals("no"))
-    //         return "Norvegian";
-    //     else if (code.equals("se"))
-    //         return "Swedish";
-    //     else if (code.equals("sorb"))
-    //         return "Sorbian";
-    //     else if (code.equals("tr"))
-    //         return "Turkish";
-    //     else
-    //         return "";
-    // }
 
     /**
      * Soft look-up in journal name gazetteer with token positions
@@ -1136,40 +1072,39 @@ public class Lexicon {
         return results;
     }
 
-    // Disabled: only test callers, no production usage.
-    // /**
-    //  * Soft look-up in location name gazetteer for a string, return a list of positions referring
-    //  * to the character positions within the string.
-    //  * <p>
-    //  * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
-    //  *
-    //  * @param s the input string
-    //  * @return a list of positions referring to the character position in the input string
-    //  */
-    // public List<OffsetPosition> charPositionsLocationNames(String s) {
-    //     if (locationPattern == null) {
-    //         initLocations();
-    //     }
-    //     List<OffsetPosition> results = locationPattern.matchCharacter(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in location name gazetteer for a list of LayoutToken, return a list of
-    //  * positions referring to the character positions in the input sequence.
-    //  * <p>
-    //  * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
-    //  *
-    //  * @param s the input list of LayoutToken
-    //  * @return a list of positions referring to the character position in the input sequence
-    //  */
-    // public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
-    //     if (locationPattern == null) {
-    //         initLocations();
-    //     }
-    //     List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
-    //     return results;
-    // }
+     /**
+      * Soft look-up in location name gazetteer for a string, return a list of positions referring
+      * to the character positions within the string.
+      * <p>
+      * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
+      *
+      * @param s the input string
+      * @return a list of positions referring to the character position in the input string
+      */
+     public List<OffsetPosition> charPositionsLocationNames(String s) {
+         if (locationPattern == null) {
+             initLocations();
+         }
+         List<OffsetPosition> results = locationPattern.matchCharacter(s);
+         return results;
+     }
+
+     /**
+      * Soft look-up in location name gazetteer for a list of LayoutToken, return a list of
+      * positions referring to the character positions in the input sequence.
+      * <p>
+      * For example "The car is in Milan" as Milan is a location, would return OffsetPosition(14,19)
+      *
+      * @param s the input list of LayoutToken
+      * @return a list of positions referring to the character position in the input sequence
+      */
+     public List<OffsetPosition> charPositionsLocationNames(List<LayoutToken> s) {
+         if (locationPattern == null) {
+             initLocations();
+         }
+         List<OffsetPosition> results = locationPattern.matchCharacterLayoutToken(s);
+         return results;
+     }
 
     /**
      * Soft look-up in person title gazetteer for a given string with token positions
@@ -1206,37 +1141,36 @@ public class Lexicon {
         return results;
     }
 
-    // Disabled: only test callers, no production usage.
-    // /**
-    //  * Soft look-up in person title name gazetteer for a string.
-    //  * It return a list of positions referring to the character positions within the string.
-    //  *
-    //  * @param s the input string
-    //  * @return a list of positions referring to the character position in the input string
-    //  */
-    // public List<OffsetPosition> charPositionsPersonTitle(String s) {
-    //     if (personTitlePattern == null) {
-    //         initPersonTitles();
-    //     }
-    //     List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
-    //     return results;
-    // }
-    //
-    // /**
-    //  * Soft look-up in person title name gazetteer for a list of LayoutToken.
-    //  * It return a list of positions referring to the character positions in the input
-    //  * sequence.
-    //  *
-    //  * @param s the input list of LayoutToken
-    //  * @return a list of positions referring to the character position in the input sequence
-    //  */
-    // public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
-    //     if (personTitlePattern == null) {
-    //         initPersonTitles();
-    //     }
-    //     List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
-    //     return results;
-    // }
+     /**
+      * Soft look-up in person title name gazetteer for a string.
+      * It returns a list of positions referring to the character positions within the string.
+      *
+      * @param s the input string
+      * @return a list of positions referring to the character position in the input string
+      */
+     public List<OffsetPosition> charPositionsPersonTitle(String s) {
+         if (personTitlePattern == null) {
+             initPersonTitles();
+         }
+         List<OffsetPosition> results = personTitlePattern.matchCharacter(s);
+         return results;
+     }
+
+     /**
+      * Soft look-up in person title name gazetteer for a list of LayoutToken.
+      * It return a list of positions referring to the character positions in the input
+      * sequence.
+      *
+      * @param s the input list of LayoutToken
+      * @return a list of positions referring to the character position in the input sequence
+      */
+     public List<OffsetPosition> charPositionsPersonTitle(List<LayoutToken> s) {
+         if (personTitlePattern == null) {
+             initPersonTitles();
+         }
+         List<OffsetPosition> results = personTitlePattern.matchCharacterLayoutToken(s);
+         return results;
+     }
 
     /**
      * Identify in tokenized input the positions of identifier patterns with token positions
@@ -1287,28 +1221,27 @@ public class Lexicon {
         return convertStringOffsetToTokenOffset(textResult, tokens);
     }
 
-    // Disabled: stub returning an empty list, never implemented, no callers.
-    // /**
-    //  * Identify in tokenized input the positions of ISSN patterns with token positions
-    //  */
-    // public List<OffsetPosition> tokenPositionsISSNPattern(List<LayoutToken> tokens) {
-    //     List<OffsetPosition> result = new ArrayList<OffsetPosition>();
-    //
-    //     // TBD !
-    //
-    //     return result;
-    // }
-    //
-    // /**
-    //  * Identify in tokenized input the positions of ISBN patterns with token positions
-    //  */
-    // public List<OffsetPosition> tokenPositionsISBNPattern(List<LayoutToken> tokens) {
-    //     List<OffsetPosition> result = new ArrayList<OffsetPosition>();
-    //
-    //     // TBD !!
-    //
-    //     return result;
-    // }
+     /**
+      * Identify in tokenized input the positions of ISSN patterns with token positions
+      */
+     public List<OffsetPosition> tokenPositionsISSNPattern(List<LayoutToken> tokens) {
+         List<OffsetPosition> result = new ArrayList<OffsetPosition>();
+
+         // TBD !
+
+         return result;
+     }
+
+     /**
+      * Identify in tokenized input the positions of ISBN patterns with token positions
+      */
+     public List<OffsetPosition> tokenPositionsISBNPattern(List<LayoutToken> tokens) {
+         List<OffsetPosition> result = new ArrayList<OffsetPosition>();
+
+         // TBD !!
+
+         return result;
+     }
 
     /**
      * Identify in tokenized input the positions of an URL pattern with token positions
@@ -1439,43 +1372,42 @@ public class Lexicon {
         return new OffsetPosition(startTokenIndex, endTokensIndex);
     }
 
-    // Disabled: only test callers, no production usage.
-    // public static OffsetPosition getTokenIndexMatchingURLDestination(List<LayoutToken> urlTokens, String destination) {
-    //     String urlString = LayoutTokensUtil.toText(urlTokens);
-    //
-    //     String joinedNoSpaces = urlString.replaceAll("\\s", "");
-    //     String destinationNoSpaces = destination.replaceAll("\\s", "");
-    //
-    //     // Find the start index in the space-less string
-    //     int destStartNoSpaces = joinedNoSpaces.indexOf(destinationNoSpaces);
-    //     if (destStartNoSpaces == -1) {
-    //         // Not found, handle as needed
-    //         return new OffsetPosition();
-    //     }
-    //
-    //     int destEndNoSpaces = destStartNoSpaces + destinationNoSpaces.length();
-    //
-    //     // Map to token indices
-    //     int charCount = 0;
-    //     int indexStart = -1, indexEnd = -1;
-    //     for (int i = 0; i < urlTokens.size(); i++) {
-    //         String tokenText = urlTokens.get(i).getText();
-    //         for (int j = 0; j < tokenText.length(); j++) {
-    //             if (!Character.isWhitespace(tokenText.charAt(j))) {
-    //                 if (charCount == destStartNoSpaces && indexStart == -1) {
-    //                     indexStart = i;
-    //                 }
-    //                 if (charCount == destEndNoSpaces - 1) {
-    //                     indexEnd = i;
-    //                 }
-    //                 charCount++;
-    //             }
-    //         }
-    //         if (indexEnd != -1)
-    //             break;
-    //     }
-    //     return new OffsetPosition(indexStart, indexEnd);
-    // }
+     public static OffsetPosition getTokenIndexMatchingURLDestination(List<LayoutToken> urlTokens, String destination) {
+         String urlString = LayoutTokensUtil.toText(urlTokens);
+
+         String joinedNoSpaces = urlString.replaceAll("\\s", "");
+         String destinationNoSpaces = destination.replaceAll("\\s", "");
+
+         // Find the start index in the space-less string
+         int destStartNoSpaces = joinedNoSpaces.indexOf(destinationNoSpaces);
+         if (destStartNoSpaces == -1) {
+             // Not found, handle as needed
+             return new OffsetPosition();
+         }
+
+         int destEndNoSpaces = destStartNoSpaces + destinationNoSpaces.length();
+
+         // Map to token indices
+         int charCount = 0;
+         int indexStart = -1, indexEnd = -1;
+         for (int i = 0; i < urlTokens.size(); i++) {
+             String tokenText = urlTokens.get(i).getText();
+             for (int j = 0; j < tokenText.length(); j++) {
+                 if (!Character.isWhitespace(tokenText.charAt(j))) {
+                     if (charCount == destStartNoSpaces && indexStart == -1) {
+                         indexStart = i;
+                     }
+                     if (charCount == destEndNoSpaces - 1) {
+                         indexEnd = i;
+                     }
+                     charCount++;
+                 }
+             }
+             if (indexEnd != -1)
+                 break;
+         }
+         return new OffsetPosition(indexStart, indexEnd);
+     }
 
     /**
      * This method returns the character offsets in relation to the string obtained by the layout tokens.

--- a/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
@@ -85,57 +85,55 @@ public class LexiconIntegrationTest {
         assertThat(inJournalNames.get(0).end, is(2));
     }
 
-    // Disabled together with charPositionsLocationNames in Lexicon (only test
-    // callers, no production usage). Restore in tandem when re-enabled.
-    // /**
-    //  * Locations
-    //  **/
-    //
-    // @Test
-    // public void testGetPositionInLocation_case1() throws Exception {
-    //     final String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
-    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
-    //
-    //     assertThat(positions, hasSize(15));
-    //     assertThat(positions.get(0).start, is(0));
-    //     assertThat(positions.get(0).end, is(2));
-    // }
-    //
-    // @Test
-    // public void testGetPositionInLocation_case1_tokenised() throws Exception {
-    //     String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
-    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-    //
-    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
-    //
-    //     assertThat(positions, hasSize(15));
-    //     assertThat(positions.get(0).start, is(0));
-    //     assertThat(positions.get(0).end, is(0));
-    // }
-    //
-    // @Test
-    // public void testGetPositionsInLocation_case2() throws Exception {
-    //     final String input = "I'm walking in The Bronx";
-    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
-    //
-    //     assertThat(positions, hasSize(4));
-    //     assertThat(positions.get(3).start, is(19));
-    //     assertThat(positions.get(3).end, is(24));
-    // }
-    //
-    // @Test
-    // public void testGetPositionsInLocation_case2_tokenised() throws Exception {
-    //     final String input = "I'm walking in The Bronx";
-    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
-    //
-    //     assertThat(positions, hasSize(4));
-    //     assertThat(positions.get(3).start, is(10));
-    //     assertThat(positions.get(3).end, is(10));
-    //
-    //     assertThat(positions.get(2).start, is(8));
-    //     assertThat(positions.get(2).end, is(10));
-    // }
+     /**
+      * Locations
+      **/
+
+     @Test
+     public void testGetPositionInLocation_case1() throws Exception {
+         final String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
+         final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
+
+         assertThat(positions, hasSize(15));
+         assertThat(positions.get(0).start, is(0));
+         assertThat(positions.get(0).end, is(2));
+     }
+
+     @Test
+     public void testGetPositionInLocation_case1_tokenised() throws Exception {
+         String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
+         List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+         final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
+
+         assertThat(positions, hasSize(15));
+         assertThat(positions.get(0).start, is(0));
+         assertThat(positions.get(0).end, is(0));
+     }
+
+     @Test
+     public void testGetPositionsInLocation_case2() throws Exception {
+         final String input = "I'm walking in The Bronx";
+         final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
+
+         assertThat(positions, hasSize(4));
+         assertThat(positions.get(3).start, is(19));
+         assertThat(positions.get(3).end, is(24));
+     }
+
+     @Test
+     public void testGetPositionsInLocation_case2_tokenised() throws Exception {
+         final String input = "I'm walking in The Bronx";
+         List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+         final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
+
+         assertThat(positions, hasSize(4));
+         assertThat(positions.get(3).start, is(10));
+         assertThat(positions.get(3).end, is(10));
+
+         assertThat(positions.get(2).start, is(8));
+         assertThat(positions.get(2).end, is(10));
+     }
 
     /**
      * ORG Form
@@ -194,40 +192,38 @@ public class LexiconIntegrationTest {
     /**
      * Person title
      **/
-    // Disabled together with charPositionsPersonTitle in Lexicon (only test
-    // callers, no production usage). Restore in tandem when re-enabled.
-    // @Test
-    // public void testGetPositionInPersonTitleNames() throws Exception {
-    //     final String input = "The president had a meeting with the vice president, duke and cto of the company.";
-    //     final List<OffsetPosition> positions = target.charPositionsPersonTitle(input);
-    //
-    //     assertThat(positions, hasSize(4));
-    //     assertThat(positions.get(0).start, is(4));
-    //     assertThat(positions.get(0).end, is(13));
-    //     assertThat(positions.get(1).start, is(37));
-    //     assertThat(positions.get(1).end, is(51));
-    //     assertThat(positions.get(2).start, is(42));
-    //     assertThat(positions.get(2).end, is(51));
-    //     assertThat(positions.get(3).start, is(53));
-    //     assertThat(positions.get(3).end, is(57));
-    // }
-    //
-    // @Test
-    // public void testGetPositionInPersonTitleNames_tokenised() throws Exception {
-    //     final String input = "The president had a meeting with the vice president, duke and cto of the company.";
-    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-    //     final List<OffsetPosition> positions = target.charPositionsPersonTitle(tokenisedInput);
-    //
-    //     assertThat(positions, hasSize(4));
-    //     assertThat(positions.get(0).start, is(2));
-    //     assertThat(positions.get(0).end, is(2));
-    //     assertThat(positions.get(1).start, is(14));
-    //     assertThat(positions.get(1).end, is(16));
-    //     assertThat(positions.get(2).start, is(16));
-    //     assertThat(positions.get(2).end, is(16));
-    //     assertThat(positions.get(3).start, is(19));
-    //     assertThat(positions.get(3).end, is(19));
-    // }
+     @Test
+     public void testGetPositionInPersonTitleNames() throws Exception {
+         final String input = "The president had a meeting with the vice president, duke and cto of the company.";
+         final List<OffsetPosition> positions = target.charPositionsPersonTitle(input);
+
+         assertThat(positions, hasSize(4));
+         assertThat(positions.get(0).start, is(4));
+         assertThat(positions.get(0).end, is(13));
+         assertThat(positions.get(1).start, is(37));
+         assertThat(positions.get(1).end, is(51));
+         assertThat(positions.get(2).start, is(42));
+         assertThat(positions.get(2).end, is(51));
+         assertThat(positions.get(3).start, is(53));
+         assertThat(positions.get(3).end, is(57));
+     }
+
+     @Test
+     public void testGetPositionInPersonTitleNames_tokenised() throws Exception {
+         final String input = "The president had a meeting with the vice president, duke and cto of the company.";
+         List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+         final List<OffsetPosition> positions = target.charPositionsPersonTitle(tokenisedInput);
+
+         assertThat(positions, hasSize(4));
+         assertThat(positions.get(0).start, is(2));
+         assertThat(positions.get(0).end, is(2));
+         assertThat(positions.get(1).start, is(14));
+         assertThat(positions.get(1).end, is(16));
+         assertThat(positions.get(2).start, is(16));
+         assertThat(positions.get(2).end, is(16));
+         assertThat(positions.get(3).start, is(19));
+         assertThat(positions.get(3).end, is(19));
+     }
 
     @Test
     public void testInJournalNamesLayoutToken() {

--- a/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
@@ -85,144 +85,149 @@ public class LexiconIntegrationTest {
         assertThat(inJournalNames.get(0).end, is(2));
     }
 
-    /**
-     * Locations
-     **/
-
-    @Test
-    public void testGetPositionInLocation_case1() throws Exception {
-        final String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
-        final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
-
-        assertThat(positions, hasSize(15));
-        assertThat(positions.get(0).start, is(0));
-        assertThat(positions.get(0).end, is(2));
-    }
-
-    @Test
-    public void testGetPositionInLocation_case1_tokenised() throws Exception {
-        String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
-        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-
-        final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
-
-        assertThat(positions, hasSize(15));
-        assertThat(positions.get(0).start, is(0));
-        assertThat(positions.get(0).end, is(0));
-    }
-
-    @Test
-    public void testGetPositionsInLocation_case2() throws Exception {
-        final String input = "I'm walking in The Bronx";
-        final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
-
-        assertThat(positions, hasSize(4));
-        assertThat(positions.get(3).start, is(19));
-        assertThat(positions.get(3).end, is(24));
-    }
-
-    @Test
-    public void testGetPositionsInLocation_case2_tokenised() throws Exception {
-        final String input = "I'm walking in The Bronx";
-        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-        final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
-
-        assertThat(positions, hasSize(4));
-        assertThat(positions.get(3).start, is(10));
-        assertThat(positions.get(3).end, is(10));
-
-        assertThat(positions.get(2).start, is(8));
-        assertThat(positions.get(2).end, is(10));
-    }
-
-    // Disabled together with the organisation/org-form gazetteer matchers
-    // in Lexicon (see Lexicon.initOrganisations / initOrgForms). Restore in
-    // tandem when those matchers are re-enabled.
+    // Disabled together with charPositionsLocationNames in Lexicon (only test
+    // callers, no production usage). Restore in tandem when re-enabled.
     // /**
-    //  * ORG Form
+    //  * Locations
     //  **/
-    // @Test
-    // public void testGetPositionInOrgForm() throws Exception {
-    //     final String input = "Matusa Inc. was bought by Bayer";
-    //     final List<OffsetPosition> positions = target.charPositionsOrgForm(input);
-    //
-    //     assertThat(positions, hasSize(1));
-    //     assertThat(positions.get(0).start, is(7));
-    //     assertThat(positions.get(0).end, is(10));
-    // }
     //
     // @Test
-    // public void testGetPositionInOrgForm_tokenised() throws Exception {
-    //     final String input = "Matusa Inc. was bought by Bayer";
-    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    // public void testGetPositionInLocation_case1() throws Exception {
+    //     final String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
+    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
     //
-    //     final List<OffsetPosition> positions = target.charPositionsOrgForm(tokenisedInput);
-    //
-    //     assertThat(positions, hasSize(1));
-    //     assertThat(positions.get(0).start, is(2));
+    //     assertThat(positions, hasSize(15));
+    //     assertThat(positions.get(0).start, is(0));
     //     assertThat(positions.get(0).end, is(2));
     // }
     //
-    // /**
-    //  * Organisation names
-    //  */
     // @Test
-    // public void testGetPositionInOrganisationNames() throws Exception {
-    //     final String input = "Matusa Inc. was bought by Bayer";
-    //     final List<OffsetPosition> positions = target.charPositionsOrganisationNames(input);
-    //
-    //     assertThat(positions, hasSize(1));
-    //     assertThat(positions.get(0).start, is(26));
-    //     assertThat(positions.get(0).end, is(31));
-    // }
-    //
-    // @Test
-    // public void testGetPositionInOrganisationNames_tokenised() throws Exception {
-    //     final String input = "Matusa Inc. was bought by Bayer";
+    // public void testGetPositionInLocation_case1_tokenised() throws Exception {
+    //     String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
     //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
     //
-    //     final List<OffsetPosition> positions = target.charPositionsOrganisationNames(tokenisedInput);
+    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
     //
-    //     assertThat(positions, hasSize(1));
-    //     assertThat(positions.get(0).start, is(11));
-    //     assertThat(positions.get(0).end, is(11));
+    //     assertThat(positions, hasSize(15));
+    //     assertThat(positions.get(0).start, is(0));
+    //     assertThat(positions.get(0).end, is(0));
     // }
+    //
+    // @Test
+    // public void testGetPositionsInLocation_case2() throws Exception {
+    //     final String input = "I'm walking in The Bronx";
+    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
+    //
+    //     assertThat(positions, hasSize(4));
+    //     assertThat(positions.get(3).start, is(19));
+    //     assertThat(positions.get(3).end, is(24));
+    // }
+    //
+    // @Test
+    // public void testGetPositionsInLocation_case2_tokenised() throws Exception {
+    //     final String input = "I'm walking in The Bronx";
+    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //     final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
+    //
+    //     assertThat(positions, hasSize(4));
+    //     assertThat(positions.get(3).start, is(10));
+    //     assertThat(positions.get(3).end, is(10));
+    //
+    //     assertThat(positions.get(2).start, is(8));
+    //     assertThat(positions.get(2).end, is(10));
+    // }
+
+    /**
+     * ORG Form
+     **/
+    @Test
+    public void testGetPositionInOrgForm() throws Exception {
+        Lexicon.builder().withOrgForms().build();
+        final String input = "Matusa Inc. was bought by Bayer";
+        final List<OffsetPosition> positions = target.charPositionsOrgForm(input);
+
+        assertThat(positions, hasSize(1));
+        assertThat(positions.get(0).start, is(7));
+        assertThat(positions.get(0).end, is(10));
+    }
+
+    @Test
+    public void testGetPositionInOrgForm_tokenised() throws Exception {
+        Lexicon.builder().withOrgForms().build();
+        final String input = "Matusa Inc. was bought by Bayer";
+        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        final List<OffsetPosition> positions = target.charPositionsOrgForm(tokenisedInput);
+
+        assertThat(positions, hasSize(1));
+        assertThat(positions.get(0).start, is(2));
+        assertThat(positions.get(0).end, is(2));
+    }
+
+    /**
+     * Organisation names
+     */
+    @Test
+    public void testGetPositionInOrganisationNames() throws Exception {
+        Lexicon.builder().withOrganisations().build();
+        final String input = "Matusa Inc. was bought by Bayer";
+        final List<OffsetPosition> positions = target.charPositionsOrganisationNames(input);
+
+        assertThat(positions, hasSize(1));
+        assertThat(positions.get(0).start, is(26));
+        assertThat(positions.get(0).end, is(31));
+    }
+
+    @Test
+    public void testGetPositionInOrganisationNames_tokenised() throws Exception {
+        Lexicon.builder().withOrganisations().build();
+        final String input = "Matusa Inc. was bought by Bayer";
+        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+
+        final List<OffsetPosition> positions = target.charPositionsOrganisationNames(tokenisedInput);
+
+        assertThat(positions, hasSize(1));
+        assertThat(positions.get(0).start, is(11));
+        assertThat(positions.get(0).end, is(11));
+    }
 
     /**
      * Person title
      **/
-    @Test
-    public void testGetPositionInPersonTitleNames() throws Exception {
-        final String input = "The president had a meeting with the vice president, duke and cto of the company.";
-        final List<OffsetPosition> positions = target.charPositionsPersonTitle(input);
-
-        assertThat(positions, hasSize(4));
-        assertThat(positions.get(0).start, is(4));
-        assertThat(positions.get(0).end, is(13));
-        assertThat(positions.get(1).start, is(37));
-        assertThat(positions.get(1).end, is(51));
-        assertThat(positions.get(2).start, is(42));
-        assertThat(positions.get(2).end, is(51));
-        assertThat(positions.get(3).start, is(53));
-        assertThat(positions.get(3).end, is(57));
-    }
-
-    @Test
-    public void testGetPositionInPersonTitleNames_tokenised() throws Exception {
-        final String input = "The president had a meeting with the vice president, duke and cto of the company.";
-        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-        final List<OffsetPosition> positions = target.charPositionsPersonTitle(tokenisedInput);
-
-        assertThat(positions, hasSize(4));
-        assertThat(positions.get(0).start, is(2));
-        assertThat(positions.get(0).end, is(2));
-        assertThat(positions.get(1).start, is(14));
-        assertThat(positions.get(1).end, is(16));
-        assertThat(positions.get(2).start, is(16));
-        assertThat(positions.get(2).end, is(16));
-        assertThat(positions.get(3).start, is(19));
-        assertThat(positions.get(3).end, is(19));
-    }
+    // Disabled together with charPositionsPersonTitle in Lexicon (only test
+    // callers, no production usage). Restore in tandem when re-enabled.
+    // @Test
+    // public void testGetPositionInPersonTitleNames() throws Exception {
+    //     final String input = "The president had a meeting with the vice president, duke and cto of the company.";
+    //     final List<OffsetPosition> positions = target.charPositionsPersonTitle(input);
+    //
+    //     assertThat(positions, hasSize(4));
+    //     assertThat(positions.get(0).start, is(4));
+    //     assertThat(positions.get(0).end, is(13));
+    //     assertThat(positions.get(1).start, is(37));
+    //     assertThat(positions.get(1).end, is(51));
+    //     assertThat(positions.get(2).start, is(42));
+    //     assertThat(positions.get(2).end, is(51));
+    //     assertThat(positions.get(3).start, is(53));
+    //     assertThat(positions.get(3).end, is(57));
+    // }
+    //
+    // @Test
+    // public void testGetPositionInPersonTitleNames_tokenised() throws Exception {
+    //     final String input = "The president had a meeting with the vice president, duke and cto of the company.";
+    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //     final List<OffsetPosition> positions = target.charPositionsPersonTitle(tokenisedInput);
+    //
+    //     assertThat(positions, hasSize(4));
+    //     assertThat(positions.get(0).start, is(2));
+    //     assertThat(positions.get(0).end, is(2));
+    //     assertThat(positions.get(1).start, is(14));
+    //     assertThat(positions.get(1).end, is(16));
+    //     assertThat(positions.get(2).start, is(16));
+    //     assertThat(positions.get(2).end, is(16));
+    //     assertThat(positions.get(3).start, is(19));
+    //     assertThat(positions.get(3).end, is(19));
+    // }
 
     @Test
     public void testInJournalNamesLayoutToken() {

--- a/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
@@ -135,55 +135,58 @@ public class LexiconIntegrationTest {
         assertThat(positions.get(2).end, is(10));
     }
 
-    /**
-     * ORG Form
-     **/
-    @Test
-    public void testGetPositionInOrgForm() throws Exception {
-        final String input = "Matusa Inc. was bought by Bayer";
-        final List<OffsetPosition> positions = target.charPositionsOrgForm(input);
-
-        assertThat(positions, hasSize(1));
-        assertThat(positions.get(0).start, is(7));
-        assertThat(positions.get(0).end, is(10));
-    }
-
-    @Test
-    public void testGetPositionInOrgForm_tokenised() throws Exception {
-        final String input = "Matusa Inc. was bought by Bayer";
-        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-
-        final List<OffsetPosition> positions = target.charPositionsOrgForm(tokenisedInput);
-
-        assertThat(positions, hasSize(1));
-        assertThat(positions.get(0).start, is(2));
-        assertThat(positions.get(0).end, is(2));
-    }
-
-    /**
-     * Organisation names
-     */
-    @Test
-    public void testGetPositionInOrganisationNames() throws Exception {
-        final String input = "Matusa Inc. was bought by Bayer";
-        final List<OffsetPosition> positions = target.charPositionsOrganisationNames(input);
-
-        assertThat(positions, hasSize(1));
-        assertThat(positions.get(0).start, is(26));
-        assertThat(positions.get(0).end, is(31));
-    }
-
-    @Test
-    public void testGetPositionInOrganisationNames_tokenised() throws Exception {
-        final String input = "Matusa Inc. was bought by Bayer";
-        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-
-        final List<OffsetPosition> positions = target.charPositionsOrganisationNames(tokenisedInput);
-
-        assertThat(positions, hasSize(1));
-        assertThat(positions.get(0).start, is(11));
-        assertThat(positions.get(0).end, is(11));
-    }
+    // Disabled together with the organisation/org-form gazetteer matchers
+    // in Lexicon (see Lexicon.initOrganisations / initOrgForms). Restore in
+    // tandem when those matchers are re-enabled.
+    // /**
+    //  * ORG Form
+    //  **/
+    // @Test
+    // public void testGetPositionInOrgForm() throws Exception {
+    //     final String input = "Matusa Inc. was bought by Bayer";
+    //     final List<OffsetPosition> positions = target.charPositionsOrgForm(input);
+    //
+    //     assertThat(positions, hasSize(1));
+    //     assertThat(positions.get(0).start, is(7));
+    //     assertThat(positions.get(0).end, is(10));
+    // }
+    //
+    // @Test
+    // public void testGetPositionInOrgForm_tokenised() throws Exception {
+    //     final String input = "Matusa Inc. was bought by Bayer";
+    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //
+    //     final List<OffsetPosition> positions = target.charPositionsOrgForm(tokenisedInput);
+    //
+    //     assertThat(positions, hasSize(1));
+    //     assertThat(positions.get(0).start, is(2));
+    //     assertThat(positions.get(0).end, is(2));
+    // }
+    //
+    // /**
+    //  * Organisation names
+    //  */
+    // @Test
+    // public void testGetPositionInOrganisationNames() throws Exception {
+    //     final String input = "Matusa Inc. was bought by Bayer";
+    //     final List<OffsetPosition> positions = target.charPositionsOrganisationNames(input);
+    //
+    //     assertThat(positions, hasSize(1));
+    //     assertThat(positions.get(0).start, is(26));
+    //     assertThat(positions.get(0).end, is(31));
+    // }
+    //
+    // @Test
+    // public void testGetPositionInOrganisationNames_tokenised() throws Exception {
+    //     final String input = "Matusa Inc. was bought by Bayer";
+    //     List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //
+    //     final List<OffsetPosition> positions = target.charPositionsOrganisationNames(tokenisedInput);
+    //
+    //     assertThat(positions, hasSize(1));
+    //     assertThat(positions.get(0).start, is(11));
+    //     assertThat(positions.get(0).end, is(11));
+    // }
 
     /**
      * Person title

--- a/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconIntegrationTest.java
@@ -85,55 +85,55 @@ public class LexiconIntegrationTest {
         assertThat(inJournalNames.get(0).end, is(2));
     }
 
-     /**
-      * Locations
-      **/
+    /**
+     * Locations
+     **/
 
-     @Test
-     public void testGetPositionInLocation_case1() throws Exception {
-         final String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
-         final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
+    @Test
+    public void testGetPositionInLocation_case1() throws Exception {
+        final String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
+        final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
 
-         assertThat(positions, hasSize(15));
-         assertThat(positions.get(0).start, is(0));
-         assertThat(positions.get(0).end, is(2));
-     }
+        assertThat(positions, hasSize(15));
+        assertThat(positions.get(0).start, is(0));
+        assertThat(positions.get(0).end, is(2));
+    }
 
-     @Test
-     public void testGetPositionInLocation_case1_tokenised() throws Exception {
-         String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
-         List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    @Test
+    public void testGetPositionInLocation_case1_tokenised() throws Exception {
+        String input = "In retrospect, the National Archives of Belgium were established by the French law of October 26th 1796 (5 Brumair V), which, amongst others, foresaw in the organisation of departmental depots (amongst others, in Brussels), in which the archives of the disbanded institutions of the Ancien Régime would be stored.";
+        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
 
-         final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
+        final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
 
-         assertThat(positions, hasSize(15));
-         assertThat(positions.get(0).start, is(0));
-         assertThat(positions.get(0).end, is(0));
-     }
+        assertThat(positions, hasSize(15));
+        assertThat(positions.get(0).start, is(0));
+        assertThat(positions.get(0).end, is(0));
+    }
 
-     @Test
-     public void testGetPositionsInLocation_case2() throws Exception {
-         final String input = "I'm walking in The Bronx";
-         final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
+    @Test
+    public void testGetPositionsInLocation_case2() throws Exception {
+        final String input = "I'm walking in The Bronx";
+        final List<OffsetPosition> positions = target.charPositionsLocationNames(input);
 
-         assertThat(positions, hasSize(4));
-         assertThat(positions.get(3).start, is(19));
-         assertThat(positions.get(3).end, is(24));
-     }
+        assertThat(positions, hasSize(4));
+        assertThat(positions.get(3).start, is(19));
+        assertThat(positions.get(3).end, is(24));
+    }
 
-     @Test
-     public void testGetPositionsInLocation_case2_tokenised() throws Exception {
-         final String input = "I'm walking in The Bronx";
-         List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-         final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
+    @Test
+    public void testGetPositionsInLocation_case2_tokenised() throws Exception {
+        final String input = "I'm walking in The Bronx";
+        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        final List<OffsetPosition> positions = target.charPositionsLocationNames(tokenisedInput);
 
-         assertThat(positions, hasSize(4));
-         assertThat(positions.get(3).start, is(10));
-         assertThat(positions.get(3).end, is(10));
+        assertThat(positions, hasSize(4));
+        assertThat(positions.get(3).start, is(10));
+        assertThat(positions.get(3).end, is(10));
 
-         assertThat(positions.get(2).start, is(8));
-         assertThat(positions.get(2).end, is(10));
-     }
+        assertThat(positions.get(2).start, is(8));
+        assertThat(positions.get(2).end, is(10));
+    }
 
     /**
      * ORG Form
@@ -192,38 +192,38 @@ public class LexiconIntegrationTest {
     /**
      * Person title
      **/
-     @Test
-     public void testGetPositionInPersonTitleNames() throws Exception {
-         final String input = "The president had a meeting with the vice president, duke and cto of the company.";
-         final List<OffsetPosition> positions = target.charPositionsPersonTitle(input);
+    @Test
+    public void testGetPositionInPersonTitleNames() throws Exception {
+        final String input = "The president had a meeting with the vice president, duke and cto of the company.";
+        final List<OffsetPosition> positions = target.charPositionsPersonTitle(input);
 
-         assertThat(positions, hasSize(4));
-         assertThat(positions.get(0).start, is(4));
-         assertThat(positions.get(0).end, is(13));
-         assertThat(positions.get(1).start, is(37));
-         assertThat(positions.get(1).end, is(51));
-         assertThat(positions.get(2).start, is(42));
-         assertThat(positions.get(2).end, is(51));
-         assertThat(positions.get(3).start, is(53));
-         assertThat(positions.get(3).end, is(57));
-     }
+        assertThat(positions, hasSize(4));
+        assertThat(positions.get(0).start, is(4));
+        assertThat(positions.get(0).end, is(13));
+        assertThat(positions.get(1).start, is(37));
+        assertThat(positions.get(1).end, is(51));
+        assertThat(positions.get(2).start, is(42));
+        assertThat(positions.get(2).end, is(51));
+        assertThat(positions.get(3).start, is(53));
+        assertThat(positions.get(3).end, is(57));
+    }
 
-     @Test
-     public void testGetPositionInPersonTitleNames_tokenised() throws Exception {
-         final String input = "The president had a meeting with the vice president, duke and cto of the company.";
-         List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-         final List<OffsetPosition> positions = target.charPositionsPersonTitle(tokenisedInput);
+    @Test
+    public void testGetPositionInPersonTitleNames_tokenised() throws Exception {
+        final String input = "The president had a meeting with the vice president, duke and cto of the company.";
+        List<LayoutToken> tokenisedInput = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        final List<OffsetPosition> positions = target.charPositionsPersonTitle(tokenisedInput);
 
-         assertThat(positions, hasSize(4));
-         assertThat(positions.get(0).start, is(2));
-         assertThat(positions.get(0).end, is(2));
-         assertThat(positions.get(1).start, is(14));
-         assertThat(positions.get(1).end, is(16));
-         assertThat(positions.get(2).start, is(16));
-         assertThat(positions.get(2).end, is(16));
-         assertThat(positions.get(3).start, is(19));
-         assertThat(positions.get(3).end, is(19));
-     }
+        assertThat(positions, hasSize(4));
+        assertThat(positions.get(0).start, is(2));
+        assertThat(positions.get(0).end, is(2));
+        assertThat(positions.get(1).start, is(14));
+        assertThat(positions.get(1).end, is(16));
+        assertThat(positions.get(2).start, is(16));
+        assertThat(positions.get(2).end, is(16));
+        assertThat(positions.get(3).start, is(19));
+        assertThat(positions.get(3).end, is(19));
+    }
 
     @Test
     public void testInJournalNamesLayoutToken() {

--- a/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconTest.java
@@ -762,52 +762,50 @@ public class LexiconTest {
                 is("https://doi.org/10.1038/s41586-024-07891-2"));
     }
 
-    // Disabled together with Lexicon.getTokenIndexMatchingURLDestination (no
-    // production callers, only these tests). Restore in tandem when re-enabled.
-    // @Test
-    // public void testGetTokenIndexMatchingURLDestination() throws Exception {
-    //     String input = "(https://doi.org/10.1038/s41586-024-07891-2.";
-    //     List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-    //     String destination = "https://doi.org/10.1038/s41586-024-07891-2";
-    //
-    //     OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
-    //
-    //     assertThat(tokenPositions.start, is(1));
-    //     //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
-    //     assertThat(tokenPositions.end, is(19));
-    //     assertThat(
-    //             LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
-    //             is("https://doi.org/10.1038/s41586-024-07891-2"));
-    // }
-    //
-    // @Test
-    // public void testGetTokenIndexMatchingURLDestination2() throws Exception {
-    //     String input = "(https://doi.org/10.1038/ s41586-024-07891-2.";
-    //     List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-    //     String destination = "https://doi.org/10.1038/s41586-024-07891-2";
-    //
-    //     OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
-    //
-    //     assertThat(tokenPositions.start, is(1));
-    //     //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
-    //     assertThat(tokenPositions.end, is(20));
-    //     assertThat(
-    //             LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
-    //             is("https://doi.org/10.1038/ s41586-024-07891-2"));
-    // }
-    //
-    // @Test
-    // public void testGetTokenIndexMatchingURLDestination3() throws Exception {
-    //     String input = "(https://doi.org/10.1038/ s41586-024- 07891-2.";
-    //     List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-    //     String destination = "https://doi.org/10.1038/s41586-024-07891-2";
-    //
-    //     OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
-    //
-    //     assertThat(tokenPositions.start, is(1));
-    //     //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
-    //     assertThat(tokenPositions.end, is(21));
-    // }
+    @Test
+    public void testGetTokenIndexMatchingURLDestination() throws Exception {
+        String input = "(https://doi.org/10.1038/s41586-024-07891-2.";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        String destination = "https://doi.org/10.1038/s41586-024-07891-2";
+
+        OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
+
+        assertThat(tokenPositions.start, is(1));
+        //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
+        assertThat(tokenPositions.end, is(19));
+        assertThat(
+                LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
+                is("https://doi.org/10.1038/s41586-024-07891-2"));
+    }
+
+    @Test
+    public void testGetTokenIndexMatchingURLDestination2() throws Exception {
+        String input = "(https://doi.org/10.1038/ s41586-024-07891-2.";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        String destination = "https://doi.org/10.1038/s41586-024-07891-2";
+
+        OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
+
+        assertThat(tokenPositions.start, is(1));
+        //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
+        assertThat(tokenPositions.end, is(20));
+        assertThat(
+                LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
+                is("https://doi.org/10.1038/ s41586-024-07891-2"));
+    }
+
+    @Test
+    public void testGetTokenIndexMatchingURLDestination3() throws Exception {
+        String input = "(https://doi.org/10.1038/ s41586-024- 07891-2.";
+        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+        String destination = "https://doi.org/10.1038/s41586-024-07891-2";
+
+        OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
+
+        assertThat(tokenPositions.start, is(1));
+        //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
+        assertThat(tokenPositions.end, is(21));
+    }
 
     @Test
     public void testCharacterPositionsUrlPattern_URLRegexMatchesTooLittle_shouldReturnCorrectInterval_1()

--- a/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/lexicon/LexiconTest.java
@@ -762,50 +762,52 @@ public class LexiconTest {
                 is("https://doi.org/10.1038/s41586-024-07891-2"));
     }
 
-    @Test
-    public void testGetTokenIndexMatchingURLDestination() throws Exception {
-        String input = "(https://doi.org/10.1038/s41586-024-07891-2.";
-        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-        String destination = "https://doi.org/10.1038/s41586-024-07891-2";
-
-        OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
-
-        assertThat(tokenPositions.start, is(1));
-        //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
-        assertThat(tokenPositions.end, is(19));
-        assertThat(
-                LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
-                is("https://doi.org/10.1038/s41586-024-07891-2"));
-    }
-
-    @Test
-    public void testGetTokenIndexMatchingURLDestination2() throws Exception {
-        String input = "(https://doi.org/10.1038/ s41586-024-07891-2.";
-        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-        String destination = "https://doi.org/10.1038/s41586-024-07891-2";
-
-        OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
-
-        assertThat(tokenPositions.start, is(1));
-        //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
-        assertThat(tokenPositions.end, is(20));
-        assertThat(
-                LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
-                is("https://doi.org/10.1038/ s41586-024-07891-2"));
-    }
-
-    @Test
-    public void testGetTokenIndexMatchingURLDestination3() throws Exception {
-        String input = "(https://doi.org/10.1038/ s41586-024- 07891-2.";
-        List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
-        String destination = "https://doi.org/10.1038/s41586-024-07891-2";
-
-        OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
-
-        assertThat(tokenPositions.start, is(1));
-        //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
-        assertThat(tokenPositions.end, is(21));
-    }
+    // Disabled together with Lexicon.getTokenIndexMatchingURLDestination (no
+    // production callers, only these tests). Restore in tandem when re-enabled.
+    // @Test
+    // public void testGetTokenIndexMatchingURLDestination() throws Exception {
+    //     String input = "(https://doi.org/10.1038/s41586-024-07891-2.";
+    //     List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //     String destination = "https://doi.org/10.1038/s41586-024-07891-2";
+    //
+    //     OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
+    //
+    //     assertThat(tokenPositions.start, is(1));
+    //     //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
+    //     assertThat(tokenPositions.end, is(19));
+    //     assertThat(
+    //             LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
+    //             is("https://doi.org/10.1038/s41586-024-07891-2"));
+    // }
+    //
+    // @Test
+    // public void testGetTokenIndexMatchingURLDestination2() throws Exception {
+    //     String input = "(https://doi.org/10.1038/ s41586-024-07891-2.";
+    //     List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //     String destination = "https://doi.org/10.1038/s41586-024-07891-2";
+    //
+    //     OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
+    //
+    //     assertThat(tokenPositions.start, is(1));
+    //     //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
+    //     assertThat(tokenPositions.end, is(20));
+    //     assertThat(
+    //             LayoutTokensUtil.toText(tokens.subList(tokenPositions.start, tokenPositions.end + 1)),
+    //             is("https://doi.org/10.1038/ s41586-024-07891-2"));
+    // }
+    //
+    // @Test
+    // public void testGetTokenIndexMatchingURLDestination3() throws Exception {
+    //     String input = "(https://doi.org/10.1038/ s41586-024- 07891-2.";
+    //     List<LayoutToken> tokens = GrobidAnalyzer.getInstance().tokenizeWithLayoutToken(input);
+    //     String destination = "https://doi.org/10.1038/s41586-024-07891-2";
+    //
+    //     OffsetPosition tokenPositions = Lexicon.getTokenIndexMatchingURLDestination(tokens, destination);
+    //
+    //     assertThat(tokenPositions.start, is(1));
+    //     //NOTE: when doing sublist of the output of this method the end is non-inclusive, so a +1 is needed
+    //     assertThat(tokenPositions.end, is(21));
+    // }
 
     @Test
     public void testCharacterPositionsUrlPattern_URLRegexMatchesTooLittle_shouldReturnCorrectInterval_1()


### PR DESCRIPTION
We started by checking which lexicon were loaded and not used, those were initially disabled. We then refactor the way the Lexicon is used, with, by default, loading only the currently grobid-used lexicon and ignoring everything else. 

The way to use the lexicon is now `Lexicon.withPerson().withOrganisation().build()`. 