### PR TITLE
run grobid as rootless (Kubernetes/OpenShift friendly)

### DIFF
--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -152,6 +152,7 @@ RUN python3 preload_embeddings.py --registry ./resources-registry.json &&  \
 RUN mkdir delft && \
     cp ./resources-registry.json delft/
 
+# Set the group to avoid running the docker image in a rootless environment
 RUN chgrp -R 0 /opt/grobid /data /tmp && \
     chmod -R g=u /opt/grobid /data /tmp
 

--- a/Dockerfile.delft
+++ b/Dockerfile.delft
@@ -56,9 +56,9 @@ RUN rm -rf grobid-home/pdf2xml
 RUN rm -rf grobid-home/pdfalto/win-* grobid-home/pdfalto/mac-64 grobid-home/pdfalto/mac_arm-64 grobid-home/pdfalto/lin-32
 RUN rm -rf grobid-home/lib/win-* grobid-home/lib/mac-64 grobid-home/lib/mac_arm-64 grobid-home/lib/lin-32
 RUN if [ "$TARGETARCH" = "arm64" ]; then \
-      rm -rf grobid-home/pdfalto/lin-64 grobid-home/lib/lin-64; \
+    rm -rf grobid-home/pdfalto/lin-64 grobid-home/lib/lin-64; \
     else \
-      rm -rf grobid-home/pdfalto/lin_arm-64 grobid-home/lib/lin_arm-64; \
+    rm -rf grobid-home/pdfalto/lin_arm-64 grobid-home/lib/lin_arm-64; \
     fi
 
 # Setting DL-powered configuration
@@ -102,9 +102,9 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
 # install TensorFlow: GPU-enabled on amd64 (with CUDA via pip), CPU-only on arm64
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
-      pip3 install --no-cache-dir "tensorflow[and-cuda]==2.17.1"; \
+    pip3 install --no-cache-dir "tensorflow[and-cuda]==2.17.1"; \
     else \
-      pip3 install --no-cache-dir tensorflow==2.17.1; \
+    pip3 install --no-cache-dir tensorflow==2.17.1; \
     fi
 
 WORKDIR /opt/grobid
@@ -151,6 +151,9 @@ RUN python3 preload_embeddings.py --registry ./resources-registry.json &&  \
 
 RUN mkdir delft && \
     cp ./resources-registry.json delft/
+
+RUN chgrp -R 0 /opt/grobid /data /tmp && \
+    chmod -R g=u /opt/grobid /data /tmp
 
 CMD ["./grobid-service/bin/grobid-service"]
 


### PR DESCRIPTION
## Summary

This PR updates the GROBID Docker image to improve compatibility with non-root container runtimes across Kubernetes distributions, including OpenShift.

## Changes

- Added writable group permissions for runtime directories:
  - `/opt/grobid`
  - `/data`
  - `/tmp`

- Updated ownership/group permissions using:

```dockerfile
RUN chgrp -R 0 /opt/grobid /data /tmp && \
    chmod -R g=u /opt/grobid /data /tmp
```

## Why

When running the container with arbitrary non-root UIDs (common in Kubernetes and required by OpenShift), GROBID failed during DeLFT model initialization with:

```text
lmdb.ReadonlyError: data/db/glove-840B: Permission denied
```

The issue was caused by build-time generated files and downloaded embeddings being owned by `root:root` and not writable by runtime users.

This change makes the image compatible with:

- Kubernetes `runAsNonRoot`
- OpenShift arbitrary UID execution
- Rootless container runtimes

without requiring a fixed UID/GID or privileged execution.

## Result

The container can now run as a non-root user while still allowing GROBID, TensorFlow, JEP, and LMDB to write required runtime/cache/model files successfully.