### PR TITLE
Add PDF-TEI Editor in the documentation

### DIFF
--- a/doc/PDF-TEI-Editor.md
+++ b/doc/PDF-TEI-Editor.md
@@ -1,0 +1,65 @@
+# Annotating training data with the PDF-TEI Editor
+
+[pdf-tei-editor](https://github.com/mpilhlt/pdf-tei-editor/) is a web-based, open-source tool for editing and correcting GROBID TEI training data side-by-side with the source PDF. It provides a graphical alternative to editing the `*.training.*.tei.xml` files by hand in a text editor, which makes the [correction of pre-annotated training data](training/General-principles.md#correcting-pre-annotated-files) considerably faster and less error-prone.
+
+The tool is developed as part of the *Legal Theory Knowledge Graph* project at the Max Planck Institute of Legal History and Legal Theory.
+
+!!! note
+    The PDF-TEI Editor is a third-party project and is **not** maintained by the GROBID team. Refer to its [repository](https://github.com/mpilhlt/pdf-tei-editor/) and documentation for support, issues, and the most up-to-date instructions.
+
+## Why use it
+
+When you [generate pre-annotated training data](Training-the-models-of-Grobid.md#generation-of-training-data) with GROBID's `createTraining` batch command, the output is a set of TEI XML files that **must be reviewed and corrected** before they can be added to the gold-standard corpus. Doing this in a raw text editor is tedious: you constantly switch between the XML and the original PDF to check whether a label is on the right span of text, and it is easy to accidentally alter the text stream — which [must be kept untouched](training/General-principles.md#correcting-pre-annotated-files).
+
+The PDF-TEI Editor addresses this by:
+
+- **Synchronized dual-pane interface** — the rendered PDF and the editable TEI XML are shown next to each other, so you can verify annotations against the source layout at a glance.
+- **Schema validation** — the TEI is validated for compliance as you edit, catching malformed markup before it reaches the training corpus.
+- **Version control** — branching, merging, comparison (diff) between versions, and detailed revision tracking, which is useful for collaborative, multi-annotator gold-standard creation.
+- **Role-based access control and collection management** — for organizing documents and contributors across a shared dataset.
+- **Multiple extraction engines** — GROBID is supported as one of the AI extraction backends, so documents can be pre-annotated and then corrected within the same interface.
+
+## Typical workflow with GROBID
+
+The editor fits into the standard GROBID training-data preparation loop described in the [annotation guidelines](training/General-principles.md):
+
+1. Run GROBID's `createTraining` (see [Generation of training data](Training-the-models-of-Grobid.md#generation-of-training-data)) to pre-annotate your PDFs, producing the `*.training.*.tei.xml` files — or use the editor's built-in GROBID extraction.
+2. Open the PDF together with its generated TEI XML in the PDF-TEI Editor.
+3. Visually correct the annotations against the PDF, **moving tags without altering the text stream** (the `<lb/>` line-break markers and the order of the text must be preserved — see the [correction principles](training/General-principles.md#correcting-pre-annotated-files)).
+4. Validate the TEI and save a clean, gold-standard version.
+5. Move the corrected file into the corresponding model's corpus directory (`grobid-trainer/resources/dataset/<MODEL>/corpus/`) and [retrain the model](Training-the-models-of-Grobid.md).
+
+!!! tip
+    Remember that GROBID training data is curated by **editing or deleting** the pre-annotated files — you should not create new `*.training.*.tei.xml` files from scratch. The editor is there to make the *correction* of GROBID's output efficient, not to author TEI independently of GROBID's extraction.
+
+## Getting started
+
+The fastest way to try it is the Docker-based deployment. From the project's documentation:
+
+```bash
+git clone https://github.com/mpilhlt/pdf-tei-editor.git
+cd pdf-tei-editor
+npm run deploy .env.deploy.demo.localhost
+```
+
+The application is then available at `http://localhost:8080` (default demo credentials `admin/admin` or `demo/demo` — change these for any non-local use).
+
+A development setup is also available:
+
+```bash
+git clone https://github.com/mpilhlt/pdf-tei-editor.git
+cd pdf-tei-editor
+cp .env.development .env
+npm install
+npm run start:dev
+```
+
+For the authoritative and most current installation, configuration, and usage instructions, see the [pdf-tei-editor repository](https://github.com/mpilhlt/pdf-tei-editor/) and its documentation.
+
+## Technical notes
+
+- **Backend:** FastAPI (Python 3.13+), SQLite, lxml
+- **Frontend:** ES6 modules, CodeMirror 6, PDF.js, Shoelace
+- **Synchronization:** WebDAV support for connecting to external systems
+
+These details may change over time; consult the upstream repository for the current stack and requirements.

--- a/doc/PDF-TEI-Editor.md
+++ b/doc/PDF-TEI-Editor.md
@@ -34,7 +34,48 @@ The editor fits into the standard GROBID training-data preparation loop describe
 
 ## Getting started
 
-The fastest way to try it is the Docker-based deployment. From the project's documentation:
+### Connecting to a GROBID server
+
+The editor does **not** bundle GROBID — it talks to a running GROBID server over its REST API to pre-annotate documents. You tell the editor which server to use with the `GROBID_SERVER_URL` environment variable.
+
+For producing training data, **run your own full GROBID instance**. The pre-annotation quality directly determines how much manual correction you have to do, so it is worth using the *full* image (`grobid/grobid:{version}-full`, or the mirror `lfoppiano/grobid:{version}-full`), which includes the Deep Learning models and gives noticeably better reference and citation extraction than the CRF-only or public light instances. See [Run with Docker](Grobid-docker.md) for the full instructions; GROBID's REST API listens on port `8070`, so the URL is typically `http://localhost:8070`:
+
+```bash
+docker run --rm --gpus all --init --ulimit core=0 -p 8070:8070 grobid/grobid:0.9.0-full
+```
+
+The public *light* instances hosted on Hugging Face (`https://grobidOrg-grobid.hf.space`, mirror `https://grobidOrg-grobid2.hf.space`, see the [Quick start](getting_started.md) page) require no installation and are convenient for a first try, but they run CRF-only models and are not recommended for building a gold-standard corpus.
+
+### Running the editor (Docker)
+
+The fastest way to run the editor itself is its Docker image, passing the GROBID endpoint via `GROBID_SERVER_URL`:
+
+```bash
+docker run -p 8000:8000 \
+  -e APP_ADMIN_PASSWORD=secure_password \
+  -e GROBID_SERVER_URL=http://host.docker.internal:8070 \
+  cboulanger/pdf-tei-editor:latest
+```
+
+The application is then available at `http://localhost:8000` (user `admin`, with the password set above). The equivalent `docker-compose.yml`:
+
+```yaml
+services:
+  pdf-tei-editor:
+    image: cboulanger/pdf-tei-editor:latest
+    ports:
+      - "8000:8000"
+    environment:
+      - APP_ADMIN_PASSWORD=secure_password
+      - GROBID_SERVER_URL=http://host.docker.internal:8070
+```
+
+!!! note
+    `GROBID_SERVER_URL` must be reachable **from inside the editor's container**. When GROBID runs on the same host, use `http://host.docker.internal:8070` (Docker Desktop) or put both containers on the same Docker network and use the GROBID container name. A bare `http://localhost:8070` refers to the editor container itself and will not reach GROBID.
+
+### Trying the bundled demo
+
+The repository also ships a one-command demo deployment:
 
 ```bash
 git clone https://github.com/mpilhlt/pdf-tei-editor.git
@@ -42,24 +83,6 @@ cd pdf-tei-editor
 npm run deploy .env.deploy.demo.localhost
 ```
 
-The application is then available at `http://localhost:8080` (default demo credentials `admin/admin` or `demo/demo` — change these for any non-local use).
-
-A development setup is also available:
-
-```bash
-git clone https://github.com/mpilhlt/pdf-tei-editor.git
-cd pdf-tei-editor
-cp .env.development .env
-npm install
-npm run start:dev
-```
+It becomes available at `http://localhost:8080` with demo credentials `admin/admin` or `demo/demo` — change these for any non-local use.
 
 For the authoritative and most current installation, configuration, and usage instructions, see the [pdf-tei-editor repository](https://github.com/mpilhlt/pdf-tei-editor/) and its documentation.
-
-## Technical notes
-
-- **Backend:** FastAPI (Python 3.13+), SQLite, lxml
-- **Frontend:** ES6 modules, CodeMirror 6, PDF.js, Shoelace
-- **Synchronization:** WebDAV support for connecting to external systems
-
-These details may change over time; consult the upstream repository for the current stack and requirements.

--- a/doc/PDF-TEI-Editor.md
+++ b/doc/PDF-TEI-Editor.md
@@ -38,13 +38,15 @@ The editor fits into the standard GROBID training-data preparation loop describe
 
 The editor does **not** bundle GROBID — it talks to a running GROBID server over its REST API to pre-annotate documents. You tell the editor which server to use with the `GROBID_SERVER_URL` environment variable.
 
-For producing training data, **run your own full GROBID instance**. The pre-annotation quality directly determines how much manual correction you have to do, so it is worth using the *full* image (`grobid/grobid:{version}-full`, or the mirror `lfoppiano/grobid:{version}-full`), which includes the Deep Learning models and gives noticeably better reference and citation extraction than the CRF-only or public light instances. See [Run with Docker](Grobid-docker.md) for the full instructions; GROBID's REST API listens on port `8070`, so the URL is typically `http://localhost:8070`:
+Pre-annotation quality directly determines how much manual correction you have to do, so always point the editor at a **full** GROBID server (one running the Deep Learning models): it gives noticeably better reference and citation extraction than the CRF-only *light* instances. You have two options:
+
+- **Use the public full instance on Hugging Face** — `https://grobidOrg-grobid-full.hf.space` (mirror `https://grobidOrg-grobid-full2.hf.space`). It runs the Deep Learning models and requires no installation, so it is the quickest way to start annotating. This is a good fit for occasional work or a first pass. (The *light* instances `https://grobidOrg-grobid.hf.space` and its mirror `https://grobidOrg-grobid2.hf.space`, documented on the [Quick start](getting_started.md) page, are CRF-only and not recommended for building a gold-standard corpus.)
+
+- **Run your own full GROBID instance** — recommended once you settle into iterative sessions of correction and retraining. Hosting it yourself removes the rate/availability limits of the public space and, more importantly, lets you point the editor at *your own* freshly retrained models so each correction cycle pre-annotates with the improvements from the previous one. Use the *full* image (`grobid/grobid:{version}-full`, or the mirror `lfoppiano/grobid:{version}-full`); see [Run with Docker](Grobid-docker.md) for the full instructions. GROBID's REST API listens on port `8070`, so the URL is typically `http://localhost:8070`:
 
 ```bash
 docker run --rm --gpus all --init --ulimit core=0 -p 8070:8070 grobid/grobid:0.9.0-full
 ```
-
-The public *light* instances hosted on Hugging Face (`https://grobidOrg-grobid.hf.space`, mirror `https://grobidOrg-grobid2.hf.space`, see the [Quick start](getting_started.md) page) require no installation and are convenient for a first try, but they run CRF-only models and are not recommended for building a gold-standard corpus.
 
 ### Running the editor (Docker)
 
@@ -53,7 +55,7 @@ The fastest way to run the editor itself is its Docker image, passing the GROBID
 ```bash
 docker run -p 8000:8000 \
   -e APP_ADMIN_PASSWORD=secure_password \
-  -e GROBID_SERVER_URL=http://host.docker.internal:8070 \
+  -e GROBID_SERVER_URL=https://grobidOrg-grobid-full.hf.space \
   cboulanger/pdf-tei-editor:latest
 ```
 
@@ -67,11 +69,11 @@ services:
       - "8000:8000"
     environment:
       - APP_ADMIN_PASSWORD=secure_password
-      - GROBID_SERVER_URL=http://host.docker.internal:8070
+      - GROBID_SERVER_URL=https://grobidOrg-grobid-full.hf.space
 ```
 
 !!! note
-    `GROBID_SERVER_URL` must be reachable **from inside the editor's container**. When GROBID runs on the same host, use `http://host.docker.internal:8070` (Docker Desktop) or put both containers on the same Docker network and use the GROBID container name. A bare `http://localhost:8070` refers to the editor container itself and will not reach GROBID.
+    The example above uses the public Hugging Face instance so it works without any further setup. If you instead run your own GROBID (see above), remember that `GROBID_SERVER_URL` must be reachable **from inside the editor's container**: when GROBID runs on the same host, use `http://host.docker.internal:8070` (Docker Desktop) or put both containers on the same Docker network and use the GROBID container name. A bare `http://localhost:8070` refers to the editor container itself and will not reach GROBID.
 
 ### Trying the bundled demo
 

--- a/doc/Training-the-models-of-Grobid.md
+++ b/doc/Training-the-models-of-Grobid.md
@@ -159,6 +159,8 @@ When a model uses PDF layout features, an additional feature file (for example `
 
 If you wish to maintain the training corpus as gold standard, these automatically generated data have to be checked and corrected manually before being moved to the training/evaluation folder of the corresponding model. For correcting/checking these data, the guidelines presented in the next section must be followed to ensure the consistency of the whole training sets. 
 
+The correction can be done in any text/XML editor, or with a dedicated graphical tool: the web-based [PDF-TEI Editor](PDF-TEI-Editor.md) lets you edit the pre-annotated TEI side-by-side with the source PDF, with schema validation and version control. See the [dedicated page](PDF-TEI-Editor.md) for details.
+
 
 ## Training guidelines
 
@@ -171,7 +173,7 @@ Annotation guidelines for creating the training data corresponding to the differ
 
 ([#139](https://github.com/kermitt2/grobid/issues/139), [#610](https://github.com/kermitt2/grobid/issues/610))
 
-Yes. [pdf-tei-editor](https://github.com/mpilhlt/pdf-tei-editor/) is a web-based tool for editing GROBID TEI training data alongside the PDF. The typical workflow is: use `createTraining` to pre-annotate, then open the generated TEI XML files in pdf-tei-editor for visual correction.
+Yes. The web-based [PDF-TEI Editor](PDF-TEI-Editor.md) lets you edit GROBID TEI training data alongside the PDF. The typical workflow is: use `createTraining` to pre-annotate, then open the generated TEI XML files in the editor for visual correction. See the [dedicated page](PDF-TEI-Editor.md) for details.
 
 ### Can I generate training data automatically (e.g., from BibTeX)?
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -20,6 +20,9 @@ The simpler way to play with Grobid is to use the [Grobid instance](https://grob
 You can use it to process a PDF file, or to test the Grobid web service. 
 The space is free and does not require any authentication.
 
+!!! note "Full (Deep Learning) instances available"
+    **Full instances**, running the Deep Learning models and producing better results (in particular for reference and citation extraction), are also deployed at [https://grobidOrg-grobid-full.hf.space](https://grobidOrg-grobid-full.hf.space) and the mirror [https://grobidOrg-grobid-full2.hf.space](https://grobidOrg-grobid-full2.hf.space).
+
 !!! warning "Grobid space is for demonstration only"
     This grobid space is not intended for production use, it is only a demonstration of Grobid capabilities. For production use, please deploy a local version or contact us.
 

--- a/doc/training/General-principles.md
+++ b/doc/training/General-principles.md
@@ -39,6 +39,8 @@ These files must be reviewed and corrected manually before being added to the tr
 
 ## Correcting pre-annotated files
 
+These corrections can be made in any text or XML editor. For a more convenient, visual workflow, the web-based [PDF-TEI Editor](../PDF-TEI-Editor.md) lets you edit the pre-annotated TEI side-by-side with the source PDF, with schema validation and version control — see its [dedicated page](../PDF-TEI-Editor.md).
+
 The most important principle when correcting the pre-annotated training data is to __keep the stream of text untouched__. Only the tags can be moved, the text itself shall not be modified or corrected. The stream of text present in the training file after extraction of the content of the PDF, is similar to the stream of text Grobid will have to process once the models are (re)created. It is thus important to have Grobid trained on this real-world input, even if they contain OCR errors, noise, unknown unicode characters, etc.   
 
 There are two exceptions to this main rule :

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
   - Developer Guide:
     - 'Build from source': 'Install-Grobid.md'
     - 'Training and evaluating models': 'Training-the-models-of-Grobid.md'
+    - 'Annotating with the PDF-TEI Editor': 'PDF-TEI-Editor.md'
     - 'End-to-end evaluation': 'End-to-end-evaluation.md'
     - 'Deep Learning models': 'Deep-Learning-models.md'
     - 'Developer notes': 'Notes-grobid-developers.md'


### PR DESCRIPTION
PDF-TEI Editor (https://github.com/mpilhlt/pdf-tei-editor) was developed in the last year to simplify the way annotations are produced. It's a generic tool that supports Grobid and has been designed for extensibility. 

We've been using it for manual and with experimental AI assisted corrections. 

Generated documentation: https://grobid.readthedocs.io/en/feature-add-pdf-tei-editor/

CC @cboulanger 