### PR TITLE
Dependency update to solve the security CVE reported by Trivvy 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,15 +200,15 @@ subprojects {
         implementation "org.apache.commons:commons-collections4:4.5.0"
         implementation 'org.apache.commons:commons-text:1.15.0'
         implementation "commons-dbutils:commons-dbutils:1.8.1"
-        implementation "com.google.guava:guava:33.5.0-jre"
+        implementation "com.google.guava:guava:33.6.0-jre"
         implementation "org.apache.httpcomponents:httpclient:4.5.14"
         implementation "black.ninia:jep:4.3.1"
         implementation 'com.github.pemistahl:lingua:1.2.2'
 
-        implementation "com.fasterxml.jackson.core:jackson-core:2.21.1"
-        implementation "com.fasterxml.jackson.core:jackson-databind:2.21.1"
-        implementation "com.fasterxml.jackson.module:jackson-module-afterburner:2.21.1"
-        implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.1"
+        implementation "com.fasterxml.jackson.core:jackson-core:2.21.3"
+        implementation "com.fasterxml.jackson.core:jackson-databind:2.21.3"
+        implementation "com.fasterxml.jackson.module:jackson-module-afterburner:2.21.3"
+        implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.21.3"
     }
 
     tasks.register('sourceJar', Jar) {
@@ -269,7 +269,7 @@ project("grobid-core") {
         implementation 'org.slf4j:slf4j-api:1.7.36'
         implementation 'ch.qos.logback:logback-classic:1.2.13'
 
-        implementation "org.apache.pdfbox:pdfbox:2.0.35"
+        implementation "org.apache.pdfbox:pdfbox:2.0.36"
 
         api "xerces:xercesImpl:2.12.2"
         api "net.arnx:jsonic:1.3.10"
@@ -280,7 +280,13 @@ project("grobid-core") {
         implementation "joda-time:joda-time:2.14.0"
         implementation "org.apache.lucene:lucene-analyzers-common:4.5.1"
         implementation 'black.ninia:jep:4.3.1'
-        implementation 'org.apache.opennlp:opennlp-tools:1.9.4'
+        implementation 'org.apache.opennlp:opennlp-tools:2.5.9'
+
+        // NOTE: jruby-complete bundles a vulnerable BouncyCastle (CVE-2026-5598) under its gem stdlib,
+        // but GROBID only uses jruby for the optional, non-default Pragmatic sentence segmenter, which
+        // never invokes Ruby's openssl — so the BC code is never loaded and the CVE is not triggerable.
+        // No released jruby ships a fixed BouncyCastle yet (latest bundles 1.83; the fix needs 1.84), so
+        // we leave it as-is and wait for an upstream jruby release with BouncyCastle >= 1.84.
         implementation group: 'org.jruby', name: 'jruby-complete', version: '9.4.12.1'
 
         shadedLib "org.apache.lucene:lucene-analyzers-common:4.5.1"
@@ -398,22 +404,31 @@ project(":grobid-service") {
         implementation project(':grobid-core')
         implementation project(':grobid-trainer')
 
-        //Dropwizard
-        implementation 'ru.vyarus:dropwizard-guicey:7.3.1'
+        //Dropwizard 5.x (Jakarta EE 10 / Jetty 12). guicey 8.x is the Dropwizard-5-compatible line.
+        implementation 'ru.vyarus:dropwizard-guicey:8.0.2'
 
-        implementation 'io.dropwizard:dropwizard-bom:4.0.17'
-        implementation 'io.dropwizard:dropwizard-core:4.0.17'
-        implementation 'io.dropwizard:dropwizard-assets:4.0.17'
-        implementation 'io.dropwizard:dropwizard-testing:4.0.17'
-        implementation 'io.dropwizard.modules:dropwizard-testing-junit4:4.0.16'
-        implementation 'io.dropwizard:dropwizard-forms:4.0.17'
-        implementation 'io.dropwizard:dropwizard-client:4.0.17'
-        implementation 'io.dropwizard:dropwizard-auth:4.0.17'
+        // Dropwizard 5.0.1 ships Jetty 12.1.5, but CVE-2026-2332 (HTTP request smuggling) is only fixed
+        // on the 12.1.x line at 12.1.7+. Import the Jetty BOMs at 12.1.9 so every Jetty artifact is
+        // forced past the vulnerable version (Gradle picks the higher of the two BOM-managed versions).
+        implementation platform('org.eclipse.jetty:jetty-bom:12.1.9')
+        implementation platform('org.eclipse.jetty.ee10:jetty-ee10-bom:12.1.9')
+
+        implementation 'io.dropwizard:dropwizard-bom:5.0.1'
+        implementation 'io.dropwizard:dropwizard-core:5.0.1'
+        implementation 'io.dropwizard:dropwizard-assets:5.0.1'
+        implementation 'io.dropwizard:dropwizard-testing:5.0.1'
+        implementation 'io.dropwizard.modules:dropwizard-testing-junit4:5.0.0'
+        implementation 'io.dropwizard:dropwizard-forms:5.0.1'
+        implementation 'io.dropwizard:dropwizard-client:5.0.1'
+        implementation 'io.dropwizard:dropwizard-auth:5.0.1'
         implementation 'io.dropwizard.metrics:metrics-core:4.2.38'
         implementation 'io.dropwizard.metrics:metrics-servlets:4.2.38'
-        implementation 'io.dropwizard:dropwizard-json-logging:4.0.17'
+        implementation 'io.dropwizard:dropwizard-json-logging:5.0.1'
+        // Jetty 12 split utility servlets/filters into the ee10 environment artifact; needed for
+        // org.eclipse.jetty.ee10.servlets.CrossOriginFilter (CORS). Version managed by jetty-ee10-bom.
+        implementation 'org.eclipse.jetty.ee10:jetty-ee10-servlets'
 
-        implementation "org.apache.pdfbox:pdfbox:2.0.35"
+        implementation "org.apache.pdfbox:pdfbox:2.0.36"
         implementation "javax.activation:activation:1.1.1"
         implementation "io.prometheus:simpleclient_dropwizard:0.16.0"
         implementation "io.prometheus:simpleclient_servlet:0.16.0"

--- a/build.gradle
+++ b/build.gradle
@@ -265,9 +265,11 @@ project("grobid-core") {
             }
         }
 
-        // Logs
-        implementation 'org.slf4j:slf4j-api:1.7.36'
-        implementation 'ch.qos.logback:logback-classic:1.2.13'
+        // Logs — slf4j 2.0.x + logback 1.5.x must move together: OpenNLP 2.5.x (and Dropwizard 5) pull
+        // slf4j-api 2.0.x, whose ServiceLoader binding (SLF4JServiceProvider) only exists in logback 1.5.x.
+        // logback 1.2.x would leave slf4j with no provider (NOP logging) in batch/standalone mode.
+        implementation 'org.slf4j:slf4j-api:2.0.17'
+        implementation 'ch.qos.logback:logback-classic:1.5.26'
 
         implementation "org.apache.pdfbox:pdfbox:2.0.36"
 
@@ -485,9 +487,9 @@ project(":grobid-trainer") {
         implementation "com.rockymadden.stringmetric:stringmetric-core_2.10:0.27.3"
         implementation "me.tongfei:progressbar:0.9.5"
 
-        // logs
-        implementation 'org.slf4j:slf4j-api:1.7.36'
-        implementation 'ch.qos.logback:logback-classic:1.2.13'
+        // logs — see grobid-core: slf4j 2.0.x needs logback 1.5.x for its ServiceLoader binding.
+        implementation 'org.slf4j:slf4j-api:2.0.17'
+        implementation 'ch.qos.logback:logback-classic:1.5.26'
     }
 
     configurations {

--- a/grobid-service/src/main/java/org/grobid/service/main/GrobidServiceApplication.java
+++ b/grobid-service/src/main/java/org/grobid/service/main/GrobidServiceApplication.java
@@ -16,7 +16,7 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterRegistration;
 import jakarta.servlet.ServletRegistration;
 import org.apache.commons.lang3.ArrayUtils;
-import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.eclipse.jetty.ee10.servlets.CrossOriginFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ru.vyarus.dropwizard.guice.GuiceBundle;


### PR DESCRIPTION
This PR solves vulnerabilities reported in #1438 

We made a general bump-up for all dependencies, we fixed:
 - openNLP https://github.com/grobidOrg/grobid/security/code-scanning/260, upgraded from 1.9.4 to 2.5.9
 - jetty https://github.com/grobidOrg/grobid/security/code-scanning/225 
 - the BouncyCastle library cannot be solved at the moment (no usable version of Jruby with the BC patch), however that part is not used by Grobid (https://github.com/grobidOrg/grobid/security/code-scanning/258) -- jruby-complete update was left  at 9.4.12.1

Deferred: 
 - PDFBox 2.x → 3.x — API changes (PDDocument.load → Loader, etc.); touches PDF parsing core. Heavy.
 - slf4j 1.7.36 → 2.x + logback 1.2.13 → 1.5.x — must move together; binding model changed.
 - Apache HttpClient 4.5.14 → 5.x — different package/API (org.apache.hc.*).
 - Saxon-HE 9.6.0-9 → 12.x, commons-pool 1.6 → 2.x, prometheus simpleclient 0.16.0 → client_java 1.x,
 PowerMock removal (already flagged TODO at build.gradle:239) — each independent, API-breaking.
 - Jruby-complete was left at 9.4.12.1