### PR TITLE
Make the CI run also on forks 

### DIFF
--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -46,25 +46,9 @@ jobs:
           file: build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
           debug: true
 
-  check-secrets:
-    needs: [build]
-    runs-on: ubuntu-latest
-    outputs:
-      can_push: ${{ steps.check.outputs.can_push }}
-    steps:
-      - id: check
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
-        run: |
-          if [ -n "$DOCKERHUB_USERNAME" ]; then
-            echo "can_push=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "can_push=false" >> "$GITHUB_OUTPUT"
-          fi
-
   docker-build-amd64:
-    needs: [build, check-secrets]
-    if: needs.check-secrets.outputs.can_push == 'true'
+    needs: [build]
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -105,8 +89,8 @@ jobs:
           cache-to: type=gha,scope=amd64,mode=max
 
   docker-build-arm64:
-    needs: [build, check-secrets]
-    if: needs.check-secrets.outputs.can_push == 'true'
+    needs: [build]
+    if: github.event.repository.fork == false
     runs-on: ubuntu-24.04-arm
     outputs:
       digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -46,8 +46,25 @@ jobs:
           file: build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
           debug: true
 
-  docker-build-amd64:
+  check-secrets:
     needs: [build]
+    runs-on: ubuntu-latest
+    outputs:
+      can_push: ${{ steps.check.outputs.can_push }}
+    steps:
+      - id: check
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME_LFOPPIANO }}
+        run: |
+          if [ -n "$DOCKERHUB_USERNAME" ]; then
+            echo "can_push=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_push=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  docker-build-amd64:
+    needs: [build, check-secrets]
+    if: needs.check-secrets.outputs.can_push == 'true'
     runs-on: ubuntu-latest
     outputs:
       digest: ${{ steps.build.outputs.digest }}
@@ -88,7 +105,8 @@ jobs:
           cache-to: type=gha,scope=amd64,mode=max
 
   docker-build-arm64:
-    needs: [build]
+    needs: [build, check-secrets]
+    if: needs.check-secrets.outputs.can_push == 'true'
     runs-on: ubuntu-24.04-arm
     outputs:
       digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
If the CI cannot run is a mess to merge PRs from external people, so the CI running on a fork should ignore pushing on the docker hub, but it should nevertheless not consider a success if our build run without credentials. 