### PR TITLE
Fix bug in the model selection with mixed DeLFT / wapiti and flavour selections

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/GrobidModels.java
+++ b/grobid-core/src/main/java/org/grobid/core/GrobidModels.java
@@ -172,7 +172,7 @@ public enum GrobidModels implements GrobidModel {
             return model;
         }
         GrobidModel grobidModel = modelFor(model.toString() + "/" + flavor.getLabel().toLowerCase());
-        if (flavoredModelExistsOnDisk(model, grobidModel)) {
+        if (flavoredModelExistsOnDisk(grobidModel)) {
             return grobidModel;
         }
         LOGGER.info(
@@ -191,23 +191,23 @@ public enum GrobidModels implements GrobidModel {
     /**
      * Returns true when a trained model file/directory for the flavored model exists on disk.
      *
-     * The check must be engine-aware because Wapiti and DeLFT use different on-disk layouts:
-     *   - Wapiti:  <home>/models/<flavor-folder>/model.wapiti            (a file, slash-separated path)
-     *   - DeLFT:   <home>/models/<hyphenated-name>-<architecture>/      (a directory, hyphenated name)
+     * The check is engine-aware because Wapiti and DeLFT use different on-disk layouts:
+     *   - Wapiti:  <home>/models/<flavor-folder>/model.wapiti          (a file, slash-separated path)
+     *   - DeLFT:   <home>/models/<hyphenated-name>-<architecture>/    (a directory, hyphenated name)
      *
-     * The engine is read from the base model — flavors inherit the engine from the base
-     * (and after the YAML cleanup, flavors typically have no config entry of their own).
+     * Both engine and DeLFT architecture are resolved against the flavored model itself.
+     * The field-level prefix-fallback in GrobidProperties means each field is inherited
+     * from the closest ancestor when the flavor entry omits it, or used as-is when the
+     * flavor entry sets it explicitly — so this helper does not need a separate handle
+     * on the base model.
      *
-     * @param baseModel     the unflavored model (used to read engine + architecture from config)
      * @param flavoredModel the candidate flavored model whose existence we are testing
      * @return true if a usable model exists on disk for {@code flavoredModel}
      */
-    private static boolean flavoredModelExistsOnDisk(GrobidModel baseModel, GrobidModel flavoredModel) {
-        // Both engine and DeLFT architecture are resolved against the flavored model.
-        // The field-level prefix-fallback in GrobidProperties means each field is
-        // inherited from the base when the flavor entry omits it, or overridden when
-        // the flavor entry sets it explicitly (e.g. a Wapiti-only flavor of a DeLFT
-        // base must set `engine: "wapiti"` on the flavor entry — see header-sdo-ietf).
+    private static boolean flavoredModelExistsOnDisk(GrobidModel flavoredModel) {
+        // A flavor that omits `engine:` inherits from the base; a flavor that sets it
+        // explicitly overrides — e.g. a Wapiti-only flavor of a DeLFT base must set
+        // `engine: "wapiti"` on the flavor entry (see header-sdo-ietf in grobid.yaml).
         GrobidCRFEngine engine = GrobidProperties.getGrobidEngine(flavoredModel);
 
         if (engine == GrobidCRFEngine.DELFT) {

--- a/grobid-core/src/main/java/org/grobid/core/GrobidModels.java
+++ b/grobid-core/src/main/java/org/grobid/core/GrobidModels.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.grobid.core.engines.tagging.GrobidCRFEngine;
 import org.grobid.core.utilities.GrobidProperties;
 
 /**
@@ -169,18 +170,60 @@ public enum GrobidModels implements GrobidModel {
     public static GrobidModel getModelFlavor(GrobidModel model, Flavor flavor) {
         if (flavor == null) {
             return model;
-        } else {
-            GrobidModel grobidModel = modelFor(model.toString() + "/" + flavor.getLabel().toLowerCase());
-            if (!Files.exists(Paths.get(grobidModel.getModelPath()))) {
-                LOGGER.info(
-                        "The requested model flavor "
-                                + flavor.getLabel()
-                                + " model is not available. Defaulting to the standard model. ");
-                return model;
-            } else {
-                return grobidModel;
-            }
         }
+        GrobidModel grobidModel = modelFor(model.toString() + "/" + flavor.getLabel().toLowerCase());
+        if (flavoredModelExistsOnDisk(model, grobidModel)) {
+            return grobidModel;
+        }
+        LOGGER.info(
+                "The requested flavor "
+                        + flavor.getLabel()
+                        + " for model "
+                        + model.getModelName()
+                        + " (resolved engine: "
+                        + GrobidProperties.getGrobidEngine(grobidModel)
+                        + ") is not available on disk. Defaulting to the standard model. "
+                        + "Note: a flavor's engine and architecture are inherited from the "
+                        + "base unless explicitly set on the flavor entry.");
+        return model;
+    }
+
+    /**
+     * Returns true when a trained model file/directory for the flavored model exists on disk.
+     *
+     * The check must be engine-aware because Wapiti and DeLFT use different on-disk layouts:
+     *   - Wapiti:  <home>/models/<flavor-folder>/model.wapiti            (a file, slash-separated path)
+     *   - DeLFT:   <home>/models/<hyphenated-name>-<architecture>/      (a directory, hyphenated name)
+     *
+     * The engine is read from the base model — flavors inherit the engine from the base
+     * (and after the YAML cleanup, flavors typically have no config entry of their own).
+     *
+     * @param baseModel     the unflavored model (used to read engine + architecture from config)
+     * @param flavoredModel the candidate flavored model whose existence we are testing
+     * @return true if a usable model exists on disk for {@code flavoredModel}
+     */
+    private static boolean flavoredModelExistsOnDisk(GrobidModel baseModel, GrobidModel flavoredModel) {
+        // Both engine and DeLFT architecture are resolved against the flavored model.
+        // The field-level prefix-fallback in GrobidProperties means each field is
+        // inherited from the base when the flavor entry omits it, or overridden when
+        // the flavor entry sets it explicitly (e.g. a Wapiti-only flavor of a DeLFT
+        // base must set `engine: "wapiti"` on the flavor entry — see header-sdo-ietf).
+        GrobidCRFEngine engine = GrobidProperties.getGrobidEngine(flavoredModel);
+
+        if (engine == GrobidCRFEngine.DELFT) {
+            String architecture = GrobidProperties.getDelftArchitecture(flavoredModel);
+            if (StringUtils.isBlank(architecture)) {
+                return false;
+            }
+            File dlDir = new File(
+                    GrobidProperties.getModelPath(),
+                    flavoredModel.getModelName() + "-" + architecture);
+            return dlDir.isDirectory();
+        }
+
+        // Wapiti (and any non-DL engine): file-based check at the flavor folder path.
+        String path = flavoredModel.getModelPath();
+        return path != null && Files.exists(Paths.get(path));
     }
 
     public static GrobidModel modelFor(final String name) {

--- a/grobid-core/src/main/java/org/grobid/core/engines/AbstractParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AbstractParser.java
@@ -21,6 +21,11 @@ public abstract class AbstractParser implements GenericTagger, Closeable {
     protected final GrobidModel model;
     protected GrobidAnalyzer analyzer = GrobidAnalyzer.getInstance();
 
+    // The flavor-aware model this parser was constructed with. Subclasses re-query the engine
+    // and DeLFT runtime params against this model (not against a hardcoded base constant), so
+    // that flavor overrides are honored.
+    protected final GrobidModel model;
+
     protected CntManager cntManager = CntManagerFactory.getNoOpCntManager();
 
     protected AbstractParser(GrobidModel model) {

--- a/grobid-core/src/main/java/org/grobid/core/engines/AbstractParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AbstractParser.java
@@ -21,11 +21,6 @@ public abstract class AbstractParser implements GenericTagger, Closeable {
     protected final GrobidModel model;
     protected GrobidAnalyzer analyzer = GrobidAnalyzer.getInstance();
 
-    // The flavor-aware model this parser was constructed with. Subclasses re-query the engine
-    // and DeLFT runtime params against this model (not against a hardcoded base constant), so
-    // that flavor overrides are honored.
-    protected final GrobidModel model;
-
     protected CntManager cntManager = CntManagerFactory.getNoOpCntManager();
 
     protected AbstractParser(GrobidModel model) {

--- a/grobid-core/src/main/java/org/grobid/core/engines/ReferenceSegmenterParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/ReferenceSegmenterParser.java
@@ -138,14 +138,14 @@ public class ReferenceSegmenterParser extends AbstractParser implements Referenc
         // this does not apply to CRF which can process "infinite" input sequence
         // this is relevant to the reference segmenter RNN model, which is position-free in its
         // application, but could not be generalized to other RNN or transformer model long inputs
-        if (GrobidProperties.getGrobidEngine(GrobidModels.REFERENCE_SEGMENTER) == GrobidCRFEngine.DELFT) {
+        if (GrobidProperties.getGrobidEngine(this.model) == GrobidCRFEngine.DELFT) {
             String[] featureVectorLines = featureVector.split("\n");
 
             int originalMaxSequence = 2000;
             if (GrobidProperties.getInstance()
-                    .getDelftRuntimeMaxSequenceLength(GrobidModels.REFERENCE_SEGMENTER.getModelName()) != -1) {
+                    .getDelftRuntimeMaxSequenceLength(this.model.getModelName()) != -1) {
                 originalMaxSequence = GrobidProperties.getInstance()
-                        .getDelftRuntimeMaxSequenceLength(GrobidModels.REFERENCE_SEGMENTER.getModelName());
+                        .getDelftRuntimeMaxSequenceLength(this.model.getModelName());
             }
 
             if (featureVectorLines.length < originalMaxSequence || originalMaxSequence < 600) {

--- a/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
+++ b/grobid-core/src/main/java/org/grobid/core/utilities/GrobidProperties.java
@@ -641,10 +641,20 @@ public class GrobidProperties {
     }
 
     public static String getGrobidEngineName(final String modelName) {
-        ModelParameters param = getGrobidModelParameters(modelName);
-        if (param == null)
-            return null;
-        return param.engine;
+        // Field-level prefix-fallback: a flavor entry that does not declare an engine
+        // inherits it from the closest ancestor (by stripping trailing "-suffix" tokens)
+        // that does. This lets flavor entries focus on per-flavor overrides (e.g. a
+        // different DeLFT architecture) without having to repeat the base's engine.
+        String name = modelName;
+        while (name != null) {
+            ModelParameters param = modelMap.get(name);
+            if (param != null && StringUtils.isNotBlank(param.engine)) {
+                return param.engine;
+            }
+            int ind = name.lastIndexOf("-");
+            name = (ind == -1) ? null : name.substring(0, ind);
+        }
+        return null;
     }
 
     public static GrobidCRFEngine getGrobidEngine(final String modelName) {
@@ -879,17 +889,21 @@ public class GrobidProperties {
     }
 
     public static String getDelftArchitecture(final String modelName) {
-        ModelParameters param = getGrobidModelParameters(modelName);
-        if (param == null) {
-            LOGGER.debug("No configuration parameter defined for model " + modelName);
-            return null;
+        // Field-level prefix-fallback: a flavor entry without `delft.architecture`
+        // inherits the architecture from the closest ancestor that sets it.
+        String name = modelName;
+        while (name != null) {
+            ModelParameters param = modelMap.get(name);
+            if (param != null
+                    && param.delft != null
+                    && StringUtils.isNotBlank(param.delft.architecture)) {
+                return param.delft.architecture;
+            }
+            int ind = name.lastIndexOf("-");
+            name = (ind == -1) ? null : name.substring(0, ind);
         }
-        DelftModelParameters delftParam = param.delft;
-        if (delftParam == null) {
-            LOGGER.debug("No configuration parameter defined for DeLFT engine for model " + modelName);
-            return null;
-        }
-        return param.delft.architecture;
+        LOGGER.debug("No DeLFT architecture configured for model " + modelName + " or any ancestor");
+        return null;
     }
 
     public static String getDelftEmbeddingsName(final String modelName) {

--- a/grobid-home/config/grobid-full.yaml
+++ b/grobid-home/config/grobid-full.yaml
@@ -39,7 +39,15 @@ grobid:
       # to use Crossref metadata plus service (available by subscription)
       #token: "yourmysteriouscrossrefmetadataplusauthorizationtokentobeputhere"
       timeoutSec: 60
+      # Minimum delay between consecutive CrossRef API requests (in milliseconds).
+      # Default: auto-computed from API tier (Plus=7ms/150req/s, Polite=100ms/10req/s, Public=200ms/5req/s).
+      # Set to a positive value to override the auto-computed rate limit.
+      #minRequestIntervalMs: 50
       # Timeout for CrossRef API calls (in seconds) - USE with CARE!
+      # Whether to post-validate CrossRef results against the source metadata.
+      # Glutton always skips post-validation (it handles validation internally).
+      # For CrossRef, set to false to disable post-validation.
+      postValidation: true
   proxy:
     # proxy to be used when doing external call to the consolidation service
     host:
@@ -84,6 +92,24 @@ grobid:
     # for feature-engineered CRF, use "wapiti" and possible training parameters are window, epsilon and nbMaxIterations
     # for Deep Learning, use "delft" and select the target DL architecture (see DeLFT library), the training
     # parameters then depends on this selected DL architecture
+    #
+    # Flavor inheritance
+    # ------------------
+    # Flavor entries (whose name extends a base, e.g. "segmentation-article-light" for
+    # base "segmentation") inherit each field from the closest ancestor that sets it.
+    # To override a field for a specific flavor, set it explicitly on that flavor entry.
+    #
+    # This applies in particular to:
+    #   - engine:           if omitted, follows the base. Set it to override —
+    #                       e.g. a Wapiti-only flavor of a DeLFT base must set
+    #                       `engine: "wapiti"` (see header-sdo-ietf below).
+    #   - delft.architecture: if omitted, follows the base. Set it to pick a
+    #                       different DL architecture per flavor.
+    #
+    # The resolved engine for a flavor must match the model that exists on disk.
+    # If the resolved engine is DeLFT but no DL model directory is present (or vice
+    # versa for Wapiti), the system logs a "not available" message and falls back
+    # to the base model.
 
     - name: "segmentation"
       # at this time, must always be CRF wapiti, the input sequence size is too large for a Deep Learning implementation
@@ -108,7 +134,7 @@ grobid:
           batch_size: 10
 
     - name: "segmentation-article-light"
-      engine: "wapiti"
+      # engine inherited from "segmentation"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.0000001
@@ -116,7 +142,7 @@ grobid:
         nbMaxIterations: 2000
 
     - name: "segmentation-article-light-ref"
-      engine: "wapiti"
+      # engine inherited from "segmentation"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.0000001
@@ -124,6 +150,7 @@ grobid:
         nbMaxIterations: 2000
 
     - name: "segmentation-sdo-ietf"
+      # explicit: only a Wapiti model is available for this flavor
       engine: "wapiti"
       wapiti:
         # wapiti training parameters, they will be used at training time only
@@ -166,30 +193,23 @@ grobid:
           batch_size: 9
 
     - name: "header-article-light"
-#      engine: "wapiti"
-      engine: "delft"
+      # engine inherited from "header"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.000001
         window: 30
         nbMaxIterations: 1500
-      delft:
-        architecture: "BidLSTM_ChainCRF_FEATURES"
-        useELMo: false
 
     - name: "header-article-light-ref"
-#      engine: "wapiti"
-      engine: "delft"
+      # engine inherited from "header"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.000001
         window: 30
         nbMaxIterations: 1500
-      delft:
-        architecture: "BidLSTM_ChainCRF_FEATURES"
-        useELMo: false
 
     - name: "header-sdo-ietf"
+      # explicit: only a Wapiti model is available for this flavor
       engine: "wapiti"
       wapiti:
         # wapiti training parameters, they will be used at training time only

--- a/grobid-home/config/grobid.yaml
+++ b/grobid-home/config/grobid.yaml
@@ -150,7 +150,8 @@ grobid:
         nbMaxIterations: 2000
 
     - name: "segmentation-sdo-ietf"
-      # engine inherited from "segmentation"
+      # explicit: only a Wapiti model is available for this flavor
+      engine: "wapiti"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.0000001
@@ -202,6 +203,7 @@ grobid:
 
     - name: "header-article-light-ref"
       # engine inherited from "header"
+      engine: "wapiti"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.000001
@@ -209,8 +211,7 @@ grobid:
         nbMaxIterations: 1500
 
     - name: "header-sdo-ietf"
-      # engine override: only a Wapiti model exists on disk for this flavor
-      # (grobid-home/models/header/sdo/ietf/model.wapiti).
+      # engine override: only a Wapiti model is available for this flavor
       engine: "wapiti"
       wapiti:
         # wapiti training parameters, they will be used at training time only

--- a/grobid-home/config/grobid.yaml
+++ b/grobid-home/config/grobid.yaml
@@ -6,7 +6,7 @@ grobid:
 
   # path relative to the grobid-home path (e.g. tmp for grobid-home/tmp) or absolute path (/tmp)
   temp: "tmp"
-  
+
   # normally nothing to change here, path relative to the grobid-home path (e.g. grobid-home/lib)
   nativelibrary: "lib"
 
@@ -23,7 +23,7 @@ grobid:
     tokensMax: 1000000
 
   consolidation:
-    # define the bibliographical data consolidation service to be used, either "crossref" for CrossRef REST API or 
+    # define the bibliographical data consolidation service to be used, either "crossref" for CrossRef REST API or
     # "glutton" for https://github.com/kermitt2/biblio-glutton
     service: "crossref"
     #service: "glutton"
@@ -50,8 +50,8 @@ grobid:
       postValidation: true
   proxy:
     # proxy to be used when doing external call to the consolidation service
-    host: 
-    port: 
+    host:
+    port:
 
   # CORS configuration for the GROBID web API service
   corsAllowedOrigins: "*"
@@ -66,18 +66,18 @@ grobid:
   #sentenceDetectorFactory: "org.grobid.core.lang.impl.PragmaticSentenceDetectorFactory"
   sentenceDetectorFactory: "org.grobid.core.lang.impl.OpenNLPSentenceDetectorFactory"
   #sentenceDetectorFactory: "org.grobid.core.lang.impl.BlingFireSentenceDetectorFactory"
-  
+
   # maximum concurrency allowed to GROBID server for processing parallel requests - change it according to your CPU/GPU capacities
   # for a production server running only GROBID, set the value slightly above the available number of threads of the server
   # to get the best performance and security
   concurrency: 10
-  # when the pool is full, for queries waiting for the availability of a Grobid engine, this is the maximum time wait to try 
+  # when the pool is full, for queries waiting for the availability of a Grobid engine, this is the maximum time wait to try
   # to get an engine (in seconds) - normally never change it
   poolMaxWait: 1
 
   delft:
     # DeLFT global parameters
-    # delft installation path if Deep Learning architectures are used to implement one of the sequence labeling model, 
+    # delft installation path if Deep Learning architectures are used to implement one of the sequence labeling model,
     # embeddings are usually compiled as lmdb under delft/data (this parameter is ignored if only featured-engineered CRF are used)
     install: "../delft"
     pythonVirtualEnv:
@@ -90,9 +90,27 @@ grobid:
   models:
     # we configure here how each sequence labeling model should be implemented
     # for feature-engineered CRF, use "wapiti" and possible training parameters are window, epsilon and nbMaxIterations
-    # for Deep Learning, use "delft" and select the target DL architecture (see DeLFT library), the training 
-    # parameters then depends on this selected DL architecture 
-    
+    # for Deep Learning, use "delft" and select the target DL architecture (see DeLFT library), the training
+    # parameters then depends on this selected DL architecture
+    #
+    # Flavor inheritance
+    # ------------------
+    # Flavor entries (whose name extends a base, e.g. "segmentation-article-light" for
+    # base "segmentation") inherit each field from the closest ancestor that sets it.
+    # To override a field for a specific flavor, set it explicitly on that flavor entry.
+    #
+    # This applies in particular to:
+    #   - engine:           if omitted, follows the base. Set it to override —
+    #                       e.g. a Wapiti-only flavor of a DeLFT base must set
+    #                       `engine: "wapiti"` (see header-sdo-ietf below).
+    #   - delft.architecture: if omitted, follows the base. Set it to pick a
+    #                       different DL architecture per flavor.
+    #
+    # The resolved engine for a flavor must match the model that exists on disk.
+    # If the resolved engine is DeLFT but no DL model directory is present (or vice
+    # versa for Wapiti), the system logs a "not available" message and falls back
+    # to the base model.
+
     - name: "segmentation"
       # at this time, must always be CRF wapiti, the input sequence size is too large for a Deep Learning implementation
       engine: "wapiti"
@@ -116,7 +134,7 @@ grobid:
           batch_size: 10
 
     - name: "segmentation-article-light"
-      engine: "wapiti"
+      # engine inherited from "segmentation"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.0000001
@@ -124,7 +142,7 @@ grobid:
         nbMaxIterations: 2000
 
     - name: "segmentation-article-light-ref"
-      engine: "wapiti"
+      # engine inherited from "segmentation"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.0000001
@@ -132,7 +150,7 @@ grobid:
         nbMaxIterations: 2000
 
     - name: "segmentation-sdo-ietf"
-      engine: "wapiti"
+      # engine inherited from "segmentation"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.0000001
@@ -152,7 +170,7 @@ grobid:
       engine: "wapiti"
       #engine: "delft"
       wapiti:
-        # wapiti training parameters, they will be used at training time only  
+        # wapiti training parameters, they will be used at training time only
         epsilon: 0.000001
         window: 30
         nbMaxIterations: 1500
@@ -174,30 +192,25 @@ grobid:
           batch_size: 9
 
     - name: "header-article-light"
-      engine: "wapiti"
-#      engine: "delft"
+      # engine inherited from "header"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.000001
         window: 30
         nbMaxIterations: 1500
-      delft:
-        architecture: "BidLSTM_ChainCRF_FEATURES"
-        useELMo: false
+
 
     - name: "header-article-light-ref"
-      engine: "wapiti"
-#      engine: "delft"
+      # engine inherited from "header"
       wapiti:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.000001
         window: 30
         nbMaxIterations: 1500
-      delft:
-        architecture: "BidLSTM_ChainCRF_FEATURES"
-        useELMo: false
 
     - name: "header-sdo-ietf"
+      # engine override: only a Wapiti model exists on disk for this flavor
+      # (grobid-home/models/header/sdo/ietf/model.wapiti).
       engine: "wapiti"
       wapiti:
         # wapiti training parameters, they will be used at training time only
@@ -264,7 +277,7 @@ grobid:
         # wapiti training parameters, they will be used at training time only
         epsilon: 0.00001
         window: 20
-      delft:  
+      delft:
         # deep learning parameters
         architecture: "BidLSTM_CRF"
 
@@ -295,7 +308,7 @@ grobid:
           batch_size: 30
         training:
           # parameters used for training
-          max_sequence_length: 500  
+          max_sequence_length: 500
           batch_size: 50
 
     - name: "patent-citation"
@@ -338,11 +351,11 @@ grobid:
           batch_size: 20
         training:
           # parameters used for training
-          max_sequence_length: 500  
+          max_sequence_length: 500
           batch_size: 40
 
     - name: "copyright"
-      # at this time, we only have a DeLFT implementation, 
+      # at this time, we only have a DeLFT implementation,
       # use "wapiti" if the deep learning library JNI is not available and model will then be ignored
       #engine: "delft"
       engine: "wapiti"
@@ -363,10 +376,10 @@ grobid:
         #architecture: "bert"
         #transformer: "allenai/scibert_scivocab_cased"
 
-  # for **service only**: how to load the models, 
-  # false -> models are loaded when needed, avoiding putting in memory useless models (only in case of CRF) but slow down 
+  # for **service only**: how to load the models,
+  # false -> models are loaded when needed, avoiding putting in memory useless models (only in case of CRF) but slow down
   #          significantly the service at first call
-  # true -> all the models are loaded into memory at the server startup (default), slow the start of the services 
+  # true -> all the models are loaded into memory at the server startup (default), slow the start of the services
   #         and models not used will take some more memory (only in case of CRF), but server is immediatly warm and ready
   modelPreload: true
 


### PR DESCRIPTION
##  Problem
When a flavor (e.g. article/light, article/dh-law-footnotes, sdo/ietf) was requested for a model whose base was configured as DeLFT, the flavor model was never selected — the system silently fell back to the base. Two failure modes were observed:

1. Base = DeLFT, flavor = DeLFT — flavor not picked up even when a valid DL model directory existed on disk (e.g. header-article-light-BidLSTM_ChainCRF_FEATURES/).
2. Base = Wapiti, hardcoded GrobidModels.REFERENCE_SEGMENTER — the labelWithLongSequenceSupport() path in ReferenceSegmenterParser queried the base model's engine regardless of which flavor the parser was constructed with, so the DeLFT branch could be incorrectly entered or skipped.

## Root cause

GrobidModels.getModelFlavor() (introduced in b07893cb7) checked filesystem existence at the Wapiti path layout — models/<flavor-folder>/model.wapiti. This is correct for Wapiti, but DeLFT models live under a completely different directory naming convention — models/<hyphenated-name>-<architecture>/ — so the existence check silently failed for any DL flavor, and the fallback to the base wrongly triggered.

## How the four scenarios now resolve

  1. Flavor entry has no engine, DL model on disk (e.g. header-article-light): getGrobidEngine(flavoredModel) walks up → returns delft from header. Checks header-article-light-BidLSTM_ChainCRF_FEATURES/ → exists → flavor used.
  2. Flavor entry has no engine, nothing on disk: same engine resolution, dir not found → log line names "resolved engine: DELFT" and falls back to base.
  3. Flavor entry sets engine: wapiti (e.g. header-sdo-ietf): override returned directly. Checks models/header/sdo/ietf/model.wapiti → exists → flavor used.
  4. Override mismatch (flavor sets engine: delft but no DL dir): falls back to base, log line names the resolved engine so the misconfiguration is visible.