### PR TITLE
Fix #149

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/visualization/CitationsVisualizer.java
+++ b/grobid-core/src/main/java/org/grobid/core/visualization/CitationsVisualizer.java
@@ -170,6 +170,16 @@ public class CitationsVisualizer {
         String[] split = coords.split(",");
 
         Long pageNum = Long.valueOf(split[0], 10) - 1;
+
+        if (pageNum < 0 || pageNum >= document.getNumberOfPages()) {
+            LOGGER.warn(
+                    "Annotation skipped: page index "
+                            + (pageNum + 1)
+                            + " is out of range (document reports "
+                            + document.getNumberOfPages()
+                            + " page(s)).");
+            return;
+        }
         PDPage page = document.getDocumentCatalog().getPages().get(pageNum.intValue());
 
         PDRectangle mediaBox = page.getCropBox();


### PR DESCRIPTION
Add a guard when calling the pdf visualiser in case the page number runs out of range. 