### PR TITLE
Close open <bibl> before <other> in reference-segmenter training data

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/ReferenceSegmenterParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/ReferenceSegmenterParser.java
@@ -493,6 +493,11 @@ public class ReferenceSegmenterParser extends AbstractParser implements Referenc
                 } else {
                     output = writeField(label, lastTag, tok, "<other>", "", addSpace, addEOL, 2);
                     if (output != null) {
+                        // close any open <bibl> before emitting the <other> content,
+                        // otherwise the generated training XML is unbalanced (issue #1355)
+                        if (refOpen) {
+                            sb.append("</bibl>");
+                        }
                         sb.append(output);
                         refOpen = false;
                     }


### PR DESCRIPTION
This resolves #1355

createTrainingData() emitted an <other> segment while a <bibl> was still open, producing unbalanced (invalid) XML in the generated *.training.references.tei.xml. Close the open <bibl> before writing the <other> content, mirroring the existing end-of-loop handling.