### PR TITLE
Make block/segmentation desync warning locatable 

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/FullTextParser.java
@@ -1047,9 +1047,21 @@ public class FullTextParser extends AbstractParser {
                 if (blockIndex == dp2.getBlockPtr()) {
                     lastPos = dp2.getTokenBlockPos() + 1;
                     if (lastPos > tokens.size()) {
-                        LOGGER.warn("DocumentPointer for block " + blockIndex + " points to " +
-                            dp2.getTokenBlockPos() + " token, but block token size is " +
-                            tokens.size());
+                        // The end DocumentPointer references a token position beyond this
+                        // block's actual token count: a block/segmentation desynchronisation.
+                        // We clamp and carry on (the document is still processed), but log the
+                        // page and a text excerpt so the offending region is locatable in the
+                        // source PDF -- earlier reports of this could never be reproduced for
+                        // lack of any locating information (issue #716).
+                        String blockExcerpt = (localText == null) ? "" :
+                            localText.replaceAll("[\\n\\r\\t ]+", " ").trim();
+                        if (blockExcerpt.length() > 80) {
+                            blockExcerpt = blockExcerpt.substring(0, 80) + "...";
+                        }
+                        LOGGER.warn("DocumentPointer for block " + blockIndex + " (page " +
+                            block.getPageNumber() + ") points to token " + dp2.getTokenBlockPos() +
+                            ", but block token size is " + tokens.size() + "; clamping. " +
+                            "Block starts with: \"" + blockExcerpt + "\"");
                         lastPos = tokens.size();
                     }
                 }


### PR DESCRIPTION
The end DocumentPointer of a document piece can reference a token position beyond the block's actual token count. The code already clamps and continues, so the document is still processed, but the warning named only the block index and token counts -- nothing that let a user locate the offending region in the source PDF. Reports of this could therefore never be reproduced.

Enrich the warning with the page number and a short text excerpt of the block so the next occurrence yields the missing reproduction case, while keeping the existing clamp behaviour unchanged.

This PR prints more information based on the report on #716