### PR TITLE
Restrict Coveralls publishing to the ubuntu-latest CI job

### DIFF
--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -38,7 +38,7 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Coveralls GitHub Action
-        if: matrix.os != 'macos-15-intel'
+        if: ${{ !startsWith(matrix.os, 'macos') }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -32,7 +32,7 @@ jobs:
         run: ./gradlew assemble test jacocoTestReport --info --stacktrace
 
       - name: Run Coveralls Gradle task
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: matrix.os == 'ubuntu-latest'
         run: ./gradlew coveralls --info --stacktrace
 
       - name: Publish Test Report
@@ -42,7 +42,7 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Coveralls GitHub Action
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-build-unstable.yml
+++ b/.github/workflows/ci-build-unstable.yml
@@ -29,7 +29,11 @@ jobs:
         run: ./gradlew spotlessCheck
         continue-on-error: false
       - name: Build and test
-        run: ./gradlew assemble test jacocoTestReport coveralls --info --stacktrace
+        run: ./gradlew assemble test jacocoTestReport --info --stacktrace
+
+      - name: Run Coveralls Gradle task
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: ./gradlew coveralls --info --stacktrace
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v4
@@ -38,7 +42,7 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
 
       - name: Coveralls GitHub Action
-        if: ${{ !startsWith(matrix.os, 'macos') }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Coveralls was being invoked from multiple Linux runners in the unstable build matrix, even though coverage publishing should happen once from the canonical Ubuntu job. This change limits both the Gradle Coveralls task and the Coveralls upload action to `ubuntu-latest` while leaving the rest of the matrix unchanged.

- **Workflow behavior**
  - Remove `coveralls` from the shared matrix build/test command.
  - Keep `assemble`, `test`, and `jacocoTestReport` running on all configured runners.

- **Coverage publishing**
  - Add a dedicated Gradle `coveralls` step gated to `matrix.os == 'ubuntu-latest'`.
  - Gate the Coveralls GitHub Action to the same `ubuntu-latest` job so upload happens only once.

- **Result**
  - Coverage generation still happens in CI.
  - Coveralls execution is centralized to the single intended runner.

```yaml
- name: Build and test
  run: ./gradlew assemble test jacocoTestReport --info --stacktrace

- name: Run Coveralls Gradle task
  if: matrix.os == 'ubuntu-latest'
  run: ./gradlew coveralls --info --stacktrace

- name: Coveralls GitHub Action
  if: matrix.os == 'ubuntu-latest'
  uses: coverallsapp/github-action@v2
```