### PR TITLE
Fix ZipUtils flagged advisor from CodeQL

### DIFF
--- a/grobid-service/src/main/java/org/grobid/service/util/ZipUtils.java
+++ b/grobid-service/src/main/java/org/grobid/service/util/ZipUtils.java
@@ -31,21 +31,17 @@ public class ZipUtils {
             return pb;
     }
 
-    public static final void copyInputStream(InputStream in, OutputStream out)
+    private static void copyInputStream(InputStream in, OutputStream out)
             throws IOException {
         byte[] buffer = new byte[1024];
         int len;
 
         while ((len = in.read(buffer)) >= 0)
             out.write(buffer, 0, len);
-
-        in.close();
-        out.close();
     }
 
     public static final void main(String[] args) {
         Enumeration entries;
-        ZipFile zipFile;
 
         if (args.length != 1) {
             System.err.println("Usage: Unzip zipfile");
@@ -53,9 +49,7 @@ public class ZipUtils {
         }
 
         String pPath = args[0];
-        try {
-            zipFile = new ZipFile(pPath);
-
+        try (ZipFile zipFile = new ZipFile(pPath)) {
             entries = zipFile.entries();
 
             File tempDir = IOUtilities.newTempFile(
@@ -89,18 +83,20 @@ public class ZipUtils {
                             "Extracting directory: "
                                     + entry.getName());
                     // This is not robust, just for demonstration purposes.
-                    outFile.mkdir();
+                    if (!outFile.mkdir() && !outFile.isDirectory()) {
+                        throw new IOException("Could not create directory: " + outFile.getAbsolutePath());
+                    }
                     continue;
                 }
 
                 System.err.println("Extracting file: " + entry.getName());
 
-                copyInputStream(
-                        zipFile.getInputStream(entry),
-                        new BufferedOutputStream(new FileOutputStream(outFile)));
+                try (InputStream in = zipFile.getInputStream(entry);
+                        FileOutputStream fos = new FileOutputStream(outFile);
+                        OutputStream out = new BufferedOutputStream(fos)) {
+                    copyInputStream(in, out);
+                }
             }
-
-            zipFile.close();
         } catch (IOException ioe) {
             System.err.println("Unhandled exception:");
             ioe.printStackTrace();

--- a/grobid-service/src/main/java/org/grobid/service/util/ZipUtils.java
+++ b/grobid-service/src/main/java/org/grobid/service/util/ZipUtils.java
@@ -70,8 +70,17 @@ public class ZipUtils {
                         + tempDir.getAbsolutePath());
             }
 
+            File canonicalTempDir = tempDir.getCanonicalFile();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = (ZipEntry) entries.nextElement();
+
+                // Resolve and validate the output path before any filesystem
+                // operation to prevent path traversal (Zip Slip).
+                File outFile = new File(canonicalTempDir.getAbsolutePath() + File.separator + entry.getName())
+                        .getCanonicalFile();
+                if (!outFile.toPath().startsWith(canonicalTempDir.toPath())) {
+                    throw new IOException("Bad zip entry: " + entry.getName());
+                }
 
                 if (entry.isDirectory()) {
                     // Assume directories are stored parents first then
@@ -80,13 +89,7 @@ public class ZipUtils {
                             "Extracting directory: "
                                     + entry.getName());
                     // This is not robust, just for demonstration purposes.
-
-                    File dir = new File(tempDir.getAbsolutePath() + File.separator + entry.getName())
-                            .getCanonicalFile();
-                    if (!dir.toPath().startsWith(tempDir.toPath())) {
-                        throw new IOException("Bad zip entry: " + entry.getName());
-                    }
-                    dir.mkdir();
+                    outFile.mkdir();
                     continue;
                 }
 
@@ -94,16 +97,7 @@ public class ZipUtils {
 
                 copyInputStream(
                         zipFile.getInputStream(entry),
-                        new BufferedOutputStream(new FileOutputStream(new File(tempDir
-                                .getAbsolutePath()
-                                + File.separator
-                                + entry.getName()).getCanonicalFile())));
-                File outFile = new File(tempDir.getAbsolutePath() + File.separator + entry.getName())
-                        .getCanonicalFile();
-                if (!outFile.toPath().startsWith(tempDir.toPath())) {
-                    throw new IOException("Bad zip entry: " + entry.getName());
-                }
-                copyInputStream(zipFile.getInputStream(entry), new BufferedOutputStream(new FileOutputStream(outFile)));
+                        new BufferedOutputStream(new FileOutputStream(outFile)));
             }
 
             zipFile.close();


### PR DESCRIPTION
What changed in main()'s extraction loop:
- Hoisted File canonicalTempDir = tempDir.getCanonicalFile(); out of the loop (computed once).
- Moved the canonical-path resolution and validation to the top of the loop, before any mkdir or write — so outFile.toPath().startsWith(canonicalTempDir.toPath()) is now the gate for every entry.
- Directory branch now calls outFile.mkdir().
- File branch does a single copyInputStream(...) write.
- Removed the two bugs: the unsafe first write that happened before validation, and the redundant second write.