### PR TITLE
Enable affiliation evaluation in End 2 end evaluation

### DIFF
--- a/doc/End-to-end-evaluation.md
+++ b/doc/End-to-end-evaluation.md
@@ -26,17 +26,33 @@ Any similar PubMed Central set of articles could normally be used, as long they 
 
 We suppose in the following that the archive is decompressed under `PATH_TO_PMC/PMC_sample_1943/`.
 
+#### Author–affiliation linking corrections
+
+Manual/curation changes to the author→affiliation links (see [Author–affiliation linking in the gold data](#authoraffiliation-linking-in-the-gold-data)). For `PMC_sample_1943`: **965 authors across 282 files** were auto-linked from a single affiliation, **3 files** completed by forced bijection, and **37** id-less affiliations were given ids for hand-linking; **20** collaboration/consortium contributors were marked and excluded. Two files remain unrecoverable and stay unlinked (out of scope): `Cases_J_2010_Mar_9_3_76` (one author with no affiliation in the JATS *or* the PDF) and `Cryst_Growth_Des_2011_Jun_1_11(6)_2107-2111` (13 authors — the PDF lists the affiliations but prints no author superscripts).
+
 ### The bioRxiv gold-standard data 
 
 For evaluation on preprint articles, we are using the balanced bioRxiv 10k dataset originally compiled with care and published by Daniel Ecer ([eLife](https://elifesciences.org)), available on [Hugging Face](https://huggingface.co/datasets/sciencialab/grobid-evaluation). More precisely we publish benchmarks using the test subset of 2000 articles. The zip archive is similar in structure to the above PMC sample 1943 dataset and further documented below. 
+
+#### Author–affiliation linking corrections
+
+For `biorxiv-10k-test-2000`: **643 authors across 203 files** were auto-linked from a single affiliation, **9** id-less affiliations were given ids for hand-linking, and **39** collaboration contributors were marked and excluded; individual files were repaired by hand (e.g. a dangling `rid` in `050567v1`, and `244319v1` where the affiliation text itself names the author). Eight files remain unlinked (out of scope), mostly source gaps where the JATS dropped the author superscripts (e.g. `338731v1`) or the superscript points to an affiliation not printed in the document.
 
 ### The PLOS 1000 dataset
 
 This is a set of 1000 PLOS articles, called `PLOS_1000` and available on [Hugging Face](https://huggingface.co/datasets/sciencialab/grobid-evaluation), randomly selected from the full [PLOS Open Access collection](https://allof.plos.org/allofplos.zip). Again, for each article, the published PDF is available with the corresponding publisher JATS XML file, around 1.3GB total size.
 
+#### Author–affiliation linking corrections
+
+For `PLOS_1000`: PLOS encodes explicit `<xref>` affiliation links, so almost no completion was needed — **6** authors were linked under the single-real-affiliation pattern (the academic-editor affiliation excluded) plus one single-affiliation case, and **43** collaboration contributors were marked and excluded. No files remain to complete.
+
 ### eLife 984 dataset
 
 The `eLife_984` dataset is a set of 984 articles from eLife, available on [Hugging Face](https://huggingface.co/datasets/sciencialab/grobid-evaluation), randomly selected from their [open collection available on GitHub](https://github.com/elifesciences/elife-article-xml). Every articles come with the published PDF, the publisher JATS XML file and the eLife public HTML file (as bonus, not used), all in their latest version, around 4.5G total.
+
+#### Author–affiliation linking corrections
+
+For `eLife_984`: eLife already encodes explicit affiliation links, so no single-affiliation completion was required. The apparent gaps were **collaboration consortiums** — e.g. 28721's "Swiss HIV Cohort Study" and 72779's "Barwon Infant Study Investigator team", whose nested member rolls were mis-read as unlinked authors — now flagged `specific-use="collaboration"` and excluded (**12** contributors), together with editorial and peer-review affiliations from `<sub-article>` and editorial-board contrib-groups. **8** id-less affiliations were given ids. No author→affiliation completion remains.
 
 ## Getting publisher gold-standard data 
 
@@ -208,6 +224,33 @@ The references 2 and 3 are thus missing.
 
 GROBID expends intervals and will likely identify and match these "intermediary" callouts (including 2 and 3 in the above example). However these additional correct extractions and matching from GROBID will be counted as false positive in the evaluation because missing from the "gold" data.
 
+
+### Author–affiliation linking in the gold data
+
+The end-to-end evaluation includes an `affiliation_linked` metric: each extracted author is paired with its gold counterpart (by normalised surname, with forename initial as tie-break) and the affiliations attached to each are compared. Scoring an author requires a *machine-readable* author→affiliation link in the gold JATS — an `<xref ref-type="aff" rid="..."/>` placed **inside** the `<contrib contrib-type="author">`, or an `<aff>` nested directly in that contrib. The `<aff>` element itself lives as a sibling inside the `<contrib-group>` (or is referenced by id); it is the `xref` *inside the contrib* that establishes the link.
+
+In practice, publisher JATS frequently encodes the association only *positionally* — the author's printed superscript is resolved by the PDF layout — or drops it entirely during conversion. Authors with no resolvable link are treated as **out of scope**: they are skipped, not counted as missed. The raw metric therefore understates performance on these corpora unless the gold links are completed.
+
+To make the metric meaningful, the gold affiliation links were curated with a tiered pipeline (scripts under `doc/affiliation-triage/`), from safe/automatic to manual:
+
+1. **single affiliation** — a contributor group with exactly one `<aff>`: every author is linked to it;
+2. **single real affiliation** — the same, once editor affiliations are excluded (the PLOS academic-editor pattern);
+3. **forced bijection** — exactly one unlinked author and exactly one unreferenced affiliation;
+4. **unlabeled default** — a group whose single *unlabeled* `<aff>` is the shared default for every author that carries no superscript;
+5. **id backfill** — an `id` is added to id-less `<aff>` elements so the remainder can be hand-linked;
+6. **manual** — the author→affiliation mapping is read from the PDF superscripts and added by hand.
+
+Two classes of contributor are deliberately **excluded**, not missing:
+
+- **Collaboration / consortium group authors** (`<collab>`, e.g. eLife 28721's "Swiss HIV Cohort Study") are flagged `specific-use="collaboration"` on their wrapping `<contrib>` and skipped — they are group authors, not individually affiliated, and their nested member rolls are never scored.
+- **Editors and reviewers** — eLife peer-review `<sub-article>` blocks and editorial-board `<contrib-group content-type="section">` — are out of scope for author-affiliation scoring.
+
+Finally, some links are **genuinely unrecoverable** and are left unlinked, because the source itself is incomplete:
+
+- an author printed with **no superscript anywhere** (neither JATS nor PDF), so no affiliation is asserted for them;
+- a superscript that **points to an affiliation that was never printed** in the document.
+
+These are source-data gaps that no author→affiliation metric can score; they remain documented known gaps rather than extraction errors. The manual-completion checklist and the remaining gaps are tracked in `doc/affiliation-triage/manual-ground-truth-todo.md`.
 
 ### Character encoding and glyphs
 

--- a/doc/End-to-end-evaluation.md
+++ b/doc/End-to-end-evaluation.md
@@ -4,11 +4,11 @@ Individual models can be evaluated as explained in [Training the different model
 
 For an end-to-end evaluation, covering the whole extraction process from the parsing of PDF to the end result of the cascading of several sequence labelling models, GROBID includes two possible evaluation progresses:
 
-* against JATS-encoded (NLM) articles, such as [PubMed Central](http://www.ncbi.nlm.nih.gov/pmc), [bioRxiv](https://www.biorxiv.org), [PLOS](https://plos.org/ ) or [eLife](https://elifesciences.org/ ). For example, PubMed Central provides both PDF and fulltext XML files in the [NLM](http://www.ncbi.nlm.nih.gov/pmc/pmcdoc/tagging-guidelines/article/style.html) format. Keeping in mind some limits described below, it is possible to estimate the ability of Grobid to extract and normalize the content of the PDF documents for matching the quality of the NLM file. bioRxiv is used in Grobid to evaluate more precisely performance on preprint articles. 
+* against JATS-encoded (NLM) articles, such as [PubMed Central](http://www.ncbi.nlm.nih.gov/pmc), [bioRxiv](https://www.biorxiv.org), [PLOS](https://plos.org/ ) or [eLife](https://elifesciences.org/ ). For example, PubMed Central provides both PDF and fulltext XML files in the [NLM](http://www.ncbi.nlm.nih.gov/pmc/pmcdoc/tagging-guidelines/article/style.html) format. Keeping in mind some limits described below, it is possible to estimate the ability of Grobid to extract and normalize the content of the PDF documents for matching the quality of the NLM file. bioRxiv is used in Grobid to evaluate more precisely performance on preprint articles.
 
-* against TEI documents produced by [Pub2TEI](https://github.com/kermitt2/Pub2TEI). Pub2TEI is a set of XSLT that permit to transform various _native_ XML publishers (including Elsevier, Wiley, Springer, etc. XML formats) into a common TEI format. This TEI format can be used as ground-truth structure information for evaluating GROBID output, keeping in mind some limits described below. 
+* against TEI documents produced by [Pub2TEI](https://github.com/kermitt2/Pub2TEI). Pub2TEI is a set of XSLT that permit to transform various _native_ XML publishers (including Elsevier, Wiley, Springer, etc. XML formats) into a common TEI format. This TEI format can be used as ground-truth structure information for evaluating GROBID output, keeping in mind some limits described below.
 
-For actual benchmarks, see the [Benchmarking page](benchmarks/Benchmarking.md). We describe below the datasets and how to run the benchmarks.  
+For actual benchmarks, see the [Benchmarking page](benchmarks/Benchmarking.md). We describe below the datasets and how to run the benchmarks.
 
 ## Datasets
 
@@ -16,13 +16,13 @@ The corpus used for the end-to-end evaluation of Grobid are all available in a s
 
 *Previously, these datasets were archived on Zenodo at [https://zenodo.org/record/7708580](https://zenodo.org/record/7708580). The Hugging Face repository is now the canonical source.*
 
-These resources are originally published under CC-BY license. Our additional annotations are similarly under CC-BY. We thank NIH, bioRxiv, PLOS and eLife for making these resources Open Access and reusable. 
+These resources are originally published under CC-BY license. Our additional annotations are similarly under CC-BY. We thank NIH, bioRxiv, PLOS and eLife for making these resources Open Access and reusable.
 
-### PubMedCentral gold-standard data 
+### PubMedCentral gold-standard data
 
-Since ages, we are evaluating GROBID using the `PMC_sample_1943` dataset compiled by Alexandru Constantin. The dataset is available at this [url](https://huggingface.co/datasets/sciencialab/grobid-evaluation) (around 1.5GB in size). The sample dataset contains 1943 articles from 1943 different journals corresponding to the latest publications from a 2011 snapshot. 
+Since ages, we are evaluating GROBID using the `PMC_sample_1943` dataset compiled by Alexandru Constantin. The dataset is available at this [url](https://huggingface.co/datasets/sciencialab/grobid-evaluation) (around 1.5GB in size). The sample dataset contains 1943 articles from 1943 different journals corresponding to the latest publications from a 2011 snapshot.
 
-Any similar PubMed Central set of articles could normally be used, as long they follow the same directory structure: one directory per article containing at least the corresponding PDF file and the reference NLM file. 
+Any similar PubMed Central set of articles could normally be used, as long they follow the same directory structure: one directory per article containing at least the corresponding PDF file and the reference NLM file.
 
 We suppose in the following that the archive is decompressed under `PATH_TO_PMC/PMC_sample_1943/`.
 
@@ -30,13 +30,21 @@ We suppose in the following that the archive is decompressed under `PATH_TO_PMC/
 
 Manual/curation changes to the author→affiliation links (see [Author–affiliation linking in the gold data](#authoraffiliation-linking-in-the-gold-data)). For `PMC_sample_1943`: **965 authors across 282 files** were auto-linked from a single affiliation, **3 files** completed by forced bijection, and **37** id-less affiliations were given ids for hand-linking; **20** collaboration/consortium contributors were marked and excluded. Two files remain unrecoverable and stay unlinked (out of scope): `Cases_J_2010_Mar_9_3_76` (one author with no affiliation in the JATS *or* the PDF) and `Cryst_Growth_Des_2011_Jun_1_11(6)_2107-2111` (13 authors — the PDF lists the affiliations but prints no author superscripts).
 
-### The bioRxiv gold-standard data 
+#### Statement-section annotations (author contributions & competing interests)
 
-For evaluation on preprint articles, we are using the balanced bioRxiv 10k dataset originally compiled with care and published by Daniel Ecer ([eLife](https://elifesciences.org)), available on [Hugging Face](https://huggingface.co/datasets/sciencialab/grobid-evaluation). More precisely we publish benchmarks using the test subset of 2000 articles. The zip archive is similar in structure to the above PMC sample 1943 dataset and further documented below. 
+This dataset is not covered, and kept out because JATS XML too messy. See [Statement sections](#statement-sections-author-contributions-and-competing-interests).
+
+### The bioRxiv gold-standard data
+
+For evaluation on preprint articles, we are using the balanced bioRxiv 10k dataset originally compiled with care and published by Daniel Ecer ([eLife](https://elifesciences.org)), available on [Hugging Face](https://huggingface.co/datasets/sciencialab/grobid-evaluation). More precisely we publish benchmarks using the test subset of 2000 articles. The zip archive is similar in structure to the above PMC sample 1943 dataset and further documented below.
 
 #### Author–affiliation linking corrections
 
 For `biorxiv-10k-test-2000`: **643 authors across 203 files** were auto-linked from a single affiliation, **9** id-less affiliations were given ids for hand-linking, and **39** collaboration contributors were marked and excluded; individual files were repaired by hand (e.g. a dangling `rid` in `050567v1`, and `244319v1` where the affiliation text itself names the author). Eight files remain unlinked (out of scope), mostly source gaps where the JATS dropped the author superscripts (e.g. `338731v1`) or the superscript points to an affiliation not printed in the document.
+
+#### Statement-section annotations (author contributions & competing interests)
+
+To let the evaluation distinguish these statement types, `sec-type` was added to the relevant `<sec>` elements (reference-annotation only — no PDF or document text touched): `sec-type="contribution"` on ~489 author-contribution sections and `sec-type="conflict"` on ~215 competing-interest sections, across 722 files. **Both are scored for bioRxiv** (no fields removed): these edits create the gold matched by `//sec[@sec-type="contribution"]` and `//sec[@sec-type="conflict"]`. See [Statement sections](#statement-sections-author-contributions-and-competing-interests).
 
 ### The PLOS 1000 dataset
 
@@ -46,6 +54,10 @@ This is a set of 1000 PLOS articles, called `PLOS_1000` and available on [Huggin
 
 For `PLOS_1000`: PLOS encodes explicit `<xref>` affiliation links, so almost no completion was needed — **6** authors were linked under the single-real-affiliation pattern (the academic-editor affiliation excluded) plus one single-affiliation case, and **43** collaboration contributors were marked and excluded. No files remain to complete.
 
+#### Statement-section annotations (author contributions & competing interests)
+
+PLOS overloads `fn-type="con"` for both contributions and conflicts, so author-contribution footnotes were given `type="contribution"` (~176 across 183 files; a few `id="contrib…"` / `id="ack…"` footnotes were also typed) to disambiguate. **Only conflicts are scored for PLOS**: `contribution_stmt` is removed (contributions are attributes in the author list), while conflicts already match `//fn[@fn-type="conflict"]`. See [Statement sections](#statement-sections-author-contributions-and-competing-interests).
+
 ### eLife 984 dataset
 
 The `eLife_984` dataset is a set of 984 articles from eLife, available on [Hugging Face](https://huggingface.co/datasets/sciencialab/grobid-evaluation), randomly selected from their [open collection available on GitHub](https://github.com/elifesciences/elife-article-xml). Every articles come with the published PDF, the publisher JATS XML file and the eLife public HTML file (as bonus, not used), all in their latest version, around 4.5G total.
@@ -54,28 +66,32 @@ The `eLife_984` dataset is a set of 984 articles from eLife, available on [Huggi
 
 For `eLife_984`: eLife already encodes explicit affiliation links, so no single-affiliation completion was required. The apparent gaps were **collaboration consortiums** — e.g. 28721's "Swiss HIV Cohort Study" and 72779's "Barwon Infant Study Investigator team", whose nested member rolls were mis-read as unlinked authors — now flagged `specific-use="collaboration"` and excluded (**12** contributors), together with editorial and peer-review affiliations from `<sub-article>` and editorial-board contrib-groups. **8** id-less affiliations were given ids. No author→affiliation completion remains.
 
-## Getting publisher gold-standard data 
+#### Statement-section annotations (author contributions & competing interests)
 
-Some publishers release publications in XML format complementary to PDF in Open Access, allowing text mining (see for instance the dedicated subset of PMC publications). On contractual basis, it is possible to acquire native XML from mainstream publishers. Unfortunately, each publisher uses a different XML schema and covering all these formats would be a very time-consuming work. To ease the processing of these XML documents, the project [Pub2TEI](https://github.com/kermitt2/Pub2TEI) permits to transform the native XML formats of a dozen mainstream publishers into a common TEI format which is the same as the output of GROBID. 
+Competing-interest footnotes are ignored for the time being (authors contributions are not standalone text elements) — pending revisit. See [Statement sections](#statement-sections-author-contributions-and-competing-interests).
 
-See [Pub2TEI](https://github.com/kermitt2/Pub2TEI) for converting native publisher XML into usable TEI. 
+## Getting publisher gold-standard data
+
+Some publishers release publications in XML format complementary to PDF in Open Access, allowing text mining (see for instance the dedicated subset of PMC publications). On contractual basis, it is possible to acquire native XML from mainstream publishers. Unfortunately, each publisher uses a different XML schema and covering all these formats would be a very time-consuming work. To ease the processing of these XML documents, the project [Pub2TEI](https://github.com/kermitt2/Pub2TEI) permits to transform the native XML formats of a dozen mainstream publishers into a common TEI format which is the same as the output of GROBID.
+
+See [Pub2TEI](https://github.com/kermitt2/Pub2TEI) for converting native publisher XML into usable TEI.
 
 ## Directory structure
 
-For running the evaluation, the tool assumes that the files are organised in a set of directory in the following way: 
+For running the evaluation, the tool assumes that the files are organised in a set of directory in the following way:
 
 * a root directory containing one sub-directory per article
 
-* each article sub-directory containing at least the PDF version and a gold XML structured version of the article (in NLM format for PubMedCentral evaluation or in TEI format for the Pub2TEI-based evaluation). See the diagram below - the name of the sub-directory and the files is free.  
+* each article sub-directory containing at least the PDF version and a gold XML structured version of the article (in NLM format for PubMedCentral evaluation or in TEI format for the Pub2TEI-based evaluation). See the diagram below - the name of the sub-directory and the files is free.
 
-* extension for files generated with [Pub2TEI](https://github.com/kermitt2/Pub2TEI) is `.pub2tei.tei.xml`. Extension for NLM files is `.nxlm` (PMC) or `xml` (bioRxiv). GROBID will generate additional TEI files with extension `.fulltext.tei.xml`. 
+* extension for files generated with [Pub2TEI](https://github.com/kermitt2/Pub2TEI) is `.pub2tei.tei.xml`. Extension for NLM files is `.nxlm` (PMC) or `xml` (bioRxiv). GROBID will generate additional TEI files with extension `.fulltext.tei.xml`.
 
 ```
 ├── article1
 │   ├── article1.pdf
 │   └── article1.pub2tei.tei.xml
 │   └── article1.nxml
-│  
+│
 └── articles2
 │   ├── article2.pdf
 │   └── article2.pub2tei.tei.xml
@@ -85,7 +101,7 @@ For running the evaluation, the tool assumes that the files are organised in a s
 
 ## Warning on JATS/NLM format
 
-JATS/NLM is a very loose XML format, in the sense that there are multiple ways to encode the same information. As a consequence, there are a variety of JATS flavors depending on the publisher and it is not possible to guarantee that any JATS files will be supported as gold standard dataset by the `jatsEval` process. PMC and bioRxiv JATS articles are supported, but for a larger variety of JATS files it is recommended to convert them first into TEI with [Pub2TEI](https://github.com/kermitt2/Pub2TEI) and use the `teiEval` process. [Pub2TEI](https://github.com/kermitt2/Pub2TEI) supports all the JATS/NLM variants we are aware of, and convert them into a constrained and unambiguous single TEI format without information loss. 
+JATS/NLM is a very loose XML format, in the sense that there are multiple ways to encode the same information. As a consequence, there are a variety of JATS flavors depending on the publisher and it is not possible to guarantee that any JATS files will be supported as gold standard dataset by the `jatsEval` process. PMC and bioRxiv JATS articles are supported, but for a larger variety of JATS files it is recommended to convert them first into TEI with [Pub2TEI](https://github.com/kermitt2/Pub2TEI) and use the `teiEval` process. [Pub2TEI](https://github.com/kermitt2/Pub2TEI) supports all the JATS/NLM variants we are aware of, and convert them into a constrained and unambiguous single TEI format without information loss.
 
 ## Configuration for evaluation
 
@@ -126,7 +142,7 @@ The multi-dataset runner script `grobid-home/scripts/run_evaluation.sh` (which l
 > sh grobid-home/scripts/run_evaluation.sh -d ABS_PATH_TO/grobid-eval-datasets --skip-checks
 ```
 
-## Running and evaluating 
+## Running and evaluating
 
 ### JATS encoded corpus, e.g. PubMed Central, bioRxiv, PLOS, eLife
 
@@ -135,7 +151,7 @@ Under ```grobid/```, the following command line is used to run and evaluate Grob
 > ./gradlew jatsEval -Pp2t=ABS_PATH_TO_JATS_DATASET/DATASET -Prun=1
 ```
 
-Replace the absolute path and directory dataset name by the selected dataset for end-to-end evaluation, for example `PMC_sample_1943`, `biorxiv-10k-test-2000`, `PLOS_1000` or `eLife_984` (see above for downloading these datasets). 
+Replace the absolute path and directory dataset name by the selected dataset for end-to-end evaluation, for example `PMC_sample_1943`, `biorxiv-10k-test-2000`, `PLOS_1000` or `eLife_984` (see above for downloading these datasets).
 
 The parameters `run` indicates if GROBID has to be executed on all the PDF of the data set. The resulting TEI file will be added in each article subdirectory. If you only want to run the evaluation without re-executing Grobid on the PDF, set the parameter to 0:
 ```bash
@@ -165,7 +181,7 @@ It is also possible to set a ratio of evaluation data to be used expressed as a 
 
 The evaluation provides precision, recall and F1-score for the different fields in the header and bibliographical references. In addition, the scores are also computed at *instance* level, which means at the level of a complete header or complete citation.
 
-An experimental evaluation for the structures of the full text body is also proposed. This is not reliable in the current state, because most of the annotations of the full texts in PudMed Central are not uniform. For instance, the numbering of the section header is sometime included in the section header annotation, sometime not. The PubMed Central annotations will need to be standardized as a pre-process for a meaningful evaluation, which is a task planned in the next releases. 
+An experimental evaluation for the structures of the full text body is also proposed. This is not reliable in the current state, because most of the annotations of the full texts in PudMed Central are not uniform. For instance, the numbering of the section header is sometime included in the section header annotation, sometime not. The PubMed Central annotations will need to be standardized as a pre-process for a meaningful evaluation, which is a task planned in the next releases.
 
 ## Matching techniques
 
@@ -178,7 +194,7 @@ The evaluation covers four different string matching techniques for textual fiel
 
 * __relative Levenshtein distance__ relative to the max length of two strings
 
-* [__Ratcliff/Obershelp similarity__](http://xlinux.nist.gov/dads/HTML/ratcliffObershelp.html) 
+* [__Ratcliff/Obershelp similarity__](http://xlinux.nist.gov/dads/HTML/ratcliffObershelp.html)
 
 These matching variants only apply to textual fields, not numerical and dates fields (such as volume, issue, dates, pages).
 
@@ -188,7 +204,7 @@ These matching variants only apply to textual fields, not numerical and dates fi
 
 ### Non structured information in XML "gold" data
 
-A relatively important number of citations in the NLM files (and other native publisher XML) are encoded only as raw string, for example in the first file of the set `AAPS_J_2011_Mar_9_13(2)_230-239/12248_2011_Article_9260.nxml`: 
+A relatively important number of citations in the NLM files (and other native publisher XML) are encoded only as raw string, for example in the first file of the set `AAPS_J_2011_Mar_9_13(2)_230-239/12248_2011_Article_9260.nxml`:
 
 ```xml
 	  ...
@@ -204,7 +220,7 @@ A relatively important number of citations in the NLM files (and other native pu
 ```
 (this file contains for instance 3 non-encoded citations out of 18)
 
-As a consequence, the fields extracted by GROBID will not match any reference 'expected' values and will all be considered as false positive. The scores for the citation structures are thus lower than the actual performance of the system. 
+As a consequence, the fields extracted by GROBID will not match any reference 'expected' values and will all be considered as false positive. The scores for the citation structures are thus lower than the actual performance of the system.
 
 ### Non encoded information in XML "gold" data for intervals
 
@@ -220,7 +236,7 @@ which is annotated as follow:
 Recent studies have described the use of contrast material with high iodine content (370 mg I/ml or 400 mg I/ml) for coronary CT angiography (CCTA) (<xref ref-type="bibr" rid="b1">1</xref>&#x2013;<xref ref-type="bibr" rid="b4">4</xref>).
 ```
 
-The references 2 and 3 are thus missing.  
+The references 2 and 3 are thus missing.
 
 GROBID expends intervals and will likely identify and match these "intermediary" callouts (including 2 and 3 in the above example). However these additional correct extractions and matching from GROBID will be counted as false positive in the evaluation because missing from the "gold" data.
 
@@ -252,19 +268,46 @@ Finally, some links are **genuinely unrecoverable** and are left unlinked, becau
 
 These are source-data gaps that no author→affiliation metric can score; they remain documented known gaps rather than extraction errors. The manual-completion checklist and the remaining gaps are tracked in `doc/affiliation-triage/manual-ground-truth-todo.md`.
 
+### Statement sections: author contributions and competing interests
+
+GROBID extracts several *statement* sections from the back matter — funding, data/code availability, author contributions and competing (conflict of) interests. Two things determine whether each is evaluated: the evaluator removes some statement fields per corpus (`EndToEndEvaluation`), and the gold is annotated (commit `1e43b54`) so that the sections match — or deliberately *don't* match — the XPaths of the scored fields (`FieldSpecification`). These are reference-annotation edits only; no PDF or actual document text is touched. **The raw XML delta is therefore not the same as what gets scored.**
+
+What is actually scored, per dataset:
+
+| Dataset | `contribution_stmt` | `conflict_stmt` |
+|---|---|---|
+| bioRxiv | scored | scored |
+| PLOS | not scored (removed) | scored |
+| eLife | not scored (removed) | not scored (removed) |
+| PMC | not scored (removed) | not scored (removed) |
+
+The removals and the reasons given in the evaluator:
+
+- **eLife** — both removed: contributions are not standalone text elements (a combination of the author and text), too hard to align "for the time being" — pending revisit.
+- **PMC** — both removed (along with availability and funding): not covered, and keeping them would make metrics non-comparable over time.
+- **PLOS** — contributions removed (they are attributes in the author list, not text elements); conflicts remain scored.
+- **bioRxiv** — nothing removed: both scored.
+
+How each annotation connects to that — the XML edit and the field-removal are two halves of one intent: each edit makes the gold match (or not match) an XPath for a field that is (or isn't) scored in that corpus.
+
+- **bioRxiv** *enables both*: `sec-type="contribution"` (~489) and `sec-type="conflict"` (~215) make the sections match `//sec[@sec-type="contribution"]` and `//sec[@sec-type="conflict"]` — nothing is removed, so this is the gold that gets scored.
+- **PLOS** *disambiguates*: PLOS overloads `fn-type="con"`; conflicts already match `//fn[@fn-type="conflict"]` (scored), and `type="contribution"` is added to the contribution footnotes to match `//fn[@type="contribution"]` — but since `contribution_stmt` is removed for PLOS, only conflicts are scored.
+- **eLife**: ignored.
+- **PMC**: ignored.
+
 ### Character encoding and glyphs
 
-XML and PDF content frequently contain many differences at character-level. This is due to PDF which tend to use particular glyphs for enhancing visual rendering. Those special glyths are often loaded in the PDF itself and uses particular unicode not matching unicode of characters in XML. Similarly some special characters are expressed with fonts (for instance using a Greek font to render a λ, using the unicode of the letter _l_). 
+XML and PDF content frequently contain many differences at character-level. This is due to PDF which tend to use particular glyphs for enhancing visual rendering. Those special glyths are often loaded in the PDF itself and uses particular unicode not matching unicode of characters in XML. Similarly some special characters are expressed with fonts (for instance using a Greek font to render a λ, using the unicode of the letter _l_).
 
 ### Ordering and presentation variants of structures and sub-structures
 
-The order of some structures might also be changed from the logical representation (XML) to the particular PDF presentation base on (unknown) style transformation. 
+The order of some structures might also be changed from the logical representation (XML) to the particular PDF presentation base on (unknown) style transformation.
 
 Still related to style rendering, text can be post-processed. For instance, in a bibliographical reference, forenames can be present in full form in the XML, but shorten to initials only in the PDF.
 
 ### Evaluation criteria
 
-The tool uses currently rather strict evaluation criteria. For instance, `authors` field is considered correct only if the whole set of authors, including the order of authors, match. More partial and fine-grained matching is not implemented yet. 
+The tool uses currently rather strict evaluation criteria. For instance, `authors` field is considered correct only if the whole set of authors, including the order of authors, match. More partial and fine-grained matching is not implemented yet.
 
 *Given these limit, this evaluation cannot be considered currently as a reliable absolute evaluation (how good GROBID will extract valid and usable structures from PDF), but rather as a way to keep track of progress from one version of GROBID to another one and avoid regressions.*
 

--- a/doc/benchmarks/Benchmarking-biorxiv.md
+++ b/doc/benchmarks/Benchmarking-biorxiv.md
@@ -34,22 +34,23 @@ Note: with CRF only models runtime is 622s (0.31 second per PDF) with 4 CPU, 8 t
 
 ## Header metadata
 
-Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
+Evaluation on 1998 random PDF files out of 1998 PDF (ratio 1.0).
 
 #### Strict Matching (exact matches)
 
 **Field-level results**
 
-| label                       | precision | recall   | f1       | support |
-|-----------------------------|-----------|----------|----------|---------|
-| abstract                    | 2.31      | 2.26     | 2.28     | 1990    |
-| authors                     | 84.86     | 84.39    | 84.63    | 1999    |
-| first_author                | 96.73     | 96.29    | 96.51    | 1997    |
-| keywords                    | 57.33     | 57.33    | 57.33    | 839     |
-| title                       | 77.27     | 76.5     | 76.88    | 2000    |
-|                             |           |          |          |         |
-| **all fields (micro avg.)** | **64.79** | **64.2** | **64.5** | 8825    |
-| all fields (macro avg.)     | 63.7      | 63.36    | 63.53    | 8825    |
+| label                       | precision | recall    | f1        | support |
+|-----------------------------|-----------|-----------|-----------|---------|
+| abstract                    | 2.31      | 2.26      | 2.29      | 1988    |
+| affiliation_linked          | 0.83      | 0.81      | 0.82      | 1961    |
+| authors                     | 84.84     | 84.38     | 84.61     | 1997    |
+| first_author                | 96.73     | 96.29     | 96.51     | 1995    |
+| keywords                    | 57.28     | 57.28     | 57.28     | 838     |
+| title                       | 77.25     | 76.48     | 76.86     | 1998    |
+|                             |           |           |           |         |
+| **all fields (micro avg.)** | **23.58** | **23.04** | **23.31** | 10777   |
+| all fields (macro avg.)     | 53.21     | 52.92     | 53.06     | 10777   |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -57,14 +58,15 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 59.54     | 58.34     | 58.93     | 1990    |
-| authors                     | 85.36     | 84.89     | 85.13     | 1999    |
-| first_author                | 96.98     | 96.54     | 96.76     | 1997    |
-| keywords                    | 63.05     | 63.05     | 63.05     | 839     |
-| title                       | 79.49     | 78.7      | 79.1      | 2000    |
+| abstract                    | 59.52     | 58.35     | 58.93     | 1988    |
+| affiliation_linked          | 72.88     | 70.63     | 71.74     | 1961    |
+| authors                     | 85.35     | 84.88     | 85.11     | 1997    |
+| first_author                | 96.98     | 96.54     | 96.76     | 1995    |
+| keywords                    | 63.01     | 63.01     | 63.01     | 838     |
+| title                       | 79.47     | 78.68     | 79.07     | 1998    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **78.78** | **78.06** | **78.42** | 8825    |
-| all fields (macro avg.)     | 76.89     | 76.31     | 76.59     | 8825    |
+| **all fields (micro avg.)** | **74.97** | **73.24** | **74.09** | 10777   |
+| all fields (macro avg.)     | 76.2      | 75.35     | 75.77     | 10777   |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -72,48 +74,60 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 80.1      | 78.49     | 79.29     | 1990    |
-| authors                     | 92.56     | 92.05     | 92.3      | 1999    |
-| first_author                | 97.23     | 96.8      | 97.01     | 1997    |
-| keywords                    | 78.19     | 78.19     | 78.19     | 839     |
-| title                       | 91.92     | 91        | 91.46     | 2000    |
+| abstract                    | 80.09     | 78.52     | 79.3      | 1988    |
+| affiliation_linked          | 75.69     | 73.36     | 74.51     | 1961    |
+| authors                     | 92.55     | 92.04     | 92.29     | 1997    |
+| first_author                | 97.23     | 96.79     | 97.01     | 1995    |
+| keywords                    | 78.16     | 78.16     | 78.16     | 838     |
+| title                       | 91.91     | 90.99     | 91.45     | 1998    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.32** | **88.51** | **88.91** | 8825    |
-| all fields (macro avg.)     | 88        | 87.3      | 87.65     | 8825    |
+| **all fields (micro avg.)** | **80.54** | **78.67** | **79.59** | 10777   |
+| all fields (macro avg.)     | 85.94     | 84.98     | 85.45     | 10777   |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
 **Field-level results**
 
-| label                       | precision | recall   | f1        | support |
-|-----------------------------|-----------|----------|-----------|---------|
-| abstract                    | 77.03     | 75.48    | 76.24     | 1990    |
-| authors                     | 88.48     | 87.99    | 88.24     | 1999    |
-| first_author                | 96.73     | 96.29    | 96.51     | 1997    |
-| keywords                    | 70.32     | 70.32    | 70.32     | 839     |
-| title                       | 87.68     | 86.8     | 87.24     | 2000    |
-|                             |           |          |           |         |
-| **all fields (micro avg.)** | **85.88** | **85.1** | **85.49** | 8825    |
-| all fields (macro avg.)     | 84.05     | 83.38    | 83.71     | 8825    |
+| label                       | precision | recall    | f1        | support |
+|-----------------------------|-----------|-----------|-----------|---------|
+| abstract                    | 77.01     | 75.5      | 76.25     | 1988    |
+| affiliation_linked          | 73.93     | 71.65     | 72.77     | 1961    |
+| authors                     | 88.47     | 87.98     | 88.22     | 1997    |
+| first_author                | 96.73     | 96.29     | 96.51     | 1995    |
+| keywords                    | 70.29     | 70.29     | 70.29     | 838     |
+| title                       | 87.66     | 86.79     | 87.22     | 1998    |
+|                             |           |           |           |         |
+| **all fields (micro avg.)** | **78.17** | **76.37** | **77.26** | 10777   |
+| all fields (macro avg.)     | 82.35     | 81.42     | 81.88     | 10777   |
+
+Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
+and their attached affiliations compared). Its support column reports the number of articles the metric is computed
+from (those with at least one explicit gold affiliation link), while precision/recall/F1 are measured over the
+individual author-affiliation links.
+Only authors whose gold affiliation link is explicit are scored; affiliations encoded purely positionally in the gold (
+no xref/@rid and no nested aff) are out of scope, not counted as misses.
+Ground truth: single-affiliation papers (exactly one <aff>) have been completed by linking every author to that sole
+affiliation (~1,649 authors across PMC, bioRxiv and PLOS). Still to be done: multi-affiliation papers that encode the
+author-to-affiliation mapping only positionally, which require the PDF superscripts to disambiguate.
 
 #### Instance-level results
 
 ```
-Total expected instances: 	2000
+Total expected instances: 	1998
 Total correct instances: 	37 (strict)
-Total correct instances: 	724 (soft)
-Total correct instances: 	1223 (Levenshtein)
-Total correct instances: 	1053 (ObservedRatcliffObershelp)
+Total correct instances: 	723 (soft)
+Total correct instances: 	1222 (Levenshtein)
+Total correct instances: 	1052 (ObservedRatcliffObershelp)
 
 Instance-level recall:	1.85	(strict)
-Instance-level recall:	36.2	(soft)
-Instance-level recall:	61.15	(Levenshtein)
+Instance-level recall:	36.19	(soft)
+Instance-level recall:	61.16	(Levenshtein)
 Instance-level recall:	52.65	(RatcliffObershelp)
 ```
 
 ## Citation metadata
 
-Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
+Evaluation on 1998 random PDF files out of 1998 PDF (ratio 1.0).
 
 #### Strict Matching (exact matches)
 
@@ -121,20 +135,20 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 88.3      | 83.07     | 85.6      | 97183   |
-| date                        | 91.55     | 85.85     | 88.61     | 97630   |
-| doi                         | 71.1      | 83.57     | 76.83     | 16894   |
-| first_author                | 95.13     | 89.42     | 92.19     | 97183   |
-| inTitle                     | 82.72     | 79.03     | 80.83     | 96430   |
-| issue                       | 93.93     | 90.77     | 92.32     | 30312   |
-| page                        | 94.83     | 77.9      | 85.53     | 88597   |
+| authors                     | 88.32     | 83.09     | 85.63     | 97094   |
+| date                        | 91.55     | 85.85     | 88.61     | 97540   |
+| doi                         | 71.01     | 83.52     | 76.76     | 16831   |
+| first_author                | 95.14     | 89.42     | 92.19     | 97094   |
+| inTitle                     | 82.72     | 79.03     | 80.83     | 96340   |
+| issue                       | 93.93     | 90.76     | 92.32     | 30298   |
+| page                        | 94.83     | 77.89     | 85.53     | 88515   |
 | pmcid                       | 65.78     | 82.9      | 73.36     | 807     |
 | pmid                        | 69.95     | 80.41     | 74.82     | 2093    |
-| title                       | 84.81     | 83.28     | 84.04     | 92463   |
-| volume                      | 95.97     | 94.78     | 95.37     | 87709   |
+| title                       | 84.81     | 83.28     | 84.04     | 92375   |
+| volume                      | 95.97     | 94.78     | 95.37     | 87626   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.77** | **84.94** | **87.29** | 707301  |
-| all fields (macro avg.)     | 84.92     | 84.63     | 84.5      | 707301  |
+| **all fields (micro avg.)** | **89.78** | **84.94** | **87.29** | 706613  |
+| all fields (macro avg.)     | 84.91     | 84.63     | 84.5      | 706613  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -142,20 +156,20 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 89.45     | 84.15     | 86.72     | 97183   |
-| date                        | 91.55     | 85.85     | 88.61     | 97630   |
-| doi                         | 75.56     | 88.82     | 81.65     | 16894   |
-| first_author                | 95.56     | 89.82     | 92.6      | 97183   |
-| inTitle                     | 92.14     | 88.03     | 90.04     | 96430   |
-| issue                       | 93.93     | 90.77     | 92.32     | 30312   |
-| page                        | 94.83     | 77.9      | 85.53     | 88597   |
+| authors                     | 89.47     | 84.17     | 86.74     | 97094   |
+| date                        | 91.55     | 85.85     | 88.61     | 97540   |
+| doi                         | 75.49     | 88.79     | 81.6      | 16831   |
+| first_author                | 95.57     | 89.82     | 92.61     | 97094   |
+| inTitle                     | 92.14     | 88.03     | 90.04     | 96340   |
+| issue                       | 93.93     | 90.76     | 92.32     | 30298   |
+| page                        | 94.83     | 77.89     | 85.53     | 88515   |
 | pmcid                       | 74.73     | 94.18     | 83.33     | 807     |
 | pmid                        | 73.82     | 84.85     | 78.95     | 2093    |
-| title                       | 93.1      | 91.42     | 92.26     | 92463   |
-| volume                      | 95.97     | 94.78     | 95.37     | 87709   |
+| title                       | 93.11     | 91.43     | 92.26     | 92375   |
+| volume                      | 95.97     | 94.78     | 95.37     | 87626   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **92.57** | **87.59** | **90.01** | 707301  |
-| all fields (macro avg.)     | 88.24     | 88.23     | 87.94     | 707301  |
+| **all fields (micro avg.)** | **92.57** | **87.59** | **90.01** | 706613  |
+| all fields (macro avg.)     | 88.24     | 88.23     | 87.94     | 706613  |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -163,20 +177,20 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1       | support |
 |-----------------------------|-----------|-----------|----------|---------|
-| authors                     | 94.66     | 89.05     | 91.77    | 97183   |
-| date                        | 91.55     | 85.85     | 88.61    | 97630   |
-| doi                         | 77.59     | 91.2      | 83.85    | 16894   |
-| first_author                | 95.71     | 89.96     | 92.74    | 97183   |
-| inTitle                     | 93.19     | 89.03     | 91.06    | 96430   |
-| issue                       | 93.93     | 90.77     | 92.32    | 30312   |
-| page                        | 94.83     | 77.9      | 85.53    | 88597   |
+| authors                     | 94.66     | 89.05     | 91.77    | 97094   |
+| date                        | 91.55     | 85.85     | 88.61    | 97540   |
+| doi                         | 77.52     | 91.18     | 83.8     | 16831   |
+| first_author                | 95.71     | 89.96     | 92.75    | 97094   |
+| inTitle                     | 93.18     | 89.03     | 91.06    | 96340   |
+| issue                       | 93.93     | 90.76     | 92.32    | 30298   |
+| page                        | 94.83     | 77.89     | 85.53    | 88515   |
 | pmcid                       | 74.73     | 94.18     | 83.33    | 807     |
 | pmid                        | 73.82     | 84.85     | 78.95    | 2093    |
-| title                       | 96        | 94.27     | 95.13    | 92463   |
-| volume                      | 95.97     | 94.78     | 95.37    | 87709   |
+| title                       | 96        | 94.27     | 95.13    | 92375   |
+| volume                      | 95.97     | 94.78     | 95.37    | 87626   |
 |                             |           |           |          |         |
-| **all fields (micro avg.)** | **93.9**  | **88.85** | **91.3** | 707301  |
-| all fields (macro avg.)     | 89.27     | 89.26     | 88.97    | 707301  |
+| **all fields (micro avg.)** | **93.9**  | **88.84** | **91.3** | 706613  |
+| all fields (macro avg.)     | 89.26     | 89.25     | 88.96    | 706613  |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -184,69 +198,69 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 91.65     | 86.22     | 88.85     | 97183   |
-| date                        | 91.55     | 85.85     | 88.61     | 97630   |
-| doi                         | 76.23     | 89.61     | 82.38     | 16894   |
-| first_author                | 95.18     | 89.46     | 92.23     | 97183   |
-| inTitle                     | 90.88     | 86.82     | 88.8      | 96430   |
-| issue                       | 93.93     | 90.77     | 92.32     | 30312   |
-| page                        | 94.83     | 77.9      | 85.53     | 88597   |
+| authors                     | 91.66     | 86.22     | 88.85     | 97094   |
+| date                        | 91.55     | 85.85     | 88.61     | 97540   |
+| doi                         | 76.16     | 89.58     | 82.33     | 16831   |
+| first_author                | 95.18     | 89.46     | 92.24     | 97094   |
+| inTitle                     | 90.88     | 86.82     | 88.8      | 96340   |
+| issue                       | 93.93     | 90.76     | 92.32     | 30298   |
+| page                        | 94.83     | 77.89     | 85.53     | 88515   |
 | pmcid                       | 65.78     | 82.9      | 73.36     | 807     |
 | pmid                        | 69.95     | 80.41     | 74.82     | 2093    |
-| title                       | 95.32     | 93.61     | 94.46     | 92463   |
-| volume                      | 95.97     | 94.78     | 95.37     | 87709   |
+| title                       | 95.32     | 93.6      | 94.45     | 92375   |
+| volume                      | 95.97     | 94.78     | 95.37     | 87626   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **92.94** | **87.94** | **90.37** | 707301  |
-| all fields (macro avg.)     | 87.39     | 87.12     | 86.98     | 707301  |
+| **all fields (micro avg.)** | **92.94** | **87.93** | **90.37** | 706613  |
+| all fields (macro avg.)     | 87.38     | 87.12     | 86.97     | 706613  |
 
 #### Instance-level results
 
 ```
-Total expected instances: 		98799
-Total extracted instances: 		97956
-Total correct instances: 		43436 (strict)
-Total correct instances: 		54320 (soft)
-Total correct instances: 		58502 (Levenshtein)
-Total correct instances: 		55277 (RatcliffObershelp)
+Total expected instances: 		98709
+Total extracted instances: 		97866
+Total correct instances: 		43399 (strict)
+Total correct instances: 		54277 (soft)
+Total correct instances: 		58438 (Levenshtein)
+Total correct instances: 		55219 (RatcliffObershelp)
 
-Instance-level precision:	44.34 (strict)
-Instance-level precision:	55.45 (soft)
-Instance-level precision:	59.72 (Levenshtein)
-Instance-level precision:	56.43 (RatcliffObershelp)
+Instance-level precision:	44.35 (strict)
+Instance-level precision:	55.46 (soft)
+Instance-level precision:	59.71 (Levenshtein)
+Instance-level precision:	56.42 (RatcliffObershelp)
 
-Instance-level recall:	43.96	(strict)
-Instance-level recall:	54.98	(soft)
-Instance-level recall:	59.21	(Levenshtein)
-Instance-level recall:	55.95	(RatcliffObershelp)
+Instance-level recall:	43.97	(strict)
+Instance-level recall:	54.99	(soft)
+Instance-level recall:	59.2	(Levenshtein)
+Instance-level recall:	55.94	(RatcliffObershelp)
 
-Instance-level f-score:	44.15 (strict)
+Instance-level f-score:	44.16 (strict)
 Instance-level f-score:	55.22 (soft)
-Instance-level f-score:	59.47 (Levenshtein)
-Instance-level f-score:	56.19 (RatcliffObershelp)
+Instance-level f-score:	59.46 (Levenshtein)
+Instance-level f-score:	56.18 (RatcliffObershelp)
 
-Matching 1 :	78844
+Matching 1 :	78769
 
-Matching 2 :	4482
+Matching 2 :	4477
 
-Matching 3 :	4342
+Matching 3 :	4339
 
-Matching 4 :	2220
+Matching 4 :	2217
 
-Total matches :	89888
+Total matches :	89802
 ```
 
 #### Citation context resolution
 
 ```
 
-Total expected references: 	 98797 - 49.4 references per article
-Total predicted references: 	 97956 - 48.98 references per article
+Total expected references: 	 98707 - 49.4 references per article
+Total predicted references: 	 97866 - 48.98 references per article
 
-Total expected citation contexts: 	 142862 - 71.43 citation contexts per article
-Total predicted citation contexts: 	 134766 - 67.38 citation contexts per article
+Total expected citation contexts: 	 142723 - 71.43 citation contexts per article
+Total predicted citation contexts: 	 134635 - 67.38 citation contexts per article
 
-Total correct predicted citation contexts: 	 116235 - 58.12 citation contexts per article
-Total wrong predicted citation contexts: 	 18531 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
+Total correct predicted citation contexts: 	 116122 - 58.12 citation contexts per article
+Total wrong predicted citation contexts: 	 18513 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
 
 Precision citation contexts: 	 86.25
 Recall citation contexts: 	 81.36
@@ -260,7 +274,7 @@ the actual PDF content and can be inconsistent from one document to another. The
 thus not very meaningful in absolute term, in particular for the strict matching (textual content of the structure can
 be very long). As relative values for comparing different models, they seem however useful.
 
-Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
+Evaluation on 1998 random PDF files out of 1998 PDF (ratio 1.0).
 
 #### Strict Matching (exact matches)
 
@@ -268,19 +282,19 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 28.34     | 27.58     | 27.95     | 446     |
-| conflict_stmt               | 66.42     | 59.11     | 62.55     | 609     |
-| contribution_stmt           | 42.86     | 43.84     | 43.34     | 609     |
-| figure_title                | 4.25      | 2.35      | 3.03      | 22978   |
+| availability_stmt           | 28.18     | 27.42     | 27.79     | 445     |
+| conflict_stmt               | 66.36     | 59.05     | 62.49     | 608     |
+| contribution_stmt           | 42.77     | 43.75     | 43.25     | 608     |
+| figure_title                | 4.25      | 2.36      | 3.03      | 22964   |
 | funding_stmt                | 3.84      | 23.96     | 6.62      | 747     |
-| reference_citation          | 71.95     | 70.95     | 71.45     | 147470  |
-| reference_figure            | 70.31     | 76.97     | 73.49     | 47984   |
-| reference_table             | 45.12     | 84.74     | 58.88     | 5957    |
-| section_title               | 69.07     | 68.62     | 68.85     | 32398   |
-| table_title                 | 6.98      | 2.55      | 3.73      | 3925    |
+| reference_citation          | 71.94     | 70.93     | 71.43     | 147331  |
+| reference_figure            | 70.34     | 76.98     | 73.51     | 47964   |
+| reference_table             | 45.32     | 84.74     | 59.06     | 5956    |
+| section_title               | 69.07     | 68.63     | 68.85     | 32350   |
+| table_title                 | 6.98      | 2.55      | 3.73      | 3924    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **65.11** | **64.76** | **64.94** | 263123  |
-| all fields (macro avg.)     | 40.91     | 46.07     | 41.99     | 263123  |
+| **all fields (micro avg.)** | **65.12** | **64.76** | **64.94** | 262897  |
+| all fields (macro avg.)     | 40.9      | 46.04     | 41.98     | 262897  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -288,31 +302,32 @@ Evaluation on 2000 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 49.54     | 48.21     | 48.86     | 446     |
-| conflict_stmt               | 81        | 72.09     | 76.28     | 609     |
-| contribution_stmt           | 72.71     | 74.38     | 73.54     | 609     |
-| figure_title                | 66.76     | 36.97     | 47.58     | 22978   |
+| availability_stmt           | 49.42     | 48.09     | 48.75     | 445     |
+| conflict_stmt               | 80.96     | 72.04     | 76.24     | 608     |
+| contribution_stmt           | 72.67     | 74.34     | 73.5      | 608     |
+| figure_title                | 66.77     | 36.97     | 47.59     | 22964   |
 | funding_stmt                | 4.1       | 25.57     | 7.06      | 747     |
-| reference_citation          | 84.28     | 83.1      | 83.69     | 147470  |
-| reference_figure            | 70.97     | 77.69     | 74.18     | 47984   |
-| reference_table             | 45.51     | 85.48     | 59.4      | 5957    |
-| section_title               | 74.49     | 74        | 74.24     | 32398   |
-| table_title                 | 81.23     | 29.66     | 43.45     | 3925    |
+| reference_citation          | 84.28     | 83.1      | 83.69     | 147331  |
+| reference_figure            | 71        | 77.7      | 74.2      | 47964   |
+| reference_table             | 45.72     | 85.48     | 59.57     | 5956    |
+| section_title               | 74.48     | 74        | 74.24     | 32350   |
+| table_title                 | 81.22     | 29.64     | 43.43     | 3924    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **76.36** | **75.95** | **76.16** | 263123  |
-| all fields (macro avg.)     | 63.06     | 60.71     | 58.83     | 263123  |
+| **all fields (micro avg.)** | **76.37** | **75.95** | **76.16** | 262897  |
+| all fields (macro avg.)     | 63.06     | 60.69     | 58.83     | 262897  |
 
 **Document-level ratio results**
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 82.35     | 97.31     | 89.21     | 446     |
-| conflict_stmt               | 95.42     | 89        | 92.1      | 609     |
-| contribution_stmt           | 91.08     | 102.3     | 96.37     | 609     |
+| availability_stmt           | 82.32     | 97.3      | 89.19     | 445     |
+| conflict_stmt               | 95.41     | 88.98     | 92.09     | 608     |
+| contribution_stmt           | 91.07     | 102.3     | 96.36     | 608     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.88** | **96.09** | **92.88** | 1664    |
-| all fields (macro avg.)     | 89.62     | 96.2      | 92.56     | 1664    |
+| **all fields (micro avg.)** | **89.86** | **96.09** | **92.87** | 1661    |
+| all fields (macro avg.)     | 89.6      | 96.2      | 92.54     | 1661    |
 
-Evaluation metrics produced in 1633.147 seconds
+Evaluation metrics produced in 204.149 seconds
+
 
 

--- a/doc/benchmarks/Benchmarking-elife.md
+++ b/doc/benchmarks/Benchmarking-elife.md
@@ -42,26 +42,28 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 8.66      | 8.33      | 8.49      | 984     |
+| affiliation_linked          | 1.94      | 2.08      | 2         | 981     |
 | authors                     | 78.18     | 77.62     | 77.9      | 983     |
 | first_author                | 93.95     | 93.38     | 93.67     | 982     |
 | title                       | 88.8      | 87.8      | 88.3      | 984     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **67.82** | **66.77** | **67.29** | 3933    |
-| all fields (macro avg.)     | 67.4      | 66.78     | 67.09     | 3933    |
+| **all fields (micro avg.)** | **18.8**  | **19.72** | **19.25** | 4914    |
+| all fields (macro avg.)     | 54.3      | 53.84     | 54.07     | 4914    |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
 **Field-level results**
 
-| label                       | precision | recall   | f1        | support |
-|-----------------------------|-----------|----------|-----------|---------|
-| abstract                    | 21.54     | 20.73    | 21.13     | 984     |
-| authors                     | 78.59     | 78.03    | 78.31     | 983     |
-| first_author                | 93.95     | 93.38    | 93.67     | 982     |
-| title                       | 95.79     | 94.72    | 95.25     | 984     |
-|                             |           |          |           |         |
-| **all fields (micro avg.)** | **72.83** | **71.7** | **72.26** | 3933    |
-| all fields (macro avg.)     | 72.47     | 71.71    | 72.09     | 3933    |
+| label                       | precision | recall    | f1       | support |
+|-----------------------------|-----------|-----------|----------|---------|
+| abstract                    | 21.54     | 20.73     | 21.13    | 984     |
+| affiliation_linked          | 68.95     | 73.96     | 71.37    | 981     |
+| authors                     | 78.59     | 78.03     | 78.31    | 983     |
+| first_author                | 93.95     | 93.38     | 93.67    | 982     |
+| title                       | 95.79     | 94.72     | 95.25    | 984     |
+|                             |           |           |          |         |
+| **all fields (micro avg.)** | **69.94** | **73.34** | **71.6** | 4914    |
+| all fields (macro avg.)     | 71.76     | 72.16     | 71.94    | 4914    |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -70,26 +72,38 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 46.67     | 44.92     | 45.78     | 984     |
+| affiliation_linked          | 73.17     | 78.49     | 75.73     | 981     |
 | authors                     | 89.86     | 89.22     | 89.54     | 983     |
 | first_author                | 94.26     | 93.69     | 93.97     | 982     |
 | title                       | 97.23     | 96.14     | 96.68     | 984     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **82.26** | **80.98** | **81.61** | 3933    |
-| all fields (macro avg.)     | 82        | 80.99     | 81.49     | 3933    |
+| **all fields (micro avg.)** | **75.49** | **79.17** | **77.29** | 4914    |
+| all fields (macro avg.)     | 80.24     | 80.49     | 80.34     | 4914    |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
 **Field-level results**
 
-| label                       | precision | recall    | f1       | support |
-|-----------------------------|-----------|-----------|----------|---------|
-| abstract                    | 43.4      | 41.77     | 42.57    | 984     |
-| authors                     | 83.3      | 82.71     | 83       | 983     |
-| first_author                | 93.95     | 93.38     | 93.67    | 982     |
-| title                       | 97.23     | 96.14     | 96.68    | 984     |
-|                             |           |           |          |         |
-| **all fields (micro avg.)** | **79.73** | **78.49** | **79.1** | 3933    |
-| all fields (macro avg.)     | 79.47     | 78.5      | 78.98    | 3933    |
+| label                       | precision | recall    | f1        | support |
+|-----------------------------|-----------|-----------|-----------|---------|
+| abstract                    | 43.4      | 41.77     | 42.57     | 984     |
+| affiliation_linked          | 71.03     | 76.19     | 73.52     | 981     |
+| authors                     | 83.3      | 82.71     | 83        | 983     |
+| first_author                | 93.95     | 93.38     | 93.67     | 982     |
+| title                       | 97.23     | 96.14     | 96.68     | 984     |
+|                             |           |           |           |         |
+| **all fields (micro avg.)** | **73.25** | **76.82** | **74.99** | 4914    |
+| all fields (macro avg.)     | 77.78     | 78.04     | 77.89     | 4914    |
+
+Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
+and their attached affiliations compared). Its support column reports the number of articles the metric is computed
+from (those with at least one explicit gold affiliation link), while precision/recall/F1 are measured over the
+individual author-affiliation links.
+Only authors whose gold affiliation link is explicit are scored; affiliations encoded purely positionally in the gold (
+no xref/@rid and no nested aff) are out of scope, not counted as misses.
+Ground truth: single-affiliation papers (exactly one <aff>) have been completed by linking every author to that sole
+affiliation (~1,649 authors across PMC, bioRxiv and PLOS). Still to be done: multi-affiliation papers that encode the
+author-to-affiliation mapping only positionally, which require the PDF superscripts to disambiguate.
 
 #### Instance-level results
 
@@ -116,7 +130,7 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 79.7      | 78.4      | 79.04     | 63265   |
+| authors                     | 79.72     | 78.41     | 79.06     | 63265   |
 | date                        | 96.01     | 93.88     | 94.93     | 63662   |
 | first_author                | 94.86     | 93.26     | 94.05     | 63265   |
 | inTitle                     | 95.52     | 94.27     | 94.89     | 63213   |
@@ -125,7 +139,7 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | title                       | 90.27     | 90.59     | 90.43     | 62044   |
 | volume                      | 97.83     | 98.28     | 98.06     | 61049   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **92.59** | **91.84** | **92.21** | 429889  |
+| **all fields (micro avg.)** | **92.59** | **91.84** | **92.22** | 429889  |
 | all fields (macro avg.)     | 81.43     | 90.6      | 81.21     | 429889  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
@@ -134,9 +148,9 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 79.84     | 78.53     | 79.18     | 63265   |
+| authors                     | 79.86     | 78.55     | 79.2      | 63265   |
 | date                        | 96.01     | 93.88     | 94.93     | 63662   |
-| first_author                | 94.94     | 93.34     | 94.13     | 63265   |
+| first_author                | 94.94     | 93.35     | 94.14     | 63265   |
 | inTitle                     | 96.01     | 94.74     | 95.37     | 63213   |
 | issue                       | 1.52      | 81.25     | 2.99      | 16      |
 | page                        | 95.73     | 94.88     | 95.3      | 53375   |
@@ -170,7 +184,7 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 87.01     | 85.58     | 86.29     | 63265   |
+| authors                     | 87.02     | 85.59     | 86.3      | 63265   |
 | date                        | 96.01     | 93.88     | 94.93     | 63662   |
 | first_author                | 94.87     | 93.28     | 94.07     | 63265   |
 | inTitle                     | 96.02     | 94.76     | 95.38     | 63213   |
@@ -187,25 +201,25 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 ```
 Total expected instances: 		63664
 Total extracted instances: 		65092
-Total correct instances: 		41799 (strict)
-Total correct instances: 		44601 (soft)
-Total correct instances: 		52283 (Levenshtein)
-Total correct instances: 		48799 (RatcliffObershelp)
+Total correct instances: 		41810 (strict)
+Total correct instances: 		44612 (soft)
+Total correct instances: 		52284 (Levenshtein)
+Total correct instances: 		48804 (RatcliffObershelp)
 
-Instance-level precision:	64.22 (strict)
-Instance-level precision:	68.52 (soft)
+Instance-level precision:	64.23 (strict)
+Instance-level precision:	68.54 (soft)
 Instance-level precision:	80.32 (Levenshtein)
-Instance-level precision:	74.97 (RatcliffObershelp)
+Instance-level precision:	74.98 (RatcliffObershelp)
 
-Instance-level recall:	65.66	(strict)
-Instance-level recall:	70.06	(soft)
+Instance-level recall:	65.67	(strict)
+Instance-level recall:	70.07	(soft)
 Instance-level recall:	82.12	(Levenshtein)
-Instance-level recall:	76.65	(RatcliffObershelp)
+Instance-level recall:	76.66	(RatcliffObershelp)
 
-Instance-level f-score:	64.93 (strict)
-Instance-level f-score:	69.28 (soft)
+Instance-level f-score:	64.94 (strict)
+Instance-level f-score:	69.3 (soft)
 Instance-level f-score:	81.21 (Levenshtein)
-Instance-level f-score:	75.8 (RatcliffObershelp)
+Instance-level f-score:	75.81 (RatcliffObershelp)
 
 Matching 1 :	58590
 
@@ -226,14 +240,14 @@ Total expected references: 	 63664 - 64.7 references per article
 Total predicted references: 	 65092 - 66.15 references per article
 
 Total expected citation contexts: 	 109022 - 110.79 citation contexts per article
-Total predicted citation contexts: 	 99970 - 101.6 citation contexts per article
+Total predicted citation contexts: 	 99946 - 101.57 citation contexts per article
 
-Total correct predicted citation contexts: 	 96026 - 97.59 citation contexts per article
-Total wrong predicted citation contexts: 	 3944 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
+Total correct predicted citation contexts: 	 96025 - 97.59 citation contexts per article
+Total wrong predicted citation contexts: 	 3921 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
 
-Precision citation contexts: 	 96.05
+Precision citation contexts: 	 96.08
 Recall citation contexts: 	 88.08
-fscore citation contexts: 	 91.89
+fscore citation contexts: 	 91.9
 ```
 
 ## Fulltext structures
@@ -251,17 +265,17 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 25.69     | 27.01     | 26.33     | 585     |
+| availability_stmt           | 25.37     | 26.67     | 26        | 585     |
 | figure_title                | 0.07      | 0.02      | 0.03      | 31718   |
 | funding_stmt                | 6.04      | 26.49     | 9.84      | 921     |
-| reference_citation          | 57.1      | 55.99     | 56.54     | 108949  |
+| reference_citation          | 57.11     | 55.99     | 56.54     | 108949  |
 | reference_figure            | 58.43     | 51.08     | 54.51     | 68926   |
 | reference_table             | 71.35     | 73.41     | 72.37     | 2381    |
 | section_title               | 83.33     | 77.3      | 80.2      | 21831   |
 | table_title                 | 0         | 0         | 0         | 1925    |
 |                             |           |           |           |         |
 | **all fields (micro avg.)** | **56.15** | **48.58** | **52.09** | 237236  |
-| all fields (macro avg.)     | 37.75     | 38.91     | 37.48     | 237236  |
+| all fields (macro avg.)     | 37.71     | 38.87     | 37.44     | 237236  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -272,13 +286,13 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | availability_stmt           | 36.1      | 37.95     | 37        | 585     |
 | figure_title                | 49.82     | 16.06     | 24.29     | 31718   |
 | funding_stmt                | 6.04      | 26.49     | 9.84      | 921     |
-| reference_citation          | 93.63     | 91.81     | 92.71     | 108949  |
+| reference_citation          | 93.65     | 91.81     | 92.72     | 108949  |
 | reference_figure            | 58.71     | 51.33     | 54.77     | 68926   |
 | reference_table             | 71.43     | 73.5      | 72.45     | 2381    |
 | section_title               | 84.38     | 78.26     | 81.21     | 21831   |
 | table_title                 | 95.08     | 28.1      | 43.38     | 1925    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **78.12** | **67.59** | **72.48** | 237236  |
+| **all fields (micro avg.)** | **78.13** | **67.59** | **72.48** | 237236  |
 | all fields (macro avg.)     | 61.9      | 50.44     | 51.96     | 237236  |
 
 **Document-level ratio results**
@@ -290,5 +304,6 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | **all fields (micro avg.)** | **93.61** | **100** | **96.7** | 585     |
 | all fields (macro avg.)     | 93.61     | 100     | 99.03    | 585     |
 
-Evaluation metrics produced in 1228.642 seconds
+Evaluation metrics produced in 195.023 seconds
+
 

--- a/doc/benchmarks/Benchmarking-plos.md
+++ b/doc/benchmarks/Benchmarking-plos.md
@@ -42,43 +42,46 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | label                       | precision | recall    | f1       | support |
 |-----------------------------|-----------|-----------|----------|---------|
 | abstract                    | 13.02     | 13.44     | 13.22    | 960     |
+| affiliation_linked          | 0         | 0         | 0        | 963     |
 | authors                     | 98.97     | 98.97     | 98.97    | 969     |
 | first_author                | 99.17     | 99.17     | 99.17    | 969     |
 | keywords                    | 0         | 0         | 0        | 0       |
 | title                       | 95.18     | 94.7      | 94.94    | 1000    |
 |                             |           |           |          |         |
-| **all fields (micro avg.)** | **76.35** | **76.86** | **76.6** | 3898    |
-| all fields (macro avg.)     | 76.58     | 76.57     | 76.58    | 3898    |
+| **all fields (micro avg.)** | **25.42** | **25.18** | **25.3** | 4861    |
+| all fields (macro avg.)     | 61.27     | 61.26     | 61.26    | 4861    |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
 **Field-level results**
 
-| label                       | precision | recall    | f1        | support |
-|-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 49.34     | 50.94     | 50.13     | 960     |
-| authors                     | 98.97     | 98.97     | 98.97     | 969     |
-| first_author                | 99.17     | 99.17     | 99.17     | 969     |
-| keywords                    | 0         | 0         | 0         | 0       |
-| title                       | 98.79     | 98.3      | 98.55     | 1000    |
-|                             |           |           |           |         |
-| **all fields (micro avg.)** | **86.44** | **87.02** | **86.73** | 3898    |
-| all fields (macro avg.)     | 86.57     | 86.84     | 86.7      | 3898    |
+| label                       | precision | recall   | f1        | support |
+|-----------------------------|-----------|----------|-----------|---------|
+| abstract                    | 49.34     | 50.94    | 50.13     | 960     |
+| affiliation_linked          | 71.74     | 70.49    | 71.11     | 963     |
+| authors                     | 98.97     | 98.97    | 98.97     | 969     |
+| first_author                | 99.17     | 99.17    | 99.17     | 969     |
+| keywords                    | 0         | 0        | 0         | 0       |
+| title                       | 98.79     | 98.3     | 98.55     | 1000    |
+|                             |           |          |           |         |
+| **all fields (micro avg.)** | **76.64** | **75.9** | **76.27** | 4861    |
+| all fields (macro avg.)     | 83.6      | 83.57    | 83.59     | 4861    |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
 **Field-level results**
 
-| label                       | precision | recall    | f1        | support |
-|-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 75.28     | 77.71     | 76.47     | 960     |
-| authors                     | 99.38     | 99.38     | 99.38     | 969     |
-| first_author                | 99.28     | 99.28     | 99.28     | 969     |
-| keywords                    | 0         | 0         | 0         | 0       |
-| title                       | 99.3      | 98.8      | 99.05     | 1000    |
-|                             |           |           |           |         |
-| **all fields (micro avg.)** | **93.25** | **93.87** | **93.56** | 3898    |
-| all fields (macro avg.)     | 93.31     | 93.79     | 93.54     | 3898    |
+| label                       | precision | recall    | f1       | support |
+|-----------------------------|-----------|-----------|----------|---------|
+| abstract                    | 75.28     | 77.71     | 76.47    | 960     |
+| affiliation_linked          | 76.22     | 74.89     | 75.55    | 963     |
+| authors                     | 99.38     | 99.38     | 99.38    | 969     |
+| first_author                | 99.28     | 99.28     | 99.28    | 969     |
+| keywords                    | 0         | 0         | 0        | 0       |
+| title                       | 99.3      | 98.8      | 99.05    | 1000    |
+|                             |           |           |          |         |
+| **all fields (micro avg.)** | **81.89** | **81.11** | **81.5** | 4861    |
+| all fields (macro avg.)     | 89.89     | 90.01     | 89.95    | 4861    |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -87,13 +90,24 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 64.78     | 66.88     | 65.81     | 960     |
+| affiliation_linked          | 74.06     | 72.76     | 73.4      | 963     |
 | authors                     | 99.28     | 99.28     | 99.28     | 969     |
 | first_author                | 99.17     | 99.17     | 99.17     | 969     |
 | keywords                    | 0         | 0         | 0         | 0       |
 | title                       | 98.99     | 98.5      | 98.75     | 1000    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **90.47** | **91.07** | **90.77** | 3898    |
-| all fields (macro avg.)     | 90.56     | 90.96     | 90.75     | 3898    |
+| **all fields (micro avg.)** | **79.52** | **78.76** | **79.14** | 4861    |
+| all fields (macro avg.)     | 87.26     | 87.32     | 87.28     | 4861    |
+
+Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
+and their attached affiliations compared). Its support column reports the number of articles the metric is computed
+from (those with at least one explicit gold affiliation link), while precision/recall/F1 are measured over the
+individual author-affiliation links.
+Only authors whose gold affiliation link is explicit are scored; affiliations encoded purely positionally in the gold (
+no xref/@rid and no nested aff) are out of scope, not counted as misses.
+Ground truth: single-affiliation papers (exactly one <aff>) have been completed by linking every author to that sole
+affiliation (~1,649 authors across PMC, bioRxiv and PLOS). Still to be done: multi-affiliation papers that encode the
+author-to-affiliation mapping only positionally, which require the PDF superscripts to disambiguate.
 
 #### Instance-level results
 
@@ -120,17 +134,17 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 81.01     | 78.03     | 79.49     | 44770   |
+| authors                     | 81.05     | 78.07     | 79.53     | 44770   |
 | date                        | 84.38     | 80.65     | 82.47     | 45457   |
-| first_author                | 91.27     | 87.89     | 89.55     | 44770   |
+| first_author                | 91.29     | 87.9      | 89.56     | 44770   |
 | inTitle                     | 81.64     | 83.14     | 82.38     | 42795   |
 | issue                       | 93.43     | 92.1      | 92.76     | 18983   |
 | page                        | 93.8      | 77.49     | 84.87     | 40844   |
 | title                       | 59.87     | 60.23     | 60.05     | 43101   |
 | volume                      | 95.72     | 95.6      | 95.66     | 40458   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **84.11** | **81.04** | **82.55** | 321178  |
-| all fields (macro avg.)     | 85.14     | 81.89     | 83.4      | 321178  |
+| **all fields (micro avg.)** | **84.11** | **81.05** | **82.55** | 321178  |
+| all fields (macro avg.)     | 85.15     | 81.9      | 83.41     | 321178  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -138,17 +152,17 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 81.33     | 78.33     | 79.8      | 44770   |
+| authors                     | 81.37     | 78.38     | 79.84     | 44770   |
 | date                        | 84.38     | 80.65     | 82.47     | 45457   |
-| first_author                | 91.5      | 88.11     | 89.77     | 44770   |
+| first_author                | 91.51     | 88.12     | 89.78     | 44770   |
 | inTitle                     | 85.44     | 87.01     | 86.22     | 42795   |
 | issue                       | 93.43     | 92.1      | 92.76     | 18983   |
 | page                        | 93.8      | 77.49     | 84.87     | 40844   |
 | title                       | 91.75     | 92.3      | 92.02     | 43101   |
 | volume                      | 95.72     | 95.6      | 95.66     | 40458   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.18** | **85.93** | **87.53** | 321178  |
-| all fields (macro avg.)     | 89.67     | 86.45     | 87.95     | 321178  |
+| **all fields (micro avg.)** | **89.19** | **85.94** | **87.54** | 321178  |
+| all fields (macro avg.)     | 89.67     | 86.46     | 87.95     | 321178  |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -156,9 +170,9 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 90.45     | 87.12     | 88.76     | 44770   |
+| authors                     | 90.45     | 87.13     | 88.76     | 44770   |
 | date                        | 84.38     | 80.65     | 82.47     | 45457   |
-| first_author                | 92.04     | 88.62     | 90.3      | 44770   |
+| first_author                | 92.05     | 88.64     | 90.31     | 44770   |
 | inTitle                     | 86.32     | 87.91     | 87.11     | 42795   |
 | issue                       | 93.43     | 92.1      | 92.76     | 18983   |
 | page                        | 93.8      | 77.49     | 84.87     | 40844   |
@@ -174,52 +188,52 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 84.77     | 81.65     | 83.18     | 44770   |
+| authors                     | 84.79     | 81.67     | 83.2      | 44770   |
 | date                        | 84.38     | 80.65     | 82.47     | 45457   |
-| first_author                | 91.27     | 87.89     | 89.55     | 44770   |
+| first_author                | 91.29     | 87.9      | 89.56     | 44770   |
 | inTitle                     | 85.06     | 86.63     | 85.84     | 42795   |
 | issue                       | 93.43     | 92.1      | 92.76     | 18983   |
 | page                        | 93.8      | 77.49     | 84.87     | 40844   |
 | title                       | 93.65     | 94.21     | 93.93     | 43101   |
 | volume                      | 95.72     | 95.6      | 95.66     | 40458   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.84** | **86.57** | **88.18** | 321178  |
-| all fields (macro avg.)     | 90.26     | 87.03     | 88.53     | 321178  |
+| **all fields (micro avg.)** | **89.85** | **86.58** | **88.18** | 321178  |
+| all fields (macro avg.)     | 90.27     | 87.03     | 88.54     | 321178  |
 
 #### Instance-level results
 
 ```
 Total expected instances: 		48449
 Total extracted instances: 		47775
-Total correct instances: 		13503 (strict)
-Total correct instances: 		22251 (soft)
-Total correct instances: 		24863 (Levenshtein)
-Total correct instances: 		23242 (RatcliffObershelp)
+Total correct instances: 		13512 (strict)
+Total correct instances: 		22262 (soft)
+Total correct instances: 		24867 (Levenshtein)
+Total correct instances: 		23248 (RatcliffObershelp)
 
-Instance-level precision:	28.26 (strict)
-Instance-level precision:	46.57 (soft)
-Instance-level precision:	52.04 (Levenshtein)
-Instance-level precision:	48.65 (RatcliffObershelp)
+Instance-level precision:	28.28 (strict)
+Instance-level precision:	46.6 (soft)
+Instance-level precision:	52.05 (Levenshtein)
+Instance-level precision:	48.66 (RatcliffObershelp)
 
-Instance-level recall:	27.87	(strict)
-Instance-level recall:	45.93	(soft)
-Instance-level recall:	51.32	(Levenshtein)
-Instance-level recall:	47.97	(RatcliffObershelp)
+Instance-level recall:	27.89	(strict)
+Instance-level recall:	45.95	(soft)
+Instance-level recall:	51.33	(Levenshtein)
+Instance-level recall:	47.98	(RatcliffObershelp)
 
-Instance-level f-score:	28.07 (strict)
-Instance-level f-score:	46.25 (soft)
-Instance-level f-score:	51.68 (Levenshtein)
-Instance-level f-score:	48.31 (RatcliffObershelp)
+Instance-level f-score:	28.08 (strict)
+Instance-level f-score:	46.27 (soft)
+Instance-level f-score:	51.69 (Levenshtein)
+Instance-level f-score:	48.32 (RatcliffObershelp)
 
 Matching 1 :	35106
 
-Matching 2 :	1259
+Matching 2 :	1261
 
-Matching 3 :	3277
+Matching 3 :	3276
 
 Matching 4 :	1850
 
-Total matches :	41492
+Total matches :	41493
 ```
 
 #### Citation context resolution
@@ -258,7 +272,7 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | availability_stmt           | 57.73     | 58.02     | 57.87     | 779     |
 | conflict_stmt               | 92.57     | 91.89     | 92.23     | 962     |
 | figure_title                | 0.18      | 0.09      | 0.12      | 8943    |
-| funding_stmt                | 5.8       | 31.12     | 9.77      | 1507    |
+| funding_stmt                | 5.79      | 31.12     | 9.77      | 1507    |
 | reference_citation          | 87.98     | 94.53     | 91.13     | 69741   |
 | reference_figure            | 74.11     | 85.79     | 79.52     | 11010   |
 | reference_table             | 70.21     | 94.32     | 80.5      | 5159    |
@@ -277,7 +291,7 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | availability_stmt           | 85.57     | 86.01     | 85.79    | 779     |
 | conflict_stmt               | 95.6      | 94.91     | 95.25    | 962     |
 | figure_title                | 93.18     | 45.82     | 61.43    | 8943    |
-| funding_stmt                | 7.33      | 39.35     | 12.36    | 1507    |
+| funding_stmt                | 7.33      | 39.35     | 12.35    | 1507    |
 | reference_citation          | 87.98     | 94.54     | 91.14    | 69741   |
 | reference_figure            | 74.35     | 86.07     | 79.78    | 11010   |
 | reference_table             | 70.37     | 94.53     | 80.68    | 5159    |
@@ -297,5 +311,5 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | **all fields (micro avg.)** | **99.71** | **99.83** | **99.77** | 1741    |
 | all fields (macro avg.)     | 99.69     | 99.89     | 99.79     | 1741    |
 
-Evaluation metrics produced in 775.589 seconds
+Evaluation metrics produced in 101.766 seconds
 

--- a/doc/benchmarks/Benchmarking-pmc.md
+++ b/doc/benchmarks/Benchmarking-pmc.md
@@ -39,16 +39,17 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 
 **Field-level results**
 
-| label                       | precision | recall   | f1        | support |
-|-----------------------------|-----------|----------|-----------|---------|
-| abstract                    | 16.34     | 16.06    | 16.2      | 1911    |
-| authors                     | 92.94     | 92.89    | 92.91     | 1941    |
-| first_author                | 96.7      | 96.65    | 96.68     | 1941    |
-| keywords                    | 63.19     | 61.09    | 62.12     | 1380    |
-| title                       | 84.4      | 84.1     | 84.25     | 1943    |
-|                             |           |          |           |         |
-| **all fields (micro avg.)** | **71.58** | **70.9** | **71.24** | 9116    |
-| all fields (macro avg.)     | 70.71     | 70.16    | 70.43     | 9116    |
+| label                       | precision | recall    | f1        | support |
+|-----------------------------|-----------|-----------|-----------|---------|
+| abstract                    | 16.34     | 16.06     | 16.2      | 1911    |
+| affiliation_linked          | 0.49      | 0.48      | 0.49      | 1927    |
+| authors                     | 92.94     | 92.89     | 92.91     | 1941    |
+| first_author                | 96.7      | 96.65     | 96.68     | 1941    |
+| keywords                    | 63.19     | 61.09     | 62.12     | 1380    |
+| title                       | 84.4      | 84.1      | 84.25     | 1943    |
+|                             |           |           |           |         |
+| **all fields (micro avg.)** | **32.04** | **31.34** | **31.68** | 11043   |
+| all fields (macro avg.)     | 59.01     | 58.54     | 58.77     | 11043   |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -57,13 +58,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 62.96     | 61.9      | 62.43     | 1911    |
+| affiliation_linked          | 54.17     | 52.46     | 53.3      | 1927    |
 | authors                     | 94.9      | 94.85     | 94.87     | 1941    |
 | first_author                | 97.16     | 97.11     | 97.14     | 1941    |
 | keywords                    | 71.14     | 68.77     | 69.93     | 1380    |
 | title                       | 92.05     | 91.71     | 91.88     | 1943    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **84.62** | **83.81** | **84.21** | 9116    |
-| all fields (macro avg.)     | 83.64     | 82.87     | 83.25     | 9116    |
+| **all fields (micro avg.)** | **67.68** | **66.19** | **66.93** | 11043   |
+| all fields (macro avg.)     | 78.73     | 77.8      | 78.26     | 11043   |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -72,13 +74,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 89.84     | 88.33     | 89.08     | 1911    |
+| affiliation_linked          | 56.59     | 54.8      | 55.68     | 1927    |
 | authors                     | 96.75     | 96.7      | 96.73     | 1941    |
 | first_author                | 97.37     | 97.32     | 97.35     | 1941    |
 | keywords                    | 84.71     | 81.88     | 83.27     | 1380    |
 | title                       | 98.24     | 97.89     | 98.07     | 1943    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **93.99** | **93.09** | **93.54** | 9116    |
-| all fields (macro avg.)     | 93.38     | 92.43     | 92.9      | 9116    |
+| **all fields (micro avg.)** | **73.18** | **71.58** | **72.37** | 11043   |
+| all fields (macro avg.)     | 87.25     | 86.15     | 86.69     | 11043   |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -87,13 +90,24 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 85.74     | 84.3      | 85.01     | 1911    |
+| affiliation_linked          | 55.16     | 53.42     | 54.28     | 1927    |
 | authors                     | 95.82     | 95.78     | 95.8      | 1941    |
 | first_author                | 96.7      | 96.65     | 96.68     | 1941    |
 | keywords                    | 78.26     | 75.65     | 76.93     | 1380    |
 | title                       | 96.23     | 95.88     | 96.06     | 1943    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **91.41** | **90.53** | **90.97** | 9116    |
-| all fields (macro avg.)     | 90.55     | 89.65     | 90.1      | 9116    |
+| **all fields (micro avg.)** | **71.25** | **69.68** | **70.46** | 11043   |
+| all fields (macro avg.)     | 84.65     | 83.61     | 84.13     | 11043   |
+
+Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
+and their attached affiliations compared). Its support column reports the number of articles the metric is computed
+from (those with at least one explicit gold affiliation link), while precision/recall/F1 are measured over the
+individual author-affiliation links.
+Only authors whose gold affiliation link is explicit are scored; affiliations encoded purely positionally in the gold (
+no xref/@rid and no nested aff) are out of scope, not counted as misses.
+Ground truth: single-affiliation papers (exactly one <aff>) have been completed by linking every author to that sole
+affiliation (~1,649 authors across PMC, bioRxiv and PLOS). Still to be done: multi-affiliation papers that encode the
+author-to-affiliation mapping only positionally, which require the PDF superscripts to disambiguate.
 
 #### Instance-level results
 
@@ -120,9 +134,9 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 82.48     | 75.35     | 78.75     | 85778   |
+| authors                     | 82.49     | 75.36     | 78.77     | 85778   |
 | date                        | 94.56     | 83.09     | 88.46     | 87067   |
-| first_author                | 88.96     | 81.24     | 84.93     | 85778   |
+| first_author                | 88.97     | 81.24     | 84.93     | 85778   |
 | inTitle                     | 72.56     | 70.77     | 71.65     | 81007   |
 | issue                       | 90.38     | 85.18     | 87.7      | 16635   |
 | page                        | 94.6      | 83.37     | 88.63     | 80501   |
@@ -138,7 +152,7 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 82.95     | 75.78     | 79.2      | 85778   |
+| authors                     | 82.96     | 75.79     | 79.22     | 85778   |
 | date                        | 94.56     | 83.09     | 88.46     | 87067   |
 | first_author                | 89.14     | 81.4      | 85.09     | 85778   |
 | inTitle                     | 84.08     | 82.01     | 83.03     | 81007   |
@@ -147,7 +161,7 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | title                       | 90.88     | 85.52     | 88.12     | 80736   |
 | volume                      | 96.06     | 88.54     | 92.15     | 80067   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **90.2**  | **82.81** | **86.34** | 597569  |
+| **all fields (micro avg.)** | **90.2**  | **82.81** | **86.35** | 597569  |
 | all fields (macro avg.)     | 90.33     | 83.11     | 86.55     | 597569  |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
@@ -191,33 +205,33 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 ```
 Total expected instances: 		90125
 Total extracted instances: 		85511
-Total correct instances: 		38660 (strict)
-Total correct instances: 		50678 (soft)
+Total correct instances: 		38667 (strict)
+Total correct instances: 		50686 (soft)
 Total correct instances: 		55503 (Levenshtein)
-Total correct instances: 		52057 (RatcliffObershelp)
+Total correct instances: 		52059 (RatcliffObershelp)
 
-Instance-level precision:	45.21 (strict)
-Instance-level precision:	59.26 (soft)
+Instance-level precision:	45.22 (strict)
+Instance-level precision:	59.27 (soft)
 Instance-level precision:	64.91 (Levenshtein)
 Instance-level precision:	60.88 (RatcliffObershelp)
 
 Instance-level recall:	42.9	(strict)
-Instance-level recall:	56.23	(soft)
+Instance-level recall:	56.24	(soft)
 Instance-level recall:	61.58	(Levenshtein)
 Instance-level recall:	57.76	(RatcliffObershelp)
 
-Instance-level f-score:	44.02 (strict)
-Instance-level f-score:	57.71 (soft)
+Instance-level f-score:	44.03 (strict)
+Instance-level f-score:	57.72 (soft)
 Instance-level f-score:	63.2 (Levenshtein)
 Instance-level f-score:	59.28 (RatcliffObershelp)
 
 Matching 1 :	67606
 
-Matching 2 :	3942
+Matching 2 :	3944
 
-Matching 3 :	1785
+Matching 3 :	1784
 
-Matching 4 :	662
+Matching 4 :	661
 
 Total matches :	73995
 ```
@@ -230,14 +244,14 @@ Total expected references: 	 90125 - 46.38 references per article
 Total predicted references: 	 85511 - 44.01 references per article
 
 Total expected citation contexts: 	 139835 - 71.97 citation contexts per article
-Total predicted citation contexts: 	 114990 - 59.18 citation contexts per article
+Total predicted citation contexts: 	 114997 - 59.19 citation contexts per article
 
-Total correct predicted citation contexts: 	 97220 - 50.04 citation contexts per article
+Total correct predicted citation contexts: 	 97227 - 50.04 citation contexts per article
 Total wrong predicted citation contexts: 	 17770 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
 
 Precision citation contexts: 	 84.55
-Recall citation contexts: 	 69.52
-fscore citation contexts: 	 76.3
+Recall citation contexts: 	 69.53
+fscore citation contexts: 	 76.31
 ```
 
 ## Fulltext structures
@@ -256,13 +270,13 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | figure_title                | 32.03     | 26.7      | 29.12     | 7281    |
-| reference_citation          | 58.11     | 58.83     | 58.47     | 134196  |
+| reference_citation          | 58.11     | 58.84     | 58.47     | 134196  |
 | reference_figure            | 60.58     | 68.28     | 64.2      | 19330   |
 | reference_table             | 82.9      | 89.64     | 86.14     | 7327    |
 | section_title               | 72.46     | 67.69     | 69.99     | 27619   |
 | table_title                 | 67.72     | 49.66     | 57.3      | 3971    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **60.55** | **60.75** | **60.65** | 199724  |
+| **all fields (micro avg.)** | **60.56** | **60.75** | **60.65** | 199724  |
 | all fields (macro avg.)     | 62.3      | 60.13     | 60.87     | 199724  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
@@ -271,14 +285,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| figure_title                | 79.91     | 66.61     | 72.66     | 7281    |
-| reference_citation          | 62.39     | 63.17     | 62.78     | 134196  |
+| figure_title                | 79.9      | 66.61     | 72.65     | 7281    |
+| reference_citation          | 62.4      | 63.18     | 62.79     | 134196  |
 | reference_figure            | 61.08     | 68.84     | 64.72     | 19330   |
 | reference_table             | 83.06     | 89.82     | 86.31     | 7327    |
 | section_title               | 77.85     | 72.73     | 75.2      | 27619   |
 | table_title                 | 94.3      | 69.15     | 79.79     | 3971    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **66.05** | **66.26** | **66.16** | 199724  |
+| **all fields (micro avg.)** | **66.05** | **66.27** | **66.16** | 199724  |
 | all fields (macro avg.)     | 76.43     | 71.72     | 73.58     | 199724  |
 
 **Document-level ratio results**
@@ -289,6 +303,5 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | **all fields (micro avg.)** | **0**     | **0**  | **0** | 0       |
 | all fields (macro avg.)     | 0         | 0      | 0     | 0       |
 
-Evaluation metrics produced in 1250.197 seconds
-
+Evaluation metrics produced in 158.976 seconds
 

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -1972,6 +1972,18 @@ public class EndToEndEvaluation {
         Stats documentLevelStatementsRatioStat = mergedResult.documentLevelStatementsRatioStat;
         int totalExpectedInstances = mergedResult.totalExpectedInstances;
         int articlesWithLinkedAffiliation = mergedResult.articlesWithLinkedAffiliation;
+
+        // Report affiliation_linked's support as the number of contributing articles (same unit as
+        // the other header fields), not its raw per-author-link count. P/R/F1 are unaffected.
+        if (sectionType == HEADER) {
+            Map<String, Long> affSupport = Collections.singletonMap(
+                    AFFILIATION_LINKED_LABEL,
+                    (long) articlesWithLinkedAffiliation);
+            strictStats.setSupportOverride(affSupport);
+            softStats.setSupportOverride(affSupport);
+            levenshteinStats.setSupportOverride(affSupport);
+            ratcliffObershelpStats.setSupportOverride(affSupport);
+        }
         int totalObservedInstances = mergedResult.totalObservedInstances;
         int totalCorrectInstancesStrict = mergedResult.totalCorrectInstancesStrict;
         int totalCorrectInstancesSoft = mergedResult.totalCorrectInstancesSoft;
@@ -2198,15 +2210,10 @@ public class EndToEndEvaluation {
         } else if (sectionType == this.HEADER) {
             String affiliationNote = "\nNote: the \"affiliation_linked\" field above is a "
                     + "linking-aware metric (each author is paired with its gold counterpart and "
-                    + "their attached affiliations compared). Computed from "
-                    + articlesWithLinkedAffiliation
-                    + " of "
-                    + nbFile
-                    + " evaluated articles "
-                    + "(those with at least one explicit gold affiliation link). Its support is a "
-                    + "different population (per-author links, not per-article), so it is not "
-                    + "comparable to the other header fields and inflates the \"all fields\" "
-                    + "support total.\n"
+                    + "their attached affiliations compared). Its support column reports the number "
+                    + "of articles the metric is computed from (those with at least one explicit "
+                    + "gold affiliation link), while precision/recall/F1 are measured over the "
+                    + "individual author-affiliation links.\n"
                     + "Only authors whose gold affiliation link is explicit are scored; "
                     + "affiliations encoded purely positionally in the gold (no xref/@rid and no "
                     + "nested aff) are out of scope, not counted as misses.\n"

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -173,6 +173,8 @@ public class EndToEndEvaluation {
         int nbFile = 0;
         int totalExpectedInstances = 0;
         int totalObservedInstances = 0;
+        // number of articles that contributed at least one scoreable author to affiliation_linked
+        int articlesWithLinkedAffiliation = 0;
         int totalCorrectInstancesStrict = 0;
         int totalCorrectInstancesSoft = 0;
         int totalCorrectInstancesLevenshtein = 0;
@@ -211,6 +213,7 @@ public class EndToEndEvaluation {
             nbFile += other.nbFile;
             totalExpectedInstances += other.totalExpectedInstances;
             totalObservedInstances += other.totalObservedInstances;
+            articlesWithLinkedAffiliation += other.articlesWithLinkedAffiliation;
             totalCorrectInstancesStrict += other.totalCorrectInstancesStrict;
             totalCorrectInstancesSoft += other.totalCorrectInstancesSoft;
             totalCorrectInstancesLevenshtein += other.totalCorrectInstancesLevenshtein;
@@ -1270,7 +1273,7 @@ public class EndToEndEvaluation {
                         // author and compares their *linked* affiliations. Accumulated under the
                         // dedicated label "affiliation_linked" on the four matching variants.
                         try {
-                            evaluateLinkedAffiliations(
+                            int linkedScoredAuthors = evaluateLinkedAffiliations(
                                     gold,
                                     tei,
                                     inputType,
@@ -1279,6 +1282,9 @@ public class EndToEndEvaluation {
                                     result.softStats,
                                     result.levenshteinStats,
                                     result.ratcliffObershelpStats);
+                            if (linkedScoredAuthors > 0) {
+                                result.articlesWithLinkedAffiliation++;
+                            }
                         } catch (Exception e) {
                             e.printStackTrace();
                         }
@@ -1965,6 +1971,7 @@ public class EndToEndEvaluation {
         Stats ratcliffObershelpStats = mergedResult.ratcliffObershelpStats;
         Stats documentLevelStatementsRatioStat = mergedResult.documentLevelStatementsRatioStat;
         int totalExpectedInstances = mergedResult.totalExpectedInstances;
+        int articlesWithLinkedAffiliation = mergedResult.articlesWithLinkedAffiliation;
         int totalObservedInstances = mergedResult.totalObservedInstances;
         int totalCorrectInstancesStrict = mergedResult.totalCorrectInstancesStrict;
         int totalCorrectInstancesSoft = mergedResult.totalCorrectInstancesSoft;
@@ -2191,9 +2198,20 @@ public class EndToEndEvaluation {
         } else if (sectionType == this.HEADER) {
             String affiliationNote = "\nNote: the \"affiliation_linked\" field above is a "
                     + "linking-aware metric (each author is paired with its gold counterpart and "
-                    + "their attached affiliations compared). Only authors whose gold affiliation "
-                    + "link is explicit are scored; affiliations encoded purely positionally in the "
-                    + "gold are out of scope.\n";
+                    + "their attached affiliations compared). Computed from "
+                    + articlesWithLinkedAffiliation + " of " + nbFile + " evaluated articles "
+                    + "(those with at least one explicit gold affiliation link). Its support is a "
+                    + "different population (per-author links, not per-article), so it is not "
+                    + "comparable to the other header fields and inflates the \"all fields\" "
+                    + "support total.\n"
+                    + "Only authors whose gold affiliation link is explicit are scored; "
+                    + "affiliations encoded purely positionally in the gold (no xref/@rid and no "
+                    + "nested aff) are out of scope, not counted as misses.\n"
+                    + "Ground truth: single-affiliation papers (exactly one <aff>) have been "
+                    + "completed by linking every author to that sole affiliation (~1,649 authors "
+                    + "across PMC, bioRxiv and PLOS). Still to be done: multi-affiliation papers "
+                    + "that encode the author-to-affiliation mapping only positionally, which "
+                    + "require the PDF superscripts to disambiguate.\n";
             report.append(affiliationNote);
             reportMD.append(affiliationNote);
 
@@ -2334,8 +2352,12 @@ public class EndToEndEvaluation {
      * or a nested {@code aff}, or a nested {@code affiliation} in pub2TEI gold) are scored. Gold
      * documents that encode affiliations purely positionally are out of scope (such authors are
      * skipped, not counted as missed). Collaboration "authors" are skipped.</p>
+     *
+     * @return the number of gold authors actually scored (those with an explicit, resolvable
+     *     affiliation link). A return value {@code > 0} means this article contributes to the
+     *     affiliation_linked metric; the caller uses it to count contributing articles.
      */
-    private void evaluateLinkedAffiliations(
+    private int evaluateLinkedAffiliations(
             Document gold,
             Document tei,
             String inputType,
@@ -2353,6 +2375,7 @@ public class EndToEndEvaluation {
         Stats[] allStats = {strictStats, softStats, levenshteinStats, ratcliffObershelpStats};
 
         boolean[] consumed = new boolean[grobidAuthors.size()];
+        int scoredAuthors = 0;
         for (AuthorAff goldAuthor : goldAuthors) {
             if (goldAuthor.surnameNorm.isEmpty()) {
                 // collaboration or otherwise unnamed contributor: out of scope
@@ -2376,6 +2399,7 @@ public class EndToEndEvaluation {
             for (int level = 0; level < allStats.length; level++) {
                 scoreAuthorAffiliations(goldAuthor.affs, grobidAffs, level, allStats[level]);
             }
+            scoredAuthors++;
         }
 
         // grobid authors that were never paired but still carry affiliation text:
@@ -2391,6 +2415,8 @@ public class EndToEndEvaluation {
                 }
             }
         }
+
+        return scoredAuthors;
     }
 
     /**

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -2199,7 +2199,10 @@ public class EndToEndEvaluation {
             String affiliationNote = "\nNote: the \"affiliation_linked\" field above is a "
                     + "linking-aware metric (each author is paired with its gold counterpart and "
                     + "their attached affiliations compared). Computed from "
-                    + articlesWithLinkedAffiliation + " of " + nbFile + " evaluated articles "
+                    + articlesWithLinkedAffiliation
+                    + " of "
+                    + nbFile
+                    + " evaluated articles "
                     + "(those with at least one explicit gold affiliation link). Its support is a "
                     + "different population (per-author links, not per-article), so it is not "
                     + "comparable to the other header fields and inflates the \"all fields\" "

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -84,6 +84,11 @@ public class EndToEndEvaluation {
     public static final double minLevenshteinDistance = 0.8;
     public static final double minRatcliffObershelpSimilarity = 0.95;
 
+    // label under which the per-author linked-affiliation metric is reported
+    private static final String AFFILIATION_LINKED_LABEL = "affiliation_linked";
+    // minimum length for a substring-containment affiliation match (avoids trivial hits)
+    private static final int AFFILIATION_CONTAINMENT_FLOOR = 5;
+
     // the list of labels considered for the evaluation
     private List<String> headerLabels = null;
     private List<String> fulltextLabels = null;
@@ -1258,6 +1263,26 @@ public class EndToEndEvaluation {
                             }
                             p++;
                         }
+
+                        // additional, linking-aware metric: per-author affiliation accuracy.
+                        // Unlike the flat header fields above (which concatenate all affiliation
+                        // text across all authors), this pairs each gold author with a grobid
+                        // author and compares their *linked* affiliations. Accumulated under the
+                        // dedicated label "affiliation_linked" on the four matching variants.
+                        try {
+                            evaluateLinkedAffiliations(
+                                    gold,
+                                    tei,
+                                    inputType,
+                                    xp,
+                                    result.strictStats,
+                                    result.softStats,
+                                    result.levenshteinStats,
+                                    result.ratcliffObershelpStats);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
+
                         result.totalExpectedInstances++;
                         if (allGoodStrict) {
                             result.totalCorrectInstancesStrict++;
@@ -2164,6 +2189,14 @@ public class EndToEndEvaluation {
             report.append(localReport.toString());
             reportMD.append("```\n" + localReport.toString() + "```\n\n");
         } else if (sectionType == this.HEADER) {
+            String affiliationNote = "\nNote: the \"affiliation_linked\" field above is a "
+                    + "linking-aware metric (each author is paired with its gold counterpart and "
+                    + "their attached affiliations compared). Only authors whose gold affiliation "
+                    + "link is explicit are scored; affiliations encoded purely positionally in the "
+                    + "gold are out of scope.\n";
+            report.append(affiliationNote);
+            reportMD.append(affiliationNote);
+
             report.append("\n===== Instance-level results =====\n\n");
             reportMD.append("\n#### Instance-level results\n\n");
 
@@ -2284,6 +2317,333 @@ public class EndToEndEvaluation {
             }
         }
         return result.toString();
+    }
+
+    /**
+     * Per-author linked-affiliation accuracy metric.
+     *
+     * <p>The standard header fields concatenate all affiliation text across all authors into a
+     * single string before comparing, so they measure affiliation <i>extraction</i>, not the
+     * author&#8596;affiliation <i>linking</i>. This metric instead pairs each gold author with a
+     * grobid author (by normalised surname, forename initial as a tie-break) and compares the
+     * affiliations that are actually attached to each of them. Results are accumulated under the
+     * label {@code affiliation_linked} on the four matching variants (strict / soft / Levenshtein /
+     * Ratcliff-Obershelp), so they appear automatically in the existing field-level tables.</p>
+     *
+     * <p>Scope note: only authors whose gold affiliation link is explicit (JATS {@code xref/@rid}
+     * or a nested {@code aff}, or a nested {@code affiliation} in pub2TEI gold) are scored. Gold
+     * documents that encode affiliations purely positionally are out of scope (such authors are
+     * skipped, not counted as missed). Collaboration "authors" are skipped.</p>
+     */
+    private void evaluateLinkedAffiliations(
+            Document gold,
+            Document tei,
+            String inputType,
+            XPath xp,
+            Stats strictStats,
+            Stats softStats,
+            Stats levenshteinStats,
+            Stats ratcliffObershelpStats) throws Exception {
+
+        List<AuthorAff> grobidAuthors = extractGrobidAuthors(tei, xp);
+        List<AuthorAff> goldAuthors = inputType.equals("nlm")
+                ? extractNlmAuthors(gold, xp)
+                : extractGrobidAuthors(gold, xp);
+
+        Stats[] allStats = {strictStats, softStats, levenshteinStats, ratcliffObershelpStats};
+
+        boolean[] consumed = new boolean[grobidAuthors.size()];
+        for (AuthorAff goldAuthor : goldAuthors) {
+            if (goldAuthor.surnameNorm.isEmpty()) {
+                // collaboration or otherwise unnamed contributor: out of scope
+                continue;
+            }
+            if (goldAuthor.affs.isEmpty()) {
+                // no explicit gold affiliation link for this author: out of scope (not a miss)
+                continue;
+            }
+
+            int matchIdx = findMatchingGrobidAuthor(goldAuthor, grobidAuthors, consumed);
+            List<Aff> grobidAffs;
+            if (matchIdx >= 0) {
+                consumed[matchIdx] = true;
+                grobidAffs = grobidAuthors.get(matchIdx).affs;
+            } else {
+                // unmatched gold author: every expected affiliation is a false negative
+                grobidAffs = Collections.emptyList();
+            }
+
+            for (int level = 0; level < allStats.length; level++) {
+                scoreAuthorAffiliations(goldAuthor.affs, grobidAffs, level, allStats[level]);
+            }
+        }
+
+        // grobid authors that were never paired but still carry affiliation text:
+        // these affiliations were linked to an author that does not align with any gold author
+        for (int i = 0; i < grobidAuthors.size(); i++) {
+            if (consumed[i]) {
+                continue;
+            }
+            int nbAffs = grobidAuthors.get(i).affs.size();
+            for (Stats stats : allStats) {
+                for (int k = 0; k < nbAffs; k++) {
+                    stats.incrementFalsePositive(AFFILIATION_LINKED_LABEL);
+                }
+            }
+        }
+    }
+
+    /**
+     * Greedy 1:1 matching of a single author's gold affiliations against the grobid ones, for a
+     * given matching variant. Each gold affiliation is one expected unit; a matched grobid
+     * affiliation is a true positive (observed), an unmatched gold affiliation a false negative,
+     * and any leftover grobid affiliation a false positive.
+     */
+    private void scoreAuthorAffiliations(List<Aff> goldAffs, List<Aff> grobidAffs, int level, Stats stats) {
+        boolean[] used = new boolean[grobidAffs.size()];
+        for (Aff goldAff : goldAffs) {
+            stats.incrementExpected(AFFILIATION_LINKED_LABEL);
+            int match = -1;
+            for (int k = 0; k < grobidAffs.size(); k++) {
+                if (used[k]) {
+                    continue;
+                }
+                if (affiliationMatches(goldAff, grobidAffs.get(k), level)) {
+                    match = k;
+                    break;
+                }
+            }
+            if (match >= 0) {
+                used[match] = true;
+                stats.incrementObserved(AFFILIATION_LINKED_LABEL);
+            } else {
+                stats.incrementFalseNegative(AFFILIATION_LINKED_LABEL);
+            }
+        }
+        for (int k = 0; k < grobidAffs.size(); k++) {
+            if (!used[k]) {
+                stats.incrementFalsePositive(AFFILIATION_LINKED_LABEL);
+            }
+        }
+    }
+
+    /**
+     * Whether a gold and a grobid affiliation match at the given variant.
+     * level: 0 = strict, 1 = soft, 2 = Levenshtein, 3 = Ratcliff/Obershelp.
+     * For the non-strict variants a substring-containment fallback is allowed, because gold JATS
+     * affiliation text is usually a superset of grobid's structured orgName (it bundles
+     * city/country/zip that grobid splits into the address).
+     */
+    private boolean affiliationMatches(Aff gold, Aff grobid, int level) {
+        if (level == 0) {
+            return gold.strictNorm.length() > 0 && gold.strictNorm.equals(grobid.strictNorm);
+        }
+
+        boolean contained = containment(gold.softNorm, grobid.orgNorm)
+                || containment(gold.orgNorm, grobid.softNorm);
+
+        if (level == 1) {
+            return (gold.softNorm.length() > 0 && gold.softNorm.equals(grobid.softNorm)) || contained;
+        }
+
+        if (level == 2) {
+            if (gold.strictNorm.length() > 0 && grobid.strictNorm.length() > 0) {
+                int distance = TextUtilities.getLevenshteinDistance(gold.strictNorm, grobid.strictNorm);
+                int bigger = Math.max(gold.strictNorm.length(), grobid.strictNorm.length());
+                double pct = (double) (bigger - distance) / bigger;
+                if (pct >= minLevenshteinDistance) {
+                    return true;
+                }
+            }
+            return contained;
+        }
+
+        // Ratcliff/Obershelp
+        if (gold.strictNorm.length() > 0 && grobid.strictNorm.length() > 0) {
+            Option<Object> similarityObject = RatcliffObershelpMetric.compare(gold.strictNorm, grobid.strictNorm);
+            if ((similarityObject != null) && (similarityObject.get() != null)
+                    && ((Double) similarityObject.get() >= minRatcliffObershelpSimilarity)) {
+                return true;
+            }
+        }
+        return contained;
+    }
+
+    private static boolean containment(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        if (a.length() < AFFILIATION_CONTAINMENT_FLOOR || b.length() < AFFILIATION_CONTAINMENT_FLOOR) {
+            return false;
+        }
+        return a.contains(b) || b.contains(a);
+    }
+
+    /**
+     * Greedy author pairing: the first not-yet-consumed grobid author with the same normalised
+     * surname; a matching forename initial is preferred when several share the surname.
+     */
+    private int findMatchingGrobidAuthor(AuthorAff gold, List<AuthorAff> grobidAuthors, boolean[] consumed) {
+        int firstSurnameMatch = -1;
+        for (int i = 0; i < grobidAuthors.size(); i++) {
+            if (consumed[i]) {
+                continue;
+            }
+            AuthorAff candidate = grobidAuthors.get(i);
+            if (candidate.surnameNorm.isEmpty() || !candidate.surnameNorm.equals(gold.surnameNorm)) {
+                continue;
+            }
+            if (firstSurnameMatch < 0) {
+                firstSurnameMatch = i;
+            }
+            if (!gold.forenameInitial.isEmpty() && gold.forenameInitial.equals(candidate.forenameInitial)) {
+                return i;
+            }
+        }
+        return firstSurnameMatch;
+    }
+
+    /**
+     * Extract authors and their nested affiliations from a grobid (or pub2TEI gold) TEI document.
+     */
+    private List<AuthorAff> extractGrobidAuthors(Document doc, XPath xp) throws Exception {
+        List<AuthorAff> result = new ArrayList<>();
+        NodeList authorNodes = (NodeList) xp.compile("//sourceDesc/biblStruct/analytic/author")
+                .evaluate(doc.getDocumentElement(), XPathConstants.NODESET);
+        for (int i = 0; i < authorNodes.getLength(); i++) {
+            Node authorNode = authorNodes.item(i);
+            AuthorAff record = new AuthorAff();
+            record.surnameNorm = normalizeName(getTextContent(xp, authorNode, "persName/surname/text()"));
+            String forename = getTextContent(xp, authorNode, "persName/forename[@type=\"first\"]/text()");
+            if (forename.isEmpty()) {
+                forename = getTextContent(xp, authorNode, "persName/forename/text()");
+            }
+            record.forenameInitial = initial(forename);
+
+            NodeList affNodes = (NodeList) xp.compile("affiliation").evaluate(authorNode, XPathConstants.NODESET);
+            for (int j = 0; j < affNodes.getLength(); j++) {
+                Node affNode = affNodes.item(j);
+                // skip collaboration-as-affiliation
+                NodeList collab = (NodeList) xp.compile("orgName[@type=\"collaboration\"]")
+                        .evaluate(affNode, XPathConstants.NODESET);
+                if (collab.getLength() > 0) {
+                    continue;
+                }
+                String orgName = getTextContent(xp, affNode, "orgName/text()");
+                String address = getTextContent(xp, affNode, "address//text()");
+                String full = (orgName + " " + address).trim();
+                if (!full.isEmpty()) {
+                    record.affs.add(makeAff(orgName, full));
+                }
+            }
+            result.add(record);
+        }
+        return result;
+    }
+
+    /**
+     * Extract authors and their linked affiliations from an NLM/JATS gold document.
+     * The author&#8594;affiliation link follows {@code contrib/xref[@ref-type="aff"]/@rid} to the
+     * {@code aff} with the matching id (under {@code contrib-group} or {@code article-meta}), with a
+     * fallback to an {@code aff} nested directly inside the {@code contrib}.
+     */
+    private List<AuthorAff> extractNlmAuthors(Document gold, XPath xp) throws Exception {
+        // index every affiliation by its id (label child excluded)
+        Map<String, Aff> affById = new HashMap<>();
+        NodeList affNodes = (NodeList) xp.compile("//article-meta//aff")
+                .evaluate(gold.getDocumentElement(), XPathConstants.NODESET);
+        for (int i = 0; i < affNodes.getLength(); i++) {
+            Node affNode = affNodes.item(i);
+            String id = getTextContent(xp, affNode, "@id");
+            if (id.isEmpty()) {
+                continue;
+            }
+            String text = getTextContent(xp, affNode, ".//text()[not(parent::label)]");
+            affById.put(id, makeAff(text, text));
+        }
+
+        List<AuthorAff> result = new ArrayList<>();
+        NodeList contribs = (NodeList) xp.compile(
+                "/article/front/article-meta/contrib-group/contrib[@contrib-type=\"author\"]")
+                .evaluate(gold.getDocumentElement(), XPathConstants.NODESET);
+        for (int i = 0; i < contribs.getLength(); i++) {
+            Node contrib = contribs.item(i);
+            AuthorAff record = new AuthorAff();
+            String surname = getTextContent(xp, contrib, "name/surname/text()");
+            if (surname.isEmpty()) {
+                surname = getTextContent(xp, contrib, "string-name/surname/text()");
+            }
+            record.surnameNorm = normalizeName(surname);
+            record.forenameInitial = initial(getTextContent(xp, contrib, "name/given-names/text()"));
+
+            NodeList rids = (NodeList) xp.compile("xref[@ref-type=\"aff\"]/@rid")
+                    .evaluate(contrib, XPathConstants.NODESET);
+            if (rids.getLength() > 0) {
+                for (int r = 0; r < rids.getLength(); r++) {
+                    for (String rid : rids.item(r).getNodeValue().trim().split("\\s+")) {
+                        Aff aff = affById.get(rid);
+                        if (aff != null) {
+                            record.affs.add(aff);
+                        }
+                    }
+                }
+            } else {
+                // fallback: affiliation nested directly inside the contrib
+                NodeList nested = (NodeList) xp.compile(".//aff").evaluate(contrib, XPathConstants.NODESET);
+                for (int n = 0; n < nested.getLength(); n++) {
+                    String text = getTextContent(xp, nested.item(n), ".//text()[not(parent::label)]");
+                    if (!text.trim().isEmpty()) {
+                        record.affs.add(makeAff(text, text));
+                    }
+                }
+            }
+            result.add(record);
+        }
+        return result;
+    }
+
+    /** Concatenated value of every node selected by the relative path, space-separated. */
+    private String getTextContent(XPath xp, Node context, String path) throws Exception {
+        NodeList nodes = (NodeList) xp.compile(path).evaluate(context, XPathConstants.NODESET);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            String value = nodes.item(i).getNodeValue();
+            if (value != null) {
+                sb.append(value).append(" ");
+            }
+        }
+        return sb.toString().trim();
+    }
+
+    private static String normalizeName(String name) {
+        return removeFullPunct(basicNormalization(name == null ? "" : name));
+    }
+
+    private static String initial(String forename) {
+        String normalized = normalizeName(forename);
+        return normalized.isEmpty() ? "" : normalized.substring(0, 1);
+    }
+
+    private static Aff makeAff(String orgNameText, String fullText) {
+        Aff aff = new Aff();
+        aff.strictNorm = basicNormalization(fullText);
+        aff.softNorm = removeFullPunct(fullText);
+        aff.orgNorm = removeFullPunct(orgNameText);
+        return aff;
+    }
+
+    /** An author with the affiliations linked to them, for linking-aware evaluation. */
+    private static class AuthorAff {
+        String surnameNorm = "";
+        String forenameInitial = "";
+        List<Aff> affs = new ArrayList<>();
+    }
+
+    /** A single affiliation reduced to the normalisations used by the matching variants. */
+    private static class Aff {
+        String strictNorm = "";
+        String softNorm = "";
+        String orgNorm = "";
     }
 
     /**

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EvaluationConfigCheck.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EvaluationConfigCheck.java
@@ -58,8 +58,13 @@ public class EvaluationConfigCheck {
             "funding-acknowledgement"
     };
 
-    /** biblio-glutton health endpoint, appended to the configured glutton base URL. */
-    private static final String GLUTTON_ISALIVE_PATH = "/service/isalive";
+    /**
+     * biblio-glutton liveness endpoint, appended to the configured glutton base URL.
+     * biblio-glutton has no {@code /service/isalive} route; {@code /service/data} is a
+     * no-parameter endpoint that always answers 200 and returns index statistics, so it
+     * doubles as a health probe that confirms the databases are loaded.
+     */
+    private static final String GLUTTON_HEALTH_PATH = "/service/data";
 
     private static final int GLUTTON_PING_TIMEOUT_MS = 5000;
 
@@ -128,7 +133,7 @@ public class EvaluationConfigCheck {
             return;
         }
 
-        String isAliveUrl = StringUtils.removeEnd(gluttonUrl, "/") + GLUTTON_ISALIVE_PATH;
+        String isAliveUrl = StringUtils.removeEnd(gluttonUrl, "/") + GLUTTON_HEALTH_PATH;
         if (!isReachable(isAliveUrl)) {
             problems.add(
                     "biblio-glutton is not reachable at "

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/Stats.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/Stats.java
@@ -15,6 +15,8 @@
  */
 package org.grobid.trainer.evaluation;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -44,8 +46,24 @@ public final class Stats {
     private double cumulated_expected = 0;
     private int totalValidFields = 0;
 
+    // Optional per-label override for the *displayed* support (and the support column total).
+    // Does not affect precision/recall/F1, which stay computed from the underlying counts. Used
+    // so an add-on metric such as "affiliation_linked" can report its support as a number of
+    // articles - the same unit as the other header fields - rather than its raw per-link count.
+    private Map<String, Long> supportOverride = new HashMap<>();
+
     public Stats() {
         this.labelStats = new TreeMap<>();
+    }
+
+    /**
+     * Overrides the support value <em>displayed</em> for the given labels (and summed into the
+     * support column total). Precision, recall and F1 are unaffected. Intended for add-on metrics
+     * whose natural support unit differs from the plain fields (e.g. reporting article coverage
+     * for {@code affiliation_linked} instead of its per-link count).
+     */
+    public void setSupportOverride(Map<String, Long> overrides) {
+        this.supportOverride = (overrides == null) ? new HashMap<>() : new HashMap<>(overrides);
     }
 
     public Set<String> getLabels() {
@@ -346,7 +364,7 @@ public final class Stats {
 
             LabelStat labelStat = getLabelStat(label);
 
-            long support = labelStat.getSupport();
+            long support = supportOverride.getOrDefault(label, labelStat.getSupport());
             report.append(
                     String.format(
                             "%-20s %-12s %-12s %-12s %-12s %-7s\n",
@@ -400,7 +418,7 @@ public final class Stats {
             }
 
             LabelStat labelStat = getLabelStat(label);
-            long support = labelStat.getSupport();
+            long support = supportOverride.getOrDefault(label, labelStat.getSupport());
             report.append(
                     "| "
                             + label

--- a/grobid-trainer/src/test/java/org/grobid/trainer/StatsTest.java
+++ b/grobid-trainer/src/test/java/org/grobid/trainer/StatsTest.java
@@ -436,4 +436,47 @@ public class StatsTest {
         assertThat(target.getLabelStat("FOO").getObserved(), is(3));
     }
 
+    @Test
+    public void testSupportOverride_changesDisplayedSupportAndTotalOnly() throws Exception {
+        target.getLabelStat("FOO").setExpected(4);
+        target.getLabelStat("FOO").setObserved(4);
+
+        target.getLabelStat("AFF").setExpected(10);
+        target.getLabelStat("AFF").setObserved(8);
+        target.getLabelStat("AFF").setFalseNegative(2);
+        target.getLabelStat("AFF").setFalsePositive(2);
+
+        double microPrecisionBefore = target.getMicroAveragePrecision();
+
+        String before = target.getMarkDownReport();
+        assertThat(supportCellOf("| AFF ", before), is("10"));
+        assertThat(supportCellOf("micro avg", before), is("14"));
+
+        // Report AFF's support as an article count (3) instead of its 10 links.
+        target.setSupportOverride(java.util.Collections.singletonMap("AFF", 3L));
+        String after = target.getMarkDownReport();
+
+        // Displayed support for AFF and the support column total now reflect the override...
+        assertThat(supportCellOf("| AFF ", after), is("3"));
+        assertThat(supportCellOf("micro avg", after), is("7"));
+        // ...while precision/recall/F1 are computed from the underlying counts, unchanged.
+        assertThat(target.getMicroAveragePrecision(), is(microPrecisionBefore));
+        assertThat(target.getLabelStat("AFF").getPrecision(), is(0.8));
+        assertThat(target.getLabelStat("AFF").getRecall(), is(0.8));
+    }
+
+    /** Returns the trimmed support (last markdown cell) of the row whose text contains {@code needle}. */
+    private static String supportCellOf(String needle, String markdownReport) {
+        for (String line : markdownReport.split("\n")) {
+            if (line.contains(needle)) {
+                String trimmed = line.trim();
+                if (trimmed.endsWith("|")) {
+                    trimmed = trimmed.substring(0, trimmed.length() - 1).trim();
+                }
+                return trimmed.substring(trimmed.lastIndexOf('|') + 1).trim();
+            }
+        }
+        return null;
+    }
+
 }


### PR DESCRIPTION
## What

Adds a new `affiliation_linked` field to the HEADER section of the end-to-end evaluation. Unlike the existing header fields, it measures how well GROBID links each **author to their own affiliation(s)**, not just whether affiliation text
was extracted somewhere on the page.

## Why

The standard `affiliation`/header comparison concatenates *all* affiliation text across *all* authors into a single string before scoring. That measures affiliation **extraction**, but it is blind to **linking**: a document where every
affiliation is correctly transcribed but attached to the wrong author scores just as well as a perfectly linked one. This metric closes that gap.

## How it works

- Pairs each gold author with a GROBID author by **normalised surname**, using the **forename initial** as a tie-break (handles duplicate surnames).
- Compares the affiliations **actually attached to each paired author** (1:1 greedy match per author), not a global text blob.
- Accumulates under the label `affiliation_linked` across the four existing matching variants (strict / soft / Levenshtein / Ratcliff-Obershelp), so it shows up automatically as a new row in the field-level tables — no report plumbing changes needed.
- Non-strict variants allow a **substring-containment** fallback, because gold JATS affiliation text is usually a superset of GROBID's structured `orgName` (JATS bundles city/country/postcode that GROBID splits out into the address).

## ⚠️ Caveat: this metric depends on how the gold JATS/TEI encodes the link

**Only authors whose gold affiliation link is *explicit* are scored.** Concretely:

- **NLM/JATS gold** (`jatsEval`): the link is followed via `contrib/xref[@ref-type="aff"]/@rid` → the `aff` with the matching `@id` (under `article-meta`), with a fallback to an `aff` nested directly inside the `contrib`.
- **pub2TEI / TEI gold** (`teiEval`): the link is the `<affiliation>` nested inside the `<author>`.

If a gold document encodes affiliations **purely positionally** — no `xref/@rid`, no nested `aff` — then those authors are **skipped, not counted as misses**. They contribute nothing to support, precision, or recall. Collaboration/unnamed contributors are also skipped.

**Consequences for reading the numbers:**

1. `affiliation_linked` **support will be lower than `authors` support** — it is a subset of the corpus (only the explicitly-linked authors). This is expected, not a bug.
2. **Coverage varies by dataset.** PMC/PLOS JATS use `xref/@rid` consistently, so coverage is high. A gold set that leans on positional layout will report a smaller support and a metric computed over fewer authors — compare `affiliation_linked` support against `authors` support to see how much of the set was actually in scope.
3. The metric evaluates GROBID's linking **against the gold's linking model**; it cannot score linking the gold itself does not express.

## How to read the output

A new row appears in each of the four HEADER matching tables:

| label             | precision | recall | f1 | support |
|-------------------|-----------|--------|----|---------|
| ...               |           |        |    |         |
| affiliation_linked| ...       | ...    | ...| N       |
| authors           | ...       | ...    | ...| M       |

with `N ≤ M`, plus an explanatory note beneath the field-level table.

## Testing

- `./gradlew grobid-trainer:compileJava spotlessCheck` → BUILD SUCCESSFUL.
- Ported onto the parallelized evaluation (#1487): the metric accumulates into the per-document `DocumentEvaluationResult` stats inside `DocumentEvaluationCallable`, so it is thread-safe under the concurrent matching introduced there.
- Re-run any dataset (`./gradlew jatsEval -Pp2t=/path/to/PMC_sample_1943`) to see the `affiliation_linked` row populate.