### PR TITLE
Fix JVM shutdown deadlock when closing JEP Python interpreters

### DIFF
--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPool.java
@@ -19,6 +19,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jep.Jep;
 import jep.JepConfig;
@@ -43,6 +44,7 @@ public class JEPThreadPool {
 
     private final ExecutorService executor;
     private final ConcurrentMap<Long, Jep> jepInstances;
+    private final AtomicBoolean shutdownStarted = new AtomicBoolean(false);
 
     private static volatile JEPThreadPool instance;
 
@@ -67,7 +69,12 @@ public class JEPThreadPool {
     private JEPThreadPool() {
         // creating a pool of POOL_SIZE threads
         //executor = Executors.newFixedThreadPool(POOL_SIZE);
-        executor = Executors.newSingleThreadExecutor();
+        // daemon thread so that a wedged Python interpreter can never prevent the JVM from exiting
+        executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "jep-pool-worker");
+            t.setDaemon(true);
+            return t;
+        });
         // each of these threads is associated to a JEP instance
         jepInstances = new ConcurrentHashMap<>();
 
@@ -229,17 +236,32 @@ public class JEPThreadPool {
     /**
      * Close all JEP instances and shutdown the executor.
      * This should be called when the application is shutting down.
+     * JEP only allows a Python interpreter to be closed by the thread that
+     * created it, so the close is delegated to the executor worker thread;
+     * not synchronized, otherwise the worker could deadlock against the
+     * caller on the singleton monitor.
      */
-    public synchronized void shutdown() {
+    public void shutdown() {
+        if (!shutdownStarted.compareAndSet(false, true)) {
+            return;
+        }
         LOGGER.info("Shutting down JEPThreadPool");
-        // Close all JEP instances
-        for (Map.Entry<Long, Jep> entry : jepInstances.entrySet()) {
-            try {
-                LOGGER.info("Closing JEP instance for thread " + entry.getKey());
-                entry.getValue().close();
-            } catch (JepException e) {
-                LOGGER.error("Failed to close JEP instance for thread " + entry.getKey(), e);
-            }
+        try {
+            Future<?> closeTask = executor.submit(this::closeCurrentJEPInstance);
+            closeTask.get(10, TimeUnit.SECONDS);
+        } catch (RejectedExecutionException | ExecutionException | TimeoutException e) {
+            LOGGER.warn("Could not close JEP instance on its owning thread", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // remaining instances belong to dead or replaced threads and cannot be
+        // closed by any other thread without corrupting the Python thread state
+        for (Long threadId : jepInstances.keySet()) {
+            LOGGER.warn(
+                    "Abandoning JEP instance of thread "
+                            + threadId
+                            + ", it can only be closed by its creating thread");
         }
         jepInstances.clear();
 
@@ -251,6 +273,7 @@ public class JEPThreadPool {
             }
         } catch (InterruptedException e) {
             executor.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPoolClassifier.java
+++ b/grobid-core/src/main/java/org/grobid/core/jni/JEPThreadPoolClassifier.java
@@ -19,6 +19,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jep.Jep;
 import jep.JepConfig;
@@ -44,6 +45,7 @@ public class JEPThreadPoolClassifier {
 
     private final ExecutorService executor;
     private final ConcurrentMap<Long, Jep> jepInstances;
+    private final AtomicBoolean shutdownStarted = new AtomicBoolean(false);
 
     private static volatile JEPThreadPoolClassifier instance;
 
@@ -68,7 +70,12 @@ public class JEPThreadPoolClassifier {
     private JEPThreadPoolClassifier() {
         // creating a pool of POOL_SIZE threads
         //executor = Executors.newFixedThreadPool(POOL_SIZE);
-        executor = Executors.newSingleThreadExecutor();
+        // daemon thread so that a wedged Python interpreter can never prevent the JVM from exiting
+        executor = Executors.newSingleThreadExecutor(r -> {
+            Thread t = new Thread(r, "jep-classifier-worker");
+            t.setDaemon(true);
+            return t;
+        });
         // each of these threads is associated to a JEP instance
         jepInstances = new ConcurrentHashMap<>();
 
@@ -190,10 +197,15 @@ public class JEPThreadPoolClassifier {
 
     public void run(Runnable task) throws InterruptedException {
         LOGGER.debug("running thread: " + Thread.currentThread().getId());
-        Future future = executor.submit(task);
-        // wait until done (in ms)
-        while (!future.isDone()) {
-            Thread.sleep(1);
+        Future<?> future = executor.submit(task);
+        try {
+            future.get(); // blocks until done, propagates exceptions
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            throw new RuntimeException(cause);
         }
     }
 
@@ -223,17 +235,32 @@ public class JEPThreadPoolClassifier {
     /**
      * Close all JEP instances and shutdown the executor.
      * This should be called when the application is shutting down.
+     * JEP only allows a Python interpreter to be closed by the thread that
+     * created it, so the close is delegated to the executor worker thread;
+     * not synchronized, otherwise the worker could deadlock against the
+     * caller on the singleton monitor.
      */
-    public synchronized void shutdown() {
+    public void shutdown() {
+        if (!shutdownStarted.compareAndSet(false, true)) {
+            return;
+        }
         LOGGER.info("Shutting down JEPThreadPoolClassifier");
-        // Close all JEP instances
-        for (Map.Entry<Long, Jep> entry : jepInstances.entrySet()) {
-            try {
-                LOGGER.info("Closing JEP instance for thread " + entry.getKey());
-                entry.getValue().close();
-            } catch (JepException e) {
-                LOGGER.error("Failed to close JEP instance for thread " + entry.getKey(), e);
-            }
+        try {
+            Future<?> closeTask = executor.submit(this::closeCurrentJEPInstance);
+            closeTask.get(10, TimeUnit.SECONDS);
+        } catch (RejectedExecutionException | ExecutionException | TimeoutException e) {
+            LOGGER.warn("Could not close JEP instance on its owning thread", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // remaining instances belong to dead or replaced threads and cannot be
+        // closed by any other thread without corrupting the Python thread state
+        for (Long threadId : jepInstances.keySet()) {
+            LOGGER.warn(
+                    "Abandoning JEP instance of thread "
+                            + threadId
+                            + ", it can only be closed by its creating thread");
         }
         jepInstances.clear();
 
@@ -245,6 +272,7 @@ public class JEPThreadPoolClassifier {
             }
         } catch (InterruptedException e) {
             executor.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/grobid-core/src/test/java/org/grobid/core/jni/JEPThreadPoolClassifierTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/JEPThreadPoolClassifierTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2008-2026 GROBID contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grobid.core.jni;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * These tests exercise the executor and shutdown logic only, no Python
+ * interpreter is created so no native JEP installation is required.
+ * The shutdown test must run last as it terminates the singleton's executor.
+ */
+@TestMethodOrder(OrderAnnotation.class)
+public class JEPThreadPoolClassifierTest {
+
+    @Test
+    @Order(1)
+    public void testWorkerThread_shouldBeNamedDaemon() throws Exception {
+        AtomicReference<Thread> worker = new AtomicReference<>();
+        JEPThreadPoolClassifier.getInstance().run(() -> worker.set(Thread.currentThread()));
+
+        assertThat(worker.get().isDaemon(), is(true));
+        assertThat(worker.get().getName(), is("jep-classifier-worker"));
+    }
+
+    @Test
+    @Order(2)
+    public void testRun_shouldPropagateTaskException() {
+        assertThrows(IllegalStateException.class, () -> JEPThreadPoolClassifier.getInstance().run(() -> {
+            throw new IllegalStateException("boom");
+        }));
+    }
+
+    @Test
+    @Order(3)
+    public void testShutdown_shouldCompleteQuicklyAndBeIdempotent() {
+        long start = System.currentTimeMillis();
+        JEPThreadPoolClassifier.getInstance().shutdown();
+        JEPThreadPoolClassifier.getInstance().shutdown();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(elapsed, is(lessThan(5000L)));
+    }
+}

--- a/grobid-core/src/test/java/org/grobid/core/jni/JEPThreadPoolTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/jni/JEPThreadPoolTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2008-2026 GROBID contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grobid.core.jni;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * These tests exercise the executor and shutdown logic only, no Python
+ * interpreter is created so no native JEP installation is required.
+ * The shutdown test must run last as it terminates the singleton's executor.
+ */
+@TestMethodOrder(OrderAnnotation.class)
+public class JEPThreadPoolTest {
+
+    @Test
+    @Order(1)
+    public void testWorkerThread_shouldBeNamedDaemon() throws Exception {
+        AtomicReference<Thread> worker = new AtomicReference<>();
+        JEPThreadPool.getInstance().run(() -> worker.set(Thread.currentThread()));
+
+        assertThat(worker.get().isDaemon(), is(true));
+        assertThat(worker.get().getName(), is("jep-pool-worker"));
+    }
+
+    @Test
+    @Order(2)
+    public void testRun_shouldPropagateTaskException() {
+        assertThrows(IllegalStateException.class, () -> JEPThreadPool.getInstance().run(() -> {
+            throw new IllegalStateException("boom");
+        }));
+    }
+
+    @Test
+    @Order(3)
+    public void testShutdown_shouldCompleteQuicklyAndBeIdempotent() {
+        long start = System.currentTimeMillis();
+        JEPThreadPool.getInstance().shutdown();
+        JEPThreadPool.getInstance().shutdown();
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertThat(elapsed, is(lessThan(5000L)));
+    }
+}

--- a/grobid-home/scripts/run_evaluation.sh
+++ b/grobid-home/scripts/run_evaluation.sh
@@ -59,7 +59,7 @@ START_PWD="$(pwd)"
 
 # determine the script dir and repository root (repo root = parent of grobid-home)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd)"
 # default absolute report source path (repo-root based)
 REPORT_SRC_DEFAULT="${REPO_ROOT}/grobid-home/tmp/report.md"
 # also consider start-pwd rooted path when gradle output differs by working dir
@@ -190,6 +190,8 @@ else
 fi
 
 overall_status=0
+# per-dataset outcomes: "<name>|OK" or "<name>|FAILED|<reason>|<log_path>"
+results=( )
 
 # iterate over matching subdirectories (non-recursive)
 shopt_cmd=""
@@ -209,12 +211,17 @@ esac
 # Build an array of dataset directories matching the pattern
 cd "${EVAL_ROOT}" || { echo "Failed to cd into ${EVAL_ROOT}" >&2; exit 2; }
 
-# Expand pattern safely
+# Expand pattern safely; keep only directories that look like datasets (contain PDFs)
 datasets=( )
 for entry in ${PATTERN}; do
-  if [ -d "${entry}" ]; then
-    datasets+=("${EVAL_ROOT}/${entry}")
+  if [ ! -d "${entry}" ]; then
+    continue
   fi
+  if [ -z "$(find "${EVAL_ROOT}/${entry}" -maxdepth 2 -iname '*.pdf' -print -quit 2>/dev/null)" ]; then
+    echo "Skipping ${entry}: no PDFs found, not a dataset"
+    continue
+  fi
+  datasets+=("${EVAL_ROOT}/${entry}")
 done
 
 if [ ${#datasets[@]} -eq 0 ]; then
@@ -237,12 +244,17 @@ for ds in "${datasets[@]}"; do
     echo "DRY: ${cmd[*]}"
     echo "DRY: would write log to ${log_dst}"
   else
+    # remove any stale report so a leftover from a previous dataset/run can
+    # never be moved as if it were this dataset's result
+    rm -f "${REPORT_SRC_DEFAULT}" "${REPORT_SRC_STARTPWD}"
+
     # execute gradlew from the directory where the script was invoked (START_PWD)
     (cd "${START_PWD}" && "${cmd[@]}") | tee "${log_dst}"
     exit_code=${PIPESTATUS[0]}
 
     if [ $exit_code -ne 0 ]; then
-      echo "Gradle jatsEval failed for ${ds_basename} with exit code ${exit_code}" >&2
+      echo "Gradle jatsEval failed for ${ds_basename} with exit code ${exit_code}, see ${log_dst}" >&2
+      results+=("${ds_basename}|FAILED|gradle exit ${exit_code}|${log_dst}")
       overall_status=1
       # continue with other datasets
     else
@@ -256,10 +268,17 @@ for ds in "${datasets[@]}"; do
       fi
 
       if [ -f "${report_src}" ]; then
-        mv "${report_src}" "${report_dst}" || { echo "Failed to move report to ${report_dst}" >&2; overall_status=1; }
-        echo "Report saved to ${report_dst}"
+        if mv "${report_src}" "${report_dst}"; then
+          echo "Report saved to ${report_dst}"
+          results+=("${ds_basename}|OK")
+        else
+          echo "Failed to move report to ${report_dst}" >&2
+          results+=("${ds_basename}|FAILED|could not move report|${log_dst}")
+          overall_status=1
+        fi
       else
         echo "Warning: report not found at ${REPORT_SRC_DEFAULT} or ${REPORT_SRC_STARTPWD} after evaluation of ${ds_basename}" >&2
+        results+=("${ds_basename}|FAILED|report not found after successful build|${log_dst}")
         overall_status=1
       fi
     fi
@@ -273,10 +292,30 @@ if [ ${DRY_RUN} -eq 1 ]; then
   exit 0
 fi
 
+echo "===== Summary ====="
+for result in "${results[@]}"; do
+  ds_name="${result%%|*}"
+  rest="${result#*|}"
+  status="${rest%%|*}"
+  if [ "${status}" = "OK" ]; then
+    printf '%-30s : OK\n' "${ds_name}"
+  else
+    reason_and_log="${rest#*|}"
+    reason="${reason_and_log%%|*}"
+    log_path="${reason_and_log#*|}"
+    printf '%-30s : FAILED (%s) — see %s\n' "${ds_name}" "${reason}" "${log_path}"
+  fi
+done
+
 if [ ${overall_status} -eq 0 ]; then
   echo "All evaluations completed successfully."
 else
-  echo "One or more evaluations failed. Check output above." >&2
+  echo "One or more evaluations failed:" >&2
+  for result in "${results[@]}"; do
+    case "${result}" in
+      *"|FAILED|"*) echo "  ${result%%|*}" >&2 ;;
+    esac
+  done
 fi
 
 exit ${overall_status}


### PR DESCRIPTION
The shutdown hook closed Jep instances from the hook thread, but JEP only allows an interpreter to be closed by the thread that created it: every close() threw "Unsafe close() of Python sub-interpreter" and the interpreter was never torn down, leaving the JVM parked forever after DeLFT evaluations completed.

- delegate the close to the executor worker thread that owns the Jep instance, with a bounded wait
- make the executor threads named daemons so a wedged interpreter can never block JVM exit
- make shutdown() idempotent via AtomicBoolean instead of synchronized, removing a monitor deadlock between the hook thread and the worker
- replace the busy-wait in JEPThreadPoolClassifier.run() with future.get() and exception propagation, matching JEPThreadPool