### PR TITLE
Avoid assigning the same affiliation once per marker character

### DIFF
--- a/doc/benchmarks/Benchmarking-biorxiv.md
+++ b/doc/benchmarks/Benchmarking-biorxiv.md
@@ -42,15 +42,15 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 2.31      | 2.26      | 2.28      | 1989    |
-| affiliation_linked          | 0.83      | 0.83      | 0.83      | 1962    |
+| abstract                    | 2.31      | 2.26      | 2.29      | 1989    |
+| affiliation_linked          | 0.86      | 0.86      | 0.86      | 1962    |
 | authors                     | 84.85     | 84.38     | 84.62     | 1998    |
 | first_author                | 96.73     | 96.29     | 96.51     | 1996    |
-| keywords                    | 57.33     | 57.33     | 57.33     | 839     |
+| keywords                    | 57.28     | 57.28     | 57.28     | 838     |
 | title                       | 77.26     | 76.49     | 76.87     | 1999    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **23.23** | **23.06** | **23.14** | 10783   |
-| all fields (macro avg.)     | 53.22     | 52.93     | 53.07     | 10783   |
+| **all fields (micro avg.)** | **22.78** | **22.77** | **22.78** | 10782   |
+| all fields (macro avg.)     | 53.21     | 52.93     | 53.07     | 10782   |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -58,31 +58,31 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 59.54     | 58.37     | 58.95     | 1989    |
-| affiliation_linked          | 72.82     | 72.34     | 72.58     | 1962    |
+| abstract                    | 59.52     | 58.32     | 58.91     | 1989    |
+| affiliation_linked          | 75.32     | 75.59     | 75.45     | 1962    |
 | authors                     | 85.35     | 84.88     | 85.12     | 1998    |
 | first_author                | 96.98     | 96.54     | 96.76     | 1996    |
-| keywords                    | 63.05     | 63.05     | 63.05     | 839     |
+| keywords                    | 63.01     | 63.01     | 63.01     | 838     |
 | title                       | 79.48     | 78.69     | 79.08     | 1999    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **74.91** | **74.35** | **74.63** | 10783   |
-| all fields (macro avg.)     | 76.21     | 75.65     | 75.92     | 10783   |
+| **all fields (micro avg.)** | **76.5**  | **76.44** | **76.47** | 10782   |
+| all fields (macro avg.)     | 76.61     | 76.17     | 76.39     | 10782   |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
 **Field-level results**
 
-| label                       | precision | recall    | f1        | support |
-|-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 80.1      | 78.53     | 79.31     | 1989    |
-| affiliation_linked          | 75.63     | 75.13     | 75.38     | 1962    |
-| authors                     | 92.55     | 92.04     | 92.3      | 1998    |
-| first_author                | 97.23     | 96.79     | 97.01     | 1996    |
-| keywords                    | 78.19     | 78.19     | 78.19     | 839     |
-| title                       | 91.92     | 91        | 91.45     | 1999    |
-|                             |           |           |           |         |
-| **all fields (micro avg.)** | **80.42** | **79.83** | **80.12** | 10783   |
-| all fields (macro avg.)     | 85.94     | 85.28     | 85.61     | 10783   |
+| label                       | precision | recall    | f1       | support |
+|-----------------------------|-----------|-----------|----------|---------|
+| abstract                    | 80.09     | 78.48     | 79.28    | 1989    |
+| affiliation_linked          | 77.47     | 77.75     | 77.61    | 1962    |
+| authors                     | 92.55     | 92.04     | 92.3     | 1998    |
+| first_author                | 97.23     | 96.79     | 97.01    | 1996    |
+| keywords                    | 78.16     | 78.16     | 78.16    | 838     |
+| title                       | 91.92     | 91        | 91.45    | 1999    |
+|                             |           |           |          |         |
+| **all fields (micro avg.)** | **81.53** | **81.47** | **81.5** | 10782   |
+| all fields (macro avg.)     | 86.24     | 85.7      | 85.97    | 10782   |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -90,15 +90,15 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 77.03     | 75.52     | 76.26     | 1989    |
-| affiliation_linked          | 73.85     | 73.37     | 73.61     | 1962    |
+| abstract                    | 77.01     | 75.47     | 76.23     | 1989    |
+| affiliation_linked          | 75.97     | 76.25     | 76.11     | 1962    |
 | authors                     | 88.48     | 87.99     | 88.23     | 1998    |
 | first_author                | 96.73     | 96.29     | 96.51     | 1996    |
-| keywords                    | 70.32     | 70.32     | 70.32     | 839     |
+| keywords                    | 70.29     | 70.29     | 70.29     | 838     |
 | title                       | 87.67     | 86.79     | 87.23     | 1999    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **78.06** | **77.48** | **77.77** | 10783   |
-| all fields (macro avg.)     | 82.35     | 81.71     | 82.03     | 10783   |
+| **all fields (micro avg.)** | **79.37** | **79.31** | **79.34** | 10782   |
+| all fields (macro avg.)     | 82.69     | 82.18     | 82.43     | 10782   |
 
 Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
 and their attached affiliations compared). Its support column reports the number of articles the metric is computed
@@ -115,14 +115,14 @@ author-to-affiliation mapping only positionally, which require the PDF superscri
 ```
 Total expected instances: 	1999
 Total correct instances: 	37 (strict)
-Total correct instances: 	724 (soft)
-Total correct instances: 	1223 (Levenshtein)
-Total correct instances: 	1053 (ObservedRatcliffObershelp)
+Total correct instances: 	723 (soft)
+Total correct instances: 	1222 (Levenshtein)
+Total correct instances: 	1052 (ObservedRatcliffObershelp)
 
 Instance-level recall:	1.85	(strict)
-Instance-level recall:	36.22	(soft)
-Instance-level recall:	61.18	(Levenshtein)
-Instance-level recall:	52.68	(RatcliffObershelp)
+Instance-level recall:	36.17	(soft)
+Instance-level recall:	61.13	(Levenshtein)
+Instance-level recall:	52.63	(RatcliffObershelp)
 ```
 
 ## Citation metadata
@@ -133,22 +133,22 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 **Field-level results**
 
-| label                       | precision | recall    | f1        | support |
-|-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 88.32     | 83.09     | 85.63     | 97113   |
-| date                        | 91.55     | 85.85     | 88.61     | 97559   |
-| doi                         | 71.01     | 83.52     | 76.76     | 16831   |
-| first_author                | 95.14     | 89.42     | 92.19     | 97113   |
-| inTitle                     | 82.72     | 79.03     | 80.83     | 96359   |
-| issue                       | 93.93     | 90.77     | 92.32     | 30312   |
-| page                        | 94.83     | 77.89     | 85.53     | 88534   |
-| pmcid                       | 65.78     | 82.9      | 73.36     | 807     |
-| pmid                        | 69.95     | 80.41     | 74.82     | 2093    |
-| title                       | 84.81     | 83.28     | 84.04     | 92394   |
-| volume                      | 95.97     | 94.78     | 95.37     | 87644   |
-|                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.78** | **84.94** | **87.29** | 706759  |
-| all fields (macro avg.)     | 84.91     | 84.63     | 84.5      | 706759  |
+| label                       | precision | recall    | f1       | support |
+|-----------------------------|-----------|-----------|----------|---------|
+| authors                     | 88.33     | 83.1      | 85.64    | 97164   |
+| date                        | 91.55     | 85.86     | 88.61    | 97611   |
+| doi                         | 71.1      | 83.57     | 76.83    | 16894   |
+| first_author                | 95.14     | 89.43     | 92.2     | 97164   |
+| inTitle                     | 82.72     | 79.03     | 80.84    | 96411   |
+| issue                       | 93.93     | 90.76     | 92.32    | 30298   |
+| page                        | 94.83     | 77.89     | 85.53    | 88578   |
+| pmcid                       | 65.78     | 82.9      | 73.36    | 807     |
+| pmid                        | 69.95     | 80.41     | 74.82    | 2093    |
+| title                       | 84.81     | 83.29     | 84.04    | 92444   |
+| volume                      | 95.97     | 94.78     | 95.37    | 87691   |
+|                             |           |           |          |         |
+| **all fields (micro avg.)** | **89.78** | **84.95** | **87.3** | 707155  |
+| all fields (macro avg.)     | 84.92     | 84.64     | 84.5     | 707155  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -156,20 +156,20 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 89.48     | 84.17     | 86.74     | 97113   |
-| date                        | 91.55     | 85.85     | 88.61     | 97559   |
-| doi                         | 75.49     | 88.79     | 81.6      | 16831   |
-| first_author                | 95.57     | 89.82     | 92.61     | 97113   |
-| inTitle                     | 92.14     | 88.03     | 90.04     | 96359   |
-| issue                       | 93.93     | 90.77     | 92.32     | 30312   |
-| page                        | 94.83     | 77.89     | 85.53     | 88534   |
+| authors                     | 89.48     | 84.18     | 86.75     | 97164   |
+| date                        | 91.55     | 85.86     | 88.61     | 97611   |
+| doi                         | 75.56     | 88.82     | 81.65     | 16894   |
+| first_author                | 95.57     | 89.83     | 92.61     | 97164   |
+| inTitle                     | 92.14     | 88.03     | 90.04     | 96411   |
+| issue                       | 93.93     | 90.76     | 92.32     | 30298   |
+| page                        | 94.83     | 77.89     | 85.53     | 88578   |
 | pmcid                       | 74.73     | 94.18     | 83.33     | 807     |
 | pmid                        | 73.82     | 84.85     | 78.95     | 2093    |
-| title                       | 93.1      | 91.42     | 92.26     | 92394   |
-| volume                      | 95.97     | 94.78     | 95.37     | 87644   |
+| title                       | 93.11     | 91.43     | 92.26     | 92444   |
+| volume                      | 95.97     | 94.78     | 95.37     | 87691   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **92.57** | **87.59** | **90.01** | 706759  |
-| all fields (macro avg.)     | 88.24     | 88.23     | 87.94     | 706759  |
+| **all fields (micro avg.)** | **92.58** | **87.59** | **90.02** | 707155  |
+| all fields (macro avg.)     | 88.24     | 88.24     | 87.95     | 707155  |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -177,20 +177,20 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1       | support |
 |-----------------------------|-----------|-----------|----------|---------|
-| authors                     | 94.66     | 89.05     | 91.77    | 97113   |
-| date                        | 91.55     | 85.85     | 88.61    | 97559   |
-| doi                         | 77.52     | 91.18     | 83.8     | 16831   |
-| first_author                | 95.71     | 89.96     | 92.75    | 97113   |
-| inTitle                     | 93.19     | 89.03     | 91.06    | 96359   |
-| issue                       | 93.93     | 90.77     | 92.32    | 30312   |
-| page                        | 94.83     | 77.89     | 85.53    | 88534   |
+| authors                     | 94.66     | 89.05     | 91.77    | 97164   |
+| date                        | 91.55     | 85.86     | 88.61    | 97611   |
+| doi                         | 77.59     | 91.2      | 83.85    | 16894   |
+| first_author                | 95.71     | 89.97     | 92.75    | 97164   |
+| inTitle                     | 93.18     | 89.03     | 91.06    | 96411   |
+| issue                       | 93.93     | 90.76     | 92.32    | 30298   |
+| page                        | 94.83     | 77.89     | 85.53    | 88578   |
 | pmcid                       | 74.73     | 94.18     | 83.33    | 807     |
 | pmid                        | 73.82     | 84.85     | 78.95    | 2093    |
-| title                       | 96        | 94.27     | 95.13    | 92394   |
-| volume                      | 95.97     | 94.78     | 95.37    | 87644   |
+| title                       | 96        | 94.27     | 95.13    | 92444   |
+| volume                      | 95.97     | 94.78     | 95.37    | 87691   |
 |                             |           |           |          |         |
-| **all fields (micro avg.)** | **93.9**  | **88.84** | **91.3** | 706759  |
-| all fields (macro avg.)     | 89.26     | 89.26     | 88.97    | 706759  |
+| **all fields (micro avg.)** | **93.9**  | **88.85** | **91.3** | 707155  |
+| all fields (macro avg.)     | 89.27     | 89.26     | 88.97    | 707155  |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -198,73 +198,73 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| authors                     | 91.66     | 86.22     | 88.86     | 97113   |
-| date                        | 91.55     | 85.85     | 88.61     | 97559   |
-| doi                         | 76.16     | 89.58     | 82.33     | 16831   |
-| first_author                | 95.19     | 89.47     | 92.24     | 97113   |
-| inTitle                     | 90.88     | 86.82     | 88.8      | 96359   |
-| issue                       | 93.93     | 90.77     | 92.32     | 30312   |
-| page                        | 94.83     | 77.89     | 85.53     | 88534   |
+| authors                     | 91.66     | 86.23     | 88.86     | 97164   |
+| date                        | 91.55     | 85.86     | 88.61     | 97611   |
+| doi                         | 76.23     | 89.61     | 82.38     | 16894   |
+| first_author                | 95.19     | 89.47     | 92.24     | 97164   |
+| inTitle                     | 90.88     | 86.82     | 88.8      | 96411   |
+| issue                       | 93.93     | 90.76     | 92.32     | 30298   |
+| page                        | 94.83     | 77.89     | 85.53     | 88578   |
 | pmcid                       | 65.78     | 82.9      | 73.36     | 807     |
 | pmid                        | 69.95     | 80.41     | 74.82     | 2093    |
-| title                       | 95.32     | 93.6      | 94.45     | 92394   |
-| volume                      | 95.97     | 94.78     | 95.37     | 87644   |
+| title                       | 95.32     | 93.6      | 94.45     | 92444   |
+| volume                      | 95.97     | 94.78     | 95.37     | 87691   |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **92.94** | **87.94** | **90.37** | 706759  |
-| all fields (macro avg.)     | 87.38     | 87.12     | 86.97     | 706759  |
+| **all fields (micro avg.)** | **92.94** | **87.94** | **90.37** | 707155  |
+| all fields (macro avg.)     | 87.39     | 87.12     | 86.98     | 707155  |
 
 #### Instance-level results
 
 ```
-Total expected instances: 		98728
-Total extracted instances: 		97885
-Total correct instances: 		43407 (strict)
-Total correct instances: 		54287 (soft)
-Total correct instances: 		58452 (Levenshtein)
-Total correct instances: 		55233 (RatcliffObershelp)
+Total expected instances: 		98780
+Total extracted instances: 		97937
+Total correct instances: 		43446 (strict)
+Total correct instances: 		54331 (soft)
+Total correct instances: 		58493 (Levenshtein)
+Total correct instances: 		55273 (RatcliffObershelp)
 
-Instance-level precision:	44.34 (strict)
-Instance-level precision:	55.46 (soft)
-Instance-level precision:	59.71 (Levenshtein)
-Instance-level precision:	56.43 (RatcliffObershelp)
+Instance-level precision:	44.36 (strict)
+Instance-level precision:	55.48 (soft)
+Instance-level precision:	59.73 (Levenshtein)
+Instance-level precision:	56.44 (RatcliffObershelp)
 
-Instance-level recall:	43.97	(strict)
-Instance-level recall:	54.99	(soft)
-Instance-level recall:	59.21	(Levenshtein)
-Instance-level recall:	55.94	(RatcliffObershelp)
+Instance-level recall:	43.98	(strict)
+Instance-level recall:	55	(soft)
+Instance-level recall:	59.22	(Levenshtein)
+Instance-level recall:	55.96	(RatcliffObershelp)
 
-Instance-level f-score:	44.15 (strict)
-Instance-level f-score:	55.22 (soft)
-Instance-level f-score:	59.46 (Levenshtein)
-Instance-level f-score:	56.18 (RatcliffObershelp)
+Instance-level f-score:	44.17 (strict)
+Instance-level f-score:	55.24 (soft)
+Instance-level f-score:	59.47 (Levenshtein)
+Instance-level f-score:	56.2 (RatcliffObershelp)
 
-Matching 1 :	78781
+Matching 1 :	78835
 
-Matching 2 :	4481
+Matching 2 :	4478
 
-Matching 3 :	4341
+Matching 3 :	4339
 
 Matching 4 :	2218
 
-Total matches :	89821
+Total matches :	89870
 ```
 
 #### Citation context resolution
 
 ```
 
-Total expected references: 	 98726 - 49.39 references per article
-Total predicted references: 	 97885 - 48.97 references per article
+Total expected references: 	 98778 - 49.41 references per article
+Total predicted references: 	 97937 - 48.99 references per article
 
-Total expected citation contexts: 	 142738 - 71.4 citation contexts per article
-Total predicted citation contexts: 	 134658 - 67.36 citation contexts per article
+Total expected citation contexts: 	 142847 - 71.46 citation contexts per article
+Total predicted citation contexts: 	 134757 - 67.41 citation contexts per article
 
-Total correct predicted citation contexts: 	 116136 - 58.1 citation contexts per article
-Total wrong predicted citation contexts: 	 18522 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
+Total correct predicted citation contexts: 	 116233 - 58.15 citation contexts per article
+Total wrong predicted citation contexts: 	 18524 (wrong callout matching, callout missing in NLM, or matching with a bib. ref. not aligned with a bib.ref. in NLM)
 
 Precision citation contexts: 	 86.25
-Recall citation contexts: 	 81.36
-fscore citation contexts: 	 83.73
+Recall citation contexts: 	 81.37
+fscore citation contexts: 	 83.74
 ```
 
 ## Fulltext structures
@@ -282,19 +282,19 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 28.18     | 27.42     | 27.79     | 445     |
-| conflict_stmt               | 66.36     | 59.05     | 62.49     | 608     |
-| contribution_stmt           | 42.77     | 43.75     | 43.25     | 608     |
-| figure_title                | 4.25      | 2.36      | 3.03      | 22970   |
+| availability_stmt           | 28.34     | 27.58     | 27.95     | 446     |
+| conflict_stmt               | 66.42     | 59.11     | 62.55     | 609     |
+| contribution_stmt           | 42.7      | 43.68     | 43.18     | 609     |
+| figure_title                | 4.25      | 2.36      | 3.03      | 22972   |
 | funding_stmt                | 3.84      | 23.96     | 6.62      | 747     |
-| reference_citation          | 71.94     | 70.94     | 71.43     | 147346  |
-| reference_figure            | 70.34     | 76.97     | 73.5      | 47972   |
-| reference_table             | 45.33     | 84.74     | 59.06     | 5957    |
-| section_title               | 69.07     | 68.63     | 68.85     | 32357   |
-| table_title                 | 6.98      | 2.55      | 3.73      | 3925    |
+| reference_citation          | 71.96     | 70.95     | 71.45     | 147455  |
+| reference_figure            | 70.31     | 76.99     | 73.5      | 47976   |
+| reference_table             | 45.11     | 84.74     | 58.88     | 5956    |
+| section_title               | 69.08     | 68.62     | 68.85     | 32391   |
+| table_title                 | 6.98      | 2.55      | 3.73      | 3924    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **65.11** | **64.76** | **64.93** | 262935  |
-| all fields (macro avg.)     | 40.9      | 46.04     | 41.98     | 262935  |
+| **all fields (micro avg.)** | **65.11** | **64.77** | **64.94** | 263085  |
+| all fields (macro avg.)     | 40.9      | 46.05     | 41.97     | 263085  |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -302,29 +302,29 @@ Evaluation on 1999 random PDF files out of 1998 PDF (ratio 1.0).
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 49.42     | 48.09     | 48.75     | 445     |
-| conflict_stmt               | 80.96     | 72.04     | 76.24     | 608     |
-| contribution_stmt           | 72.67     | 74.34     | 73.5      | 608     |
-| figure_title                | 66.76     | 36.97     | 47.58     | 22970   |
+| availability_stmt           | 49.54     | 48.21     | 48.86     | 446     |
+| conflict_stmt               | 81        | 72.09     | 76.28     | 609     |
+| contribution_stmt           | 72.71     | 74.38     | 73.54     | 609     |
+| figure_title                | 66.77     | 36.97     | 47.59     | 22972   |
 | funding_stmt                | 4.1       | 25.57     | 7.06      | 747     |
-| reference_citation          | 84.27     | 83.1      | 83.68     | 147346  |
-| reference_figure            | 71        | 77.69     | 74.19     | 47972   |
-| reference_table             | 45.72     | 85.48     | 59.58     | 5957    |
-| section_title               | 74.47     | 74        | 74.24     | 32357   |
-| table_title                 | 81.23     | 29.66     | 43.45     | 3925    |
+| reference_citation          | 84.29     | 83.11     | 83.69     | 147455  |
+| reference_figure            | 70.97     | 77.71     | 74.19     | 47976   |
+| reference_table             | 45.5      | 85.48     | 59.39     | 5956    |
+| section_title               | 74.49     | 74        | 74.25     | 32391   |
+| table_title                 | 81.22     | 29.64     | 43.43     | 3924    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **76.37** | **75.95** | **76.16** | 262935  |
-| all fields (macro avg.)     | 63.06     | 60.69     | 58.83     | 262935  |
+| **all fields (micro avg.)** | **76.36** | **75.96** | **76.16** | 263085  |
+| all fields (macro avg.)     | 63.06     | 60.71     | 58.83     | 263085  |
 
 **Document-level ratio results**
 
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
-| availability_stmt           | 82.32     | 97.3      | 89.19     | 445     |
-| conflict_stmt               | 95.41     | 88.98     | 92.09     | 608     |
-| contribution_stmt           | 91.07     | 102.3     | 96.36     | 608     |
+| availability_stmt           | 82.35     | 97.31     | 89.21     | 446     |
+| conflict_stmt               | 95.42     | 89        | 92.1      | 609     |
+| contribution_stmt           | 91.08     | 102.3     | 96.37     | 609     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **89.86** | **96.09** | **92.87** | 1661    |
-| all fields (macro avg.)     | 89.6      | 96.2      | 92.54     | 1661    |
+| **all fields (micro avg.)** | **89.88** | **96.09** | **92.88** | 1664    |
+| all fields (macro avg.)     | 89.62     | 96.2      | 92.56     | 1664    |
 
-Evaluation metrics produced in 207.811 seconds
+Evaluation metrics produced in 206.556 seconds

--- a/doc/benchmarks/Benchmarking-elife.md
+++ b/doc/benchmarks/Benchmarking-elife.md
@@ -42,13 +42,13 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 8.66      | 8.33      | 8.49      | 984     |
-| affiliation_linked          | 1.92      | 2.09      | 2         | 981     |
+| affiliation_linked          | 2.47      | 2.86      | 2.65      | 981     |
 | authors                     | 78.18     | 77.62     | 77.9      | 983     |
 | first_author                | 93.95     | 93.38     | 93.67     | 982     |
 | title                       | 88.8      | 87.8      | 88.3      | 984     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **18.65** | **19.72** | **19.17** | 4914    |
-| all fields (macro avg.)     | 54.3      | 53.85     | 54.07     | 4914    |
+| **all fields (micro avg.)** | **18.26** | **20.28** | **19.22** | 4914    |
+| all fields (macro avg.)     | 54.41     | 54        | 54.2      | 4914    |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -57,13 +57,13 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 21.54     | 20.73     | 21.13     | 984     |
-| affiliation_linked          | 68.98     | 74.83     | 71.79     | 981     |
+| affiliation_linked          | 68.63     | 79.51     | 73.67     | 981     |
 | authors                     | 78.59     | 78.03     | 78.31     | 983     |
 | first_author                | 93.95     | 93.38     | 93.67     | 982     |
 | title                       | 95.79     | 94.72     | 95.25     | 984     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **69.96** | **73.98** | **71.91** | 4914    |
-| all fields (macro avg.)     | 71.77     | 72.34     | 72.03     | 4914    |
+| **all fields (micro avg.)** | **69.64** | **77.38** | **73.31** | 4914    |
+| all fields (macro avg.)     | 71.7      | 73.27     | 72.4      | 4914    |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -72,13 +72,13 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 46.67     | 44.92     | 45.78     | 984     |
-| affiliation_linked          | 73.26     | 79.47     | 76.24     | 981     |
+| affiliation_linked          | 71.72     | 83.09     | 76.99     | 981     |
 | authors                     | 89.86     | 89.22     | 89.54     | 983     |
 | first_author                | 94.26     | 93.69     | 93.97     | 982     |
 | title                       | 97.23     | 96.14     | 96.68     | 984     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **75.55** | **79.88** | **77.65** | 4914    |
-| all fields (macro avg.)     | 80.26     | 80.69     | 80.44     | 4914    |
+| **all fields (micro avg.)** | **74.27** | **82.52** | **78.18** | 4914    |
+| all fields (macro avg.)     | 79.95     | 81.41     | 80.59     | 4914    |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -87,13 +87,13 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 43.4      | 41.77     | 42.57     | 984     |
-| affiliation_linked          | 71.08     | 77.11     | 73.97     | 981     |
+| affiliation_linked          | 70.09     | 81.2      | 75.24     | 981     |
 | authors                     | 83.3      | 82.71     | 83        | 983     |
 | first_author                | 93.95     | 93.38     | 93.67     | 982     |
 | title                       | 97.23     | 96.14     | 96.68     | 984     |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **73.28** | **77.48** | **75.32** | 4914    |
-| all fields (macro avg.)     | 77.79     | 78.22     | 77.98     | 4914    |
+| **all fields (micro avg.)** | **72.42** | **80.46** | **76.23** | 4914    |
+| all fields (macro avg.)     | 77.59     | 79.04     | 78.23     | 4914    |
 
 Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
 and their attached affiliations compared). Its support column reports the number of articles the metric is computed
@@ -304,4 +304,5 @@ Evaluation on 984 random PDF files out of 982 PDF (ratio 1.0).
 | **all fields (micro avg.)** | **93.61** | **100** | **96.7** | 585     |
 | all fields (macro avg.)     | 93.61     | 100     | 99.03    | 585     |
 
-Evaluation metrics produced in 199.998 seconds
+Evaluation metrics produced in 207.269 seconds
+

--- a/doc/benchmarks/Benchmarking-plos.md
+++ b/doc/benchmarks/Benchmarking-plos.md
@@ -48,40 +48,40 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | keywords                    | 0         | 0         | 0         | 0       |
 | title                       | 95.18     | 94.7      | 94.94     | 1000    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **24.48** | **25.18** | **24.83** | 4861    |
+| **all fields (micro avg.)** | **24.02** | **25.18** | **24.59** | 4861    |
 | all fields (macro avg.)     | 61.27     | 61.26     | 61.26     | 4861    |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
 **Field-level results**
 
-| label                       | precision | recall   | f1       | support |
-|-----------------------------|-----------|----------|----------|---------|
-| abstract                    | 49.34     | 50.94    | 50.13    | 960     |
-| affiliation_linked          | 71.98     | 74.8     | 73.36    | 963     |
-| authors                     | 98.97     | 98.97    | 98.97    | 969     |
-| first_author                | 99.17     | 99.17    | 99.17    | 969     |
-| keywords                    | 0         | 0        | 0        | 0       |
-| title                       | 98.79     | 98.3     | 98.55    | 1000    |
-|                             |           |          |          |         |
-| **all fields (micro avg.)** | **76.62** | **78.8** | **77.7** | 4861    |
-| all fields (macro avg.)     | 83.65     | 84.44    | 84.04    | 4861    |
+| label                       | precision | recall    | f1        | support |
+|-----------------------------|-----------|-----------|-----------|---------|
+| abstract                    | 49.34     | 50.94     | 50.13     | 960     |
+| affiliation_linked          | 73.43     | 78.47     | 75.87     | 963     |
+| authors                     | 98.97     | 98.97     | 98.97     | 969     |
+| first_author                | 99.17     | 99.17     | 99.17     | 969     |
+| keywords                    | 0         | 0         | 0         | 0       |
+| title                       | 98.79     | 98.3      | 98.55     | 1000    |
+|                             |           |           |           |         |
+| **all fields (micro avg.)** | **77.52** | **81.27** | **79.35** | 4861    |
+| all fields (macro avg.)     | 83.94     | 85.17     | 84.54     | 4861    |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
 **Field-level results**
 
-| label                       | precision | recall    | f1        | support |
-|-----------------------------|-----------|-----------|-----------|---------|
-| abstract                    | 75.28     | 77.71     | 76.47     | 960     |
-| affiliation_linked          | 76.86     | 79.86     | 78.33     | 963     |
-| authors                     | 99.38     | 99.38     | 99.38     | 969     |
-| first_author                | 99.28     | 99.28     | 99.28     | 969     |
-| keywords                    | 0         | 0         | 0         | 0       |
-| title                       | 99.3      | 98.8      | 99.05     | 1000    |
-|                             |           |           |           |         |
-| **all fields (micro avg.)** | **82.11** | **84.45** | **83.26** | 4861    |
-| all fields (macro avg.)     | 90.02     | 91.01     | 90.5      | 4861    |
+| label                       | precision | recall    | f1     | support |
+|-----------------------------|-----------|-----------|--------|---------|
+| abstract                    | 75.28     | 77.71     | 76.47  | 960     |
+| affiliation_linked          | 78.35     | 83.74     | 80.95  | 963     |
+| authors                     | 99.38     | 99.38     | 99.38  | 969     |
+| first_author                | 99.28     | 99.28     | 99.28  | 969     |
+| keywords                    | 0         | 0         | 0      | 0       |
+| title                       | 99.3      | 98.8      | 99.05  | 1000    |
+|                             |           |           |        |         |
+| **all fields (micro avg.)** | **83.04** | **87.06** | **85** | 4861    |
+| all fields (macro avg.)     | 90.32     | 91.78     | 91.03  | 4861    |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -90,14 +90,14 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 64.78     | 66.88     | 65.81     | 960     |
-| affiliation_linked          | 74.49     | 77.4      | 75.91     | 963     |
+| affiliation_linked          | 76.05     | 81.27     | 78.57     | 963     |
 | authors                     | 99.28     | 99.28     | 99.28     | 969     |
 | first_author                | 99.17     | 99.17     | 99.17     | 969     |
 | keywords                    | 0         | 0         | 0         | 0       |
 | title                       | 98.99     | 98.5      | 98.75     | 1000    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **79.61** | **81.88** | **80.73** | 4861    |
-| all fields (macro avg.)     | 87.34     | 88.25     | 87.79     | 4861    |
+| **all fields (micro avg.)** | **80.58** | **84.48** | **82.49** | 4861    |
+| all fields (macro avg.)     | 87.66     | 89.02     | 88.32     | 4861    |
 
 Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
 and their attached affiliations compared). Its support column reports the number of articles the metric is computed
@@ -311,4 +311,4 @@ Evaluation on 1000 random PDF files out of 998 PDF (ratio 1.0).
 | **all fields (micro avg.)** | **99.71** | **99.83** | **99.77** | 1741    |
 | all fields (macro avg.)     | 99.69     | 99.89     | 99.79     | 1741    |
 
-Evaluation metrics produced in 102.635 seconds
+Evaluation metrics produced in 101.785 seconds

--- a/doc/benchmarks/Benchmarking-pmc.md
+++ b/doc/benchmarks/Benchmarking-pmc.md
@@ -42,14 +42,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 16.34     | 16.06     | 16.2      | 1911    |
-| affiliation_linked          | 0.53      | 0.53      | 0.53      | 1927    |
+| affiliation_linked          | 0.63      | 0.68      | 0.66      | 1927    |
 | authors                     | 92.89     | 92.84     | 92.86     | 1941    |
 | first_author                | 96.7      | 96.65     | 96.68     | 1941    |
 | keywords                    | 63.19     | 61.09     | 62.12     | 1380    |
 | title                       | 84.4      | 84.1      | 84.25     | 1943    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **31.4**  | **31.36** | **31.38** | 11043   |
-| all fields (macro avg.)     | 59.01     | 58.54     | 58.77     | 11043   |
+| **all fields (micro avg.)** | **30.2**  | **31.45** | **30.81** | 11043   |
+| all fields (macro avg.)     | 59.03     | 58.57     | 58.79     | 11043   |
 
 #### Soft Matching (ignoring punctuation, case and space characters mismatches)
 
@@ -58,14 +58,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 62.96     | 61.9      | 62.43     | 1911    |
-| affiliation_linked          | 54.02     | 54.31     | 54.17     | 1927    |
+| affiliation_linked          | 61.65     | 66.62     | 64.04     | 1927    |
 | authors                     | 94.85     | 94.8      | 94.82     | 1941    |
 | first_author                | 97.16     | 97.11     | 97.14     | 1941    |
 | keywords                    | 71.14     | 68.77     | 69.93     | 1380    |
 | title                       | 92.05     | 91.71     | 91.88     | 1943    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **67.31** | **67.23** | **67.27** | 11043   |
-| all fields (macro avg.)     | 78.7      | 78.1      | 78.39     | 11043   |
+| **all fields (micro avg.)** | **71.22** | **74.15** | **72.66** | 11043   |
+| all fields (macro avg.)     | 79.97     | 80.15     | 80.04     | 11043   |
 
 #### Levenshtein Matching (Minimum Levenshtein distance at 0.8)
 
@@ -74,14 +74,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1        | support |
 |-----------------------------|-----------|-----------|-----------|---------|
 | abstract                    | 89.84     | 88.33     | 89.08     | 1911    |
-| affiliation_linked          | 56.53     | 56.84     | 56.68     | 1927    |
+| affiliation_linked          | 64.16     | 69.34     | 66.65     | 1927    |
 | authors                     | 96.7      | 96.65     | 96.68     | 1941    |
 | first_author                | 97.37     | 97.32     | 97.35     | 1941    |
 | keywords                    | 84.71     | 81.88     | 83.27     | 1380    |
 | title                       | 98.24     | 97.89     | 98.07     | 1943    |
 |                             |           |           |           |         |
-| **all fields (micro avg.)** | **72.8**  | **72.72** | **72.76** | 11043   |
-| all fields (macro avg.)     | 87.23     | 86.49     | 86.85     | 11043   |
+| **all fields (micro avg.)** | **76.59** | **79.74** | **78.13** | 11043   |
+| all fields (macro avg.)     | 88.5      | 88.57     | 88.51     | 11043   |
 
 #### Ratcliff/Obershelp Matching (Minimum Ratcliff/Obershelp similarity at 0.95)
 
@@ -90,14 +90,14 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | label                       | precision | recall    | f1       | support |
 |-----------------------------|-----------|-----------|----------|---------|
 | abstract                    | 85.74     | 84.3      | 85.01    | 1911    |
-| affiliation_linked          | 55.05     | 55.35     | 55.2     | 1927    |
+| affiliation_linked          | 62.59     | 67.63     | 65.01    | 1927    |
 | authors                     | 95.77     | 95.72     | 95.75    | 1941    |
 | first_author                | 96.7      | 96.65     | 96.68    | 1941    |
 | keywords                    | 78.26     | 75.65     | 76.93    | 1380    |
 | title                       | 96.23     | 95.88     | 96.06    | 1943    |
 |                             |           |           |          |         |
-| **all fields (micro avg.)** | **70.84** | **70.76** | **70.8** | 11043   |
-| all fields (macro avg.)     | 84.63     | 83.93     | 84.27    | 11043   |
+| **all fields (micro avg.)** | **74.6**  | **77.66** | **76.1** | 11043   |
+| all fields (macro avg.)     | 85.88     | 85.97     | 85.91    | 11043   |
 
 Note: the "affiliation_linked" field above is a linking-aware metric (each author is paired with its gold counterpart
 and their attached affiliations compared). Its support column reports the number of articles the metric is computed
@@ -303,4 +303,5 @@ Evaluation on 1943 random PDF files out of 1941 PDF (ratio 1.0).
 | **all fields (micro avg.)** | **0**     | **0**  | **0** | 0       |
 | all fields (macro avg.)     | 0         | 0      | 0     | 0       |
 
-Evaluation metrics produced in 159.838 seconds
+Evaluation metrics produced in 164.25 seconds
+

--- a/grobid-core/src/main/java/org/grobid/core/data/Person.java
+++ b/grobid-core/src/main/java/org/grobid/core/data/Person.java
@@ -153,6 +153,12 @@ public class Person {
     public void addAffiliation(org.grobid.core.data.Affiliation f) {
         if (affiliations == null)
             affiliations = new ArrayList<>();
+        // An author never holds the same affiliation twice. The assignment tiers in
+        // AuthorAffiliationAssigner run in sequence rather than exclusively, and a shared
+        // affiliation may carry several markers, so the same instance can be offered more
+        // than once for one author - guard here rather than at each call site.
+        if (affiliations.contains(f))
+            return;
         affiliations.add(f);
     }
 

--- a/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
@@ -70,8 +70,7 @@ public class AuthorParser {
     // A single comma separates markers; two or more are a marker in their own right.
     // Runs must not be split: turning "§§§§" into four "§" makes it collide with the
     // distinct affiliation marked "§", which then gets assigned once per character.
-    private static final Pattern MARKER_SPLIT_PATTERN =
-            Pattern.compile("[0-9a-zA-Z]+|,{2,}|([^0-9a-zA-Z,\\s])\\1*");
+    private static final Pattern MARKER_SPLIT_PATTERN = Pattern.compile("[0-9a-zA-Z]+|,{2,}|([^0-9a-zA-Z,\\s])\\1*");
 
     static List<String> splitMarkers(String markerCluster) {
         List<String> result = new ArrayList<>();

--- a/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
+++ b/grobid-core/src/main/java/org/grobid/core/engines/AuthorParser.java
@@ -65,7 +65,13 @@ public class AuthorParser {
      * conventionally a single corresponding-author marker); other symbols
      * (`*`, `†`, etc.) become individual markers.
      */
-    private static final Pattern MARKER_SPLIT_PATTERN = Pattern.compile("[0-9a-zA-Z]+|\\*\\*|[^0-9a-zA-Z,\\s]");
+    // A marker is a run of identical characters, taken whole: an alphanumeric run
+    // ("12", "1a"), a repeated symbol ("*", "**", "§§§§"), or a repeated comma (",,").
+    // A single comma separates markers; two or more are a marker in their own right.
+    // Runs must not be split: turning "§§§§" into four "§" makes it collide with the
+    // distinct affiliation marked "§", which then gets assigned once per character.
+    private static final Pattern MARKER_SPLIT_PATTERN =
+            Pattern.compile("[0-9a-zA-Z]+|,{2,}|([^0-9a-zA-Z,\\s])\\1*");
 
     static List<String> splitMarkers(String markerCluster) {
         List<String> result = new ArrayList<>();

--- a/grobid-core/src/test/java/org/grobid/core/data/util/AuthorAffiliationAssignerTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/data/util/AuthorAffiliationAssignerTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.grobid.core.data.Affiliation;
@@ -110,6 +111,91 @@ public class AuthorAffiliationAssignerTest {
         assertThat(authors.get(0).getAffiliations().get(0).getMarker(), is("1"));
         assertThat(authors.get(1).getAffiliations(), hasSize(1));
         assertThat(authors.get(1).getAffiliations().get(0).getMarker(), is("2"));
+    }
+
+    @Test
+    public void testMarkerMatching_sameAffiliationAssignedOnlyOnce() {
+        // An affiliation already attached to an author must not be attached again,
+        // whatever route offers it a second time. Here the author carries the same
+        // marker twice - which the split pattern no longer produces, but the tiers
+        // in assign() run in sequence rather than exclusively, so the guard has to
+        // hold on its own.
+        List<Person> authors = new ArrayList<>();
+        authors.add(personWithMarkers("Smith", "J", "§", "§"));
+
+        List<Affiliation> affs = Arrays.asList(affWithMarker("University of Mersin", "§"));
+
+        AuthorAffiliationAssigner.assign(authors, affs, "Smith §");
+
+        assertThat(authors.get(0).getAffiliations(), hasSize(1));
+        assertThat(authors.get(0).getAffiliations().get(0).getMarker(), is("§"));
+    }
+
+    @Test
+    public void testMarkerMatching_repeatedSymbolRunDoesNotRepeatTheShorterMarker() {
+        // "§§§§" marks an equal-contribution footnote, not the affiliation marked
+        // "§". Before the split pattern took symbol runs whole, "§§§§" became four
+        // separate "§" and each one matched, so the author collected the same
+        // affiliation four times over.
+        //
+        // Note this asserts the no-duplicate invariant, not that the author ends up
+        // with nothing: rescueOrphanAffiliations deliberately attaches an otherwise
+        // unlinked affiliation to the nearest author, which is a separate concern.
+        List<Person> authors = new ArrayList<>();
+        authors.add(personWithMarkers("Persinoti", "G", "*"));
+        authors.add(personWithMarkers("Martinez", "D", "§§§§"));
+
+        Affiliation saoPaulo = affWithMarker("University of Sao Paulo", "*");
+        Affiliation mersin = affWithMarker("University of Mersin", "§");
+        List<Affiliation> affs = Arrays.asList(saoPaulo, mersin);
+
+        AuthorAffiliationAssigner.assign(authors, affs, "Persinoti *, Martinez §§§§");
+
+        // Marker matching still links Persinoti to the affiliation marked "*".
+        assertTrue(
+                "Persinoti should be linked to the affiliation marked '*'",
+                authors.get(0).getAffiliations().contains(saoPaulo));
+
+        // No author holds the same affiliation more than once.
+        for (Person author : authors) {
+            List<Affiliation> got = author.getAffiliations();
+            if (got == null) {
+                continue;
+            }
+            assertThat(
+                    "duplicate affiliation on " + author.getLastName(),
+                    new HashSet<>(got).size(),
+                    is(got.size()));
+        }
+    }
+
+    @Ignore("Documents intended behaviour that is not implemented yet. "
+            + "An affiliation that no marker claims is currently handed to the nearest "
+            + "author by rescueOrphanAffiliations, so a footnote-only marker such as "
+            + "\"§§§§\" (equal contribution) still drags an unrelated affiliation onto "
+            + "the author. Arguably the rescue should only run when the header carries "
+            + "no markers at all - with markers present, an unclaimed affiliation is "
+            + "more likely to belong to nobody than to the nearest name.")
+    @Test
+    public void testMarkerMatching_unclaimedAffiliationIsNotForcedOntoAnAuthor() {
+        List<Person> authors = new ArrayList<>();
+        authors.add(personWithMarkers("Persinoti", "G", "*"));
+        authors.add(personWithMarkers("Martinez", "D", "§§§§"));
+
+        Affiliation saoPaulo = affWithMarker("University of Sao Paulo", "*");
+        Affiliation mersin = affWithMarker("University of Mersin", "§");
+        List<Affiliation> affs = Arrays.asList(saoPaulo, mersin);
+
+        AuthorAffiliationAssigner.assign(authors, affs, "Persinoti *, Martinez §§§§");
+
+        // Persinoti is marked "*" only, so only Sao Paulo should be attached.
+        assertThat(authors.get(0).getAffiliations(), hasSize(1));
+        assertThat(authors.get(0).getAffiliations().get(0).getMarker(), is("*"));
+        // "§§§§" claims no affiliation, so Martinez should get none.
+        assertTrue(
+                "Martinez should not inherit an affiliation no marker claims",
+                authors.get(1).getAffiliations() == null
+                        || authors.get(1).getAffiliations().isEmpty());
     }
 
     @Test

--- a/grobid-core/src/test/java/org/grobid/core/engines/AuthorParserTest.java
+++ b/grobid-core/src/test/java/org/grobid/core/engines/AuthorParserTest.java
@@ -151,7 +151,39 @@ public class AuthorParserTest {
         // Comma-separated markers still split; digit and letter runs still group.
         assertThat(AuthorParser.splitMarkers("1, 2"), contains("1", "2"));
         assertThat(AuthorParser.splitMarkers("11"), contains("11"));
-        // The literal "**" stays grouped; other symbols become individual markers.
+        // The literal "**" stays grouped.
         assertThat(AuthorParser.splitMarkers("1**"), contains("1", "**"));
+    }
+
+    @Test
+    public void test_splitMarkers_keepsRepeatedSymbolRunTogether() {
+        // A run of one repeated symbol is a single marker, whatever the symbol and
+        // however long the run. "**" used to be special-cased; the rule is general.
+        assertThat(AuthorParser.splitMarkers("**"), contains("**"));
+        assertThat(AuthorParser.splitMarkers("***"), contains("***"));
+        assertThat(AuthorParser.splitMarkers("††"), contains("††"));
+        assertThat(AuthorParser.splitMarkers("‡‡‡"), contains("‡‡‡"));
+        assertThat(AuthorParser.splitMarkers("§§§§"), contains("§§§§"));
+
+        // Runs of different symbols stay separate markers.
+        assertThat(AuthorParser.splitMarkers("*†"), contains("*", "†"));
+        assertThat(AuthorParser.splitMarkers("§§ §"), contains("§§", "§"));
+
+        // A longer run must not be conflated with the shorter marker it repeats:
+        // an author marked "§§§§" is not affiliated to the institution marked "§".
+        assertThat(
+                AuthorParser.splitMarkers("*,§§§§"),
+                contains("*", "§§§§"));
+    }
+
+    @Test
+    public void test_splitMarkers_treatsRepeatedCommaAsMarker() {
+        // A single comma separates markers, but a run of commas is itself a marker.
+        assertThat(AuthorParser.splitMarkers("a,b"), contains("a", "b"));
+        assertThat(AuthorParser.splitMarkers("a,,b"), contains("a", ",,", "b"));
+        assertThat(AuthorParser.splitMarkers(",,,"), contains(",,,"));
+        assertThat(
+                AuthorParser.splitMarkers("‡,,§"),
+                contains("‡", ",,", "§"));
     }
 }


### PR DESCRIPTION
Authors carrying a repeated-symbol marker received the same affiliation several times. On 261743v1, the three authors marked "§§§§" each got two affiliations attached five times over; measured across 11,945 documents, duplicate-key affiliations rose from 826 to 2,687 (1,074 documents affected) compared with 0.9.0.

Two causes, fixed separately:

* AuthorParser.MARKER_SPLIT_PATTERN matched symbol markers one character at a time, so "§§§§" split into four "§". Each then matched, exactly, the distinct affiliation marked "§", and assignByDirectMarkers assigned it once per character. Alphanumeric runs were already taken whole and "**" had a narrow special case; the pattern now takes any run of one repeated symbol whole, which subsumes that special case. "§§§§" and "§" are no longer conflated - relevant here because "§§§§" marks "equal contribution as first authors" and is not an affiliation marker at all.

* Person.addAffiliation appended unconditionally. The tiers in AuthorAffiliationAssigner run in sequence rather than exclusively, so one author can be offered the same affiliation instance more than once; only preLinkByPrecedingAuthorCluster guarded against it. The guard now lives in addAffiliation, covering every call site.
