### PR TITLE
Fix evaluation script on invalid arguments instead of exiting 0

### DIFF
--- a/grobid-home/scripts/run_evaluation.sh
+++ b/grobid-home/scripts/run_evaluation.sh
@@ -112,6 +112,19 @@ for arg in "$@"; do
   fi
 done
 
+# -f is the file ratio, not the flavor - passing a flavor here used to be accepted
+# silently and only surfaced much later as a missing report
+case "${FILERATIO}" in
+  ''|*[!0-9.]*|*.*.*)
+    echo "Error: -f must be a ratio between 0.0 and 1.0, got '${FILERATIO}'" >&2
+    if [ "${FILERATIO#*/}" != "${FILERATIO}" ]; then
+      echo "       That looks like a flavor - use -l '${FILERATIO}' instead." >&2
+    fi
+    usage
+    exit 2
+    ;;
+esac
+
 # required
 if [ -z "${EVAL_ROOT}" ]; then
   echo "Error: evaluation root folder must be provided with -d" >&2

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -2694,20 +2695,20 @@ public class EndToEndEvaluation {
         if (args.length > 5 || args.length == 0) {
             System.err
                     .println("usage: command [path to the (gold) evaluation XML dataset] Run[0|1] fileRatio[0.0-1.0]");
-            return;
+            System.exit(1);
         }
 
         String inputType = args[0];
         if (StringUtils.isBlank(inputType) || (!inputType.equals("nlm") && !inputType.equals("tei"))) {
             System.err.println("Input type is not correctly set, should be [tei|nlm]");
-            return;
+            System.exit(1);
         }
 
         boolean runGrobidVal = true;
         String xmlInputPath = args[1];
         if (StringUtils.isBlank(xmlInputPath)) {
             System.err.println("Path to evaluation (gold) XML data is not correctly set");
-            return;
+            System.exit(1);
         }
 
         String runGrobid = args[2];
@@ -2717,7 +2718,7 @@ public class EndToEndEvaluation {
             runGrobidVal = true;
         } else {
             System.err.println("Invalid value for last argument (run): [0|1]");
-            return;
+            System.exit(1);
         }
 
         // optional file ratio for applying the evaluation
@@ -2729,7 +2730,7 @@ public class EndToEndEvaluation {
                     fileRatio = Double.parseDouble(fileRatioString);
                 } catch (Exception e) {
                     System.err.println("Invalid argument fileRatio, must be a double, e.g. 0.1");
-                    return;
+                    System.exit(1);
                 }
             }
         }
@@ -2737,10 +2738,20 @@ public class EndToEndEvaluation {
         GrobidModels.Flavor parsedFlavor = null;
         if (args.length > 4) {
             String flavor = args[4];
-            parsedFlavor = GrobidModels.Flavor.fromLabel(flavor);
-            if (parsedFlavor == null) {
-                System.out.println("Flavor was not specified, or was empty. Using default Grobid process. ");
+            if (StringUtils.isBlank(flavor)) {
+                System.out.println("Flavor was not specified. Using default Grobid process. ");
             } else {
+                parsedFlavor = GrobidModels.Flavor.fromLabel(flavor);
+                if (parsedFlavor == null) {
+                    // Falling back to the default process here would silently evaluate
+                    // something other than what was asked for, and the report gives no hint
+                    // that the flavor was ignored.
+                    System.err.println("Unknown flavor '" + flavor + "'. Known flavors: "
+                            + Arrays.stream(GrobidModels.Flavor.values())
+                                    .map(GrobidModels.Flavor::getLabel)
+                                    .collect(Collectors.joining(", ")));
+                    System.exit(1);
+                }
                 System.out.println("Setting flavor to: " + parsedFlavor);
             }
         }
@@ -2749,11 +2760,11 @@ public class EndToEndEvaluation {
             File xmlPath = new File(xmlInputPath);
             if (!xmlPath.exists()) {
                 System.err.println("Path to evaluation (gold) XML data does not exist");
-                return;
+                System.exit(1);
             }
             if (!xmlPath.isDirectory()) {
                 System.err.println("Path to evaluation (gold) XML data is not a directory");
-                return;
+                System.exit(1);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
+++ b/grobid-trainer/src/main/java/org/grobid/trainer/evaluation/EndToEndEvaluation.java
@@ -2746,10 +2746,13 @@ public class EndToEndEvaluation {
                     // Falling back to the default process here would silently evaluate
                     // something other than what was asked for, and the report gives no hint
                     // that the flavor was ignored.
-                    System.err.println("Unknown flavor '" + flavor + "'. Known flavors: "
-                            + Arrays.stream(GrobidModels.Flavor.values())
-                                    .map(GrobidModels.Flavor::getLabel)
-                                    .collect(Collectors.joining(", ")));
+                    System.err.println(
+                            "Unknown flavor '"
+                                    + flavor
+                                    + "'. Known flavors: "
+                                    + Arrays.stream(GrobidModels.Flavor.values())
+                                            .map(GrobidModels.Flavor::getLabel)
+                                            .collect(Collectors.joining(", ")));
                     System.exit(1);
                 }
                 System.out.println("Setting flavor to: " + parsedFlavor);


### PR DESCRIPTION
EndToEndEvaluation.main() validated its arguments and then returned, so the JVM exited 0. Gradle reported BUILD SUCCESSFUL, run_evaluation.sh saw a successful build, and the only symptom was the missing markdown report - reported as "report not found after successful build", which points at the report rather than at the argument that was rejected.

Reproduced with `-PfileRatio=article/light-ref`: "Invalid argument fileRatio, must be a double" on stderr, BUILD SUCCESSFUL, exit 0.

Every validation bail-out in main() now exits 1, so the failure surfaces where it happens.

Two related traps, same shape:

- An unrecognised flavor fell back to the default process with only an informational message, so the evaluation silently measured something other than what was asked for and the report gave no hint. A non-empty flavor that does not resolve is now an error listing the known flavors. An absent or empty flavor still means the default.

- run_evaluation.sh's -f is the file ratio; the flavor is -l. Passing a flavor to -f was accepted and only failed much later. -f is now validated, and a value containing '/' suggests -l instead.